### PR TITLE
Add support for Stelem.i4

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/CopyHelper.cs
+++ b/ILCompiler/Compiler/CodeGenerators/CopyHelper.cs
@@ -1,4 +1,5 @@
-﻿using Z80Assembler;
+﻿using System.Diagnostics;
+using Z80Assembler;
 
 namespace ILCompiler.Compiler.CodeGenerators
 {
@@ -58,6 +59,35 @@ namespace ILCompiler.Compiler.CodeGenerators
                 assembler.Ld(R16.DE, (short)(-changeToIX));
                 assembler.Add(I16.IX, R16.DE);
             }
+        }
+
+        public static void CopyFromStackToHeap(Assembler assembler, int size, int ixOffset = 0, bool restoreIX = false)
+        {
+            // Currently only support int32 here
+            Debug.Assert(size == 4);
+
+            // Reverse endianness, stack is big endian, heap is little endian
+            assembler.Pop(R16.HL);
+            assembler.Ld(I16.IX, (short)(ixOffset + 3), R8.H);
+            assembler.Ld(I16.IX, (short)(ixOffset + 2), R8.L);
+
+            assembler.Pop(R16.HL);
+            assembler.Ld(I16.IX, (short)(ixOffset + 1), R8.H);
+            assembler.Ld(I16.IX, (short)(ixOffset + 0), R8.L);
+        }
+
+        public static void CopyFromHeapToStack(Assembler assembler, int size, int ixOffset = 0, bool restoreIX = false)
+        {
+            // Currently only support int32 here
+            Debug.Assert(size == 4);
+
+            assembler.Ld(R8.H, I16.IX, (short)(ixOffset + 1));
+            assembler.Ld(R8.L, I16.IX, (short)(ixOffset + 0));
+            assembler.Push(R16.HL);
+
+            assembler.Ld(R8.H, I16.IX, (short)(ixOffset + 3));
+            assembler.Ld(R8.L, I16.IX, (short)(ixOffset + 2));
+            assembler.Push(R16.HL);
         }
 
         public static void CopyFromIXToStack(Assembler assembler, int size, int ixOffset = 0, bool restoreIX = false)

--- a/ILCompiler/Compiler/CodeGenerators/IndirectCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/IndirectCodeGenerator.cs
@@ -26,7 +26,14 @@ namespace ILCompiler.Compiler.CodeGenerators
                     context.Assembler.Push(R16.HL);
                 }
 
-                CopyHelper.CopyFromIXToStack(context.Assembler, size, (short)entry.Offset);
+                if (entry.SourceInHeap)
+                {
+                    CopyHelper.CopyFromHeapToStack(context.Assembler, size, (short)entry.Offset, false);
+                }
+                else
+                {
+                    CopyHelper.CopyFromIXToStack(context.Assembler, size, (short)entry.Offset, false);
+                }
 
                 // Restore IX
                 context.Assembler.Push(R16.BC);

--- a/ILCompiler/Compiler/CodeGenerators/StoreIndCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/StoreIndCodeGenerator.cs
@@ -16,7 +16,15 @@ namespace ILCompiler.Compiler.CodeGenerators
                 context.Assembler.Pop(I16.IX);  
 
                 short offset = (short)entry.FieldOffset;
-                CopyHelper.CopyFromStackToIX(context.Assembler, exactSize, offset);
+
+                if (entry.TargetInHeap)
+                {
+                    CopyHelper.CopyFromStackToHeap(context.Assembler, exactSize, offset);
+                }
+                else
+                {
+                    CopyHelper.CopyFromStackToIX(context.Assembler, exactSize, offset);
+                }
 
                 context.Assembler.Push(R16.BC);
                 context.Assembler.Pop(I16.IX);

--- a/ILCompiler/Compiler/EvaluationStack/IndirectEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/IndirectEntry.cs
@@ -11,6 +11,8 @@ namespace ILCompiler.Compiler.EvaluationStack
 
         public int DesiredSize { get; }
 
+        public bool SourceInHeap { get; set; }
+
         public IndirectEntry(StackEntry op1, StackValueKind kind, int? exactSize, int desiredSize = 4, uint offset = 0) : base(kind, exactSize)
         {
             Op1 = op1;
@@ -20,7 +22,7 @@ namespace ILCompiler.Compiler.EvaluationStack
 
         public override StackEntry Duplicate()
         {
-            return new IndirectEntry(Op1.Duplicate(), Kind, ExactSize, DesiredSize, Offset);
+            return new IndirectEntry(Op1.Duplicate(), Kind, ExactSize, DesiredSize, Offset) { SourceInHeap = this.SourceInHeap };
         }
 
         public override void Accept(IStackEntryVisitor visitor)

--- a/ILCompiler/Compiler/EvaluationStack/StoreIndEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/StoreIndEntry.cs
@@ -8,6 +8,8 @@ namespace ILCompiler.Compiler.EvaluationStack
         public StackEntry Op1 { get; }
         public uint FieldOffset { get; }
 
+        public bool TargetInHeap { get; set; }
+
         public WellKnownType TargetType { get; }
 
         public StoreIndEntry(StackEntry addr, StackEntry op1, WellKnownType targetType, uint fieldOffset = 0, int? size = 4) : base(addr.Kind, size)
@@ -20,7 +22,7 @@ namespace ILCompiler.Compiler.EvaluationStack
 
         public override StackEntry Duplicate()
         {
-            return new StoreIndEntry(Addr, Op1.Duplicate(), TargetType, FieldOffset, ExactSize);
+            return new StoreIndEntry(Addr, Op1.Duplicate(), TargetType, FieldOffset, ExactSize) { TargetInHeap = this.TargetInHeap };
         }
 
         public override void Accept(IStackEntryVisitor visitor)

--- a/ILCompiler/Compiler/Importer/ServiceCollectionExtensions.cs
+++ b/ILCompiler/Compiler/Importer/ServiceCollectionExtensions.cs
@@ -35,6 +35,7 @@ namespace ILCompiler.Compiler.Importer
             services.AddSingleton<IOpcodeImporter, ShiftOperationImporter>();
             services.AddSingleton<IOpcodeImporter, NewarrImporter>();
             services.AddSingleton<IOpcodeImporter, LoadElemImporter>();
+            services.AddSingleton<IOpcodeImporter, StoreElemImporter>();
 
             return services;
         }

--- a/ILCompiler/Compiler/Importer/StoreElemImporter.cs
+++ b/ILCompiler/Compiler/Importer/StoreElemImporter.cs
@@ -1,0 +1,39 @@
+﻿using dnlib.DotNet.Emit;
+using ILCompiler.Common.TypeSystem;
+using ILCompiler.Common.TypeSystem.IL;
+using ILCompiler.Compiler.EvaluationStack;
+using ILCompiler.Interfaces;
+
+namespace ILCompiler.Compiler.Importer
+{
+    public class StoreElemImporter : IOpcodeImporter
+    {
+        public bool CanImport(Code code) => code == Code.Stelem_I4;
+
+        public void Import(Instruction instruction, ImportContext context, IILImporterProxy importer)
+        {
+            var value = importer.PopExpression();
+            var indexOp = importer.PopExpression();
+            var arrayOp = importer.PopExpression();
+
+            var elemSize = 4;
+
+            StackEntry addr = indexOp;
+            if (elemSize > 1)
+            {
+                // elemSize * index
+
+                var size = new Int32ConstantEntry(elemSize);
+                addr = new BinaryOperator(Operation.Mul, isComparison: false, size, indexOp, StackValueKind.Int32);
+                addr = new CastEntry(WellKnownType.UIntPtr, addr, StackValueKind.NativeInt);
+            }
+
+            addr = new BinaryOperator(Operation.Add, isComparison: false, arrayOp, addr, StackValueKind.NativeInt);
+
+            var targetType = WellKnownType.Int32;
+
+            var op = new StoreIndEntry(addr, value, targetType) { TargetInHeap = true };
+            importer.ImportAppendTree(op);
+        }
+    }
+}

--- a/ILCompiler/Compiler/LIRDumper.cs
+++ b/ILCompiler/Compiler/LIRDumper.cs
@@ -146,7 +146,7 @@ namespace ILCompiler.Compiler
         public void Visit(IndirectEntry entry)
         {
             _sb.AppendLine($"       ┌──▌  t{entry.Op1.TreeID}");
-            _sb.AppendLine($"       ind ${entry.Offset}");
+            _sb.AppendLine($"t{entry.TreeID, -3} = ind ${entry.Offset}");
         }
 
         public void Visit(FieldAddressEntry entry)

--- a/Tests/ILCompiler.IntegrationTests/il_bvt/array_testss.il
+++ b/Tests/ILCompiler.IntegrationTests/il_bvt/array_testss.il
@@ -11,9 +11,36 @@
 .method public static int32 Main() {
 .entrypoint
 .maxstack  5
-.locals ()
+.locals (int32[])
 	ldc.i4 0x00000004
 	newarr [mscorlib]System.Int32
+	stloc 0
+
+	ldloc 0
+	ldc.i4 0x00
+	ldc.i4 0x25
+	stelem.i4
+
+	ldloc 0
+	ldc.i4 0x00
+	ldelem.i4
+
+	ldc.i4 0x25
+	ceq
+	brfalse FAIL
+
+	ldloc 0
+	ldc.i4 0x01
+	ldc.i4 0x08
+	stelem.i4
+
+	ldloc 0
+	ldc.i4 0x01
+	ldelem.i4
+
+	ldc.i4 0x08
+	ceq
+	brfalse FAIL
 
 PASS:
 	ldc.i4 0x0000


### PR DESCRIPTION
Fix bug in LIR dumping as Indirect nodes where missing the temp details
Fix Morpher for Array Index as wasn't casting elemSize * offset to nativeint