### PR TITLE
Add new evaluation stack node to represent array indexing

### DIFF
--- a/ILCompiler/Compiler/EvaluationStack/GenericStackEntryAdapter.cs
+++ b/ILCompiler/Compiler/EvaluationStack/GenericStackEntryAdapter.cs
@@ -107,5 +107,10 @@
         {
             _genericStackEntryVisitor.Visit<LocalHeapEntry>(entry);
         }
+
+        public void Visit(IndexRefEntry entry)
+        {
+            _genericStackEntryVisitor.Visit<IndexRefEntry>(entry);
+        }
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/IStackEntryVisitor.cs
+++ b/ILCompiler/Compiler/EvaluationStack/IStackEntryVisitor.cs
@@ -27,5 +27,6 @@
         public void Visit(SwitchEntry entry);
         public void Visit(AllocObjEntry entry);
         public void Visit(LocalHeapEntry entry);
+        public void Visit(IndexRefEntry entry);
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/IndexRefEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/IndexRefEntry.cs
@@ -1,0 +1,29 @@
+﻿using ILCompiler.Common.TypeSystem.IL;
+
+namespace ILCompiler.Compiler.EvaluationStack
+{
+    public class IndexRefEntry : StackEntry
+    {
+        public StackEntry IndexOp { get; }
+        public StackEntry ArrayOp { get; }
+
+        public int ElemSize { get; }
+
+        public IndexRefEntry(StackEntry indexOp, StackEntry arrayOp, int elemSize, StackValueKind kind) : base(kind)
+        {
+            IndexOp = indexOp;
+            ArrayOp = arrayOp;
+            ElemSize = elemSize;
+        }
+
+        public override void Accept(IStackEntryVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
+
+        public override StackEntry Duplicate()
+        {
+            return new IndexRefEntry(IndexOp.Duplicate(), ArrayOp.Duplicate(), ElemSize, Kind);
+        }
+    }
+}

--- a/ILCompiler/Compiler/Flowgraph.cs
+++ b/ILCompiler/Compiler/Flowgraph.cs
@@ -166,6 +166,13 @@ namespace ILCompiler.Compiler
             SetNext(entry);
         }
 
+        public void Visit(IndexRefEntry entry)
+        {
+            entry.IndexOp.Accept(this);
+            entry.ArrayOp.Accept(this);
+            SetNext(entry);
+        }
+
         private void SetNext(StackEntry entry)
         {
             if (Current != null)

--- a/ILCompiler/Compiler/LIRDumper.cs
+++ b/ILCompiler/Compiler/LIRDumper.cs
@@ -171,5 +171,10 @@ namespace ILCompiler.Compiler
             _sb.AppendLine($"       ┌──▌  t{entry.Op1.TreeID}");
             _sb.AppendLine($"       lclheap");
         }
+
+        public void Visit(IndexRefEntry entry)
+        {
+            throw new Exception("IndexRefEntry not valid in LIR");
+        }
     }
 }

--- a/ILCompiler/Compiler/MethodCompiler.cs
+++ b/ILCompiler/Compiler/MethodCompiler.cs
@@ -123,6 +123,9 @@ namespace ILCompiler.Compiler
                     _logger.LogInformation("{treedump}", treedump);
                 }
 
+                var morpher = _phaseFactory.Create<IMorpher>();
+                morpher.Morph(basicBlocks);
+
                 var flowgraph = _phaseFactory.Create<IFlowgraph>();
                 flowgraph.SetBlockOrder(basicBlocks);
 

--- a/ILCompiler/Compiler/Morpher.cs
+++ b/ILCompiler/Compiler/Morpher.cs
@@ -1,0 +1,13 @@
+﻿using ILCompiler.Interfaces;
+
+namespace ILCompiler.Compiler
+{
+    public class Morpher : IMorpher
+    {
+        public void Morph(IList<BasicBlock> blocks)
+        {
+            // TODO: Add Morphing code here
+            // fgMorphBlocks -> fgMorphStmts -> fgMorphTree -> fgMorphSmpOp -> fgMorphArrayIndex
+        }
+    }
+}

--- a/ILCompiler/Compiler/TreeDumper.cs
+++ b/ILCompiler/Compiler/TreeDumper.cs
@@ -196,5 +196,16 @@ namespace ILCompiler.Compiler
             entry.Op1.Accept(this);
             _indent--;
         }
+
+        public void Visit(IndexRefEntry entry)
+        {
+            _indent++;
+            entry.IndexOp.Accept(this);
+            _indent--;
+            Print($"[]");
+            _indent++;
+            entry.ArrayOp.Accept(this);
+            _indent--;
+        }
     }
 }

--- a/ILCompiler/Interfaces/IMorpher.cs
+++ b/ILCompiler/Interfaces/IMorpher.cs
@@ -1,0 +1,9 @@
+﻿using ILCompiler.Compiler;
+
+namespace ILCompiler.Interfaces
+{
+    internal interface IMorpher : IPhase
+    {
+        void Morph(IList<BasicBlock> blocks);
+    }
+}

--- a/ILCompiler/IoC/ServiceProviderFactory.cs
+++ b/ILCompiler/IoC/ServiceProviderFactory.cs
@@ -26,6 +26,8 @@ namespace ILCompiler.IoC
             services.AddTransient<IILImporter, ILImporter>();
             services.AddImporters();
 
+            services.AddTransient<IMorpher, Morpher>();
+
             services.AddTransient<IFlowgraph, Flowgraph>();
 
             services.AddTransient<ISsaBuilder, SsaBuilder>();


### PR DESCRIPTION
Add morpher into compiler phases.

Next step is to implement morpher to morph array indexing into tree to make explicit the elemSize * index + arrayRef.