### PR TITLE
Var types

### DIFF
--- a/ILCompiler/Common/TypeSystem/IL/DnlibExtensions.cs
+++ b/ILCompiler/Common/TypeSystem/IL/DnlibExtensions.cs
@@ -10,21 +10,6 @@ namespace ILCompiler.Common.TypeSystem.IL
         {
             return method.HasCustomAttributes && method.CustomAttributes.IsDefined(CompilerIntrinsicAttribute);
         }
-
-        public static bool IsUnsigned(this TypeSig typeSig)
-        {
-            switch (typeSig.ElementType)
-            {
-                case ElementType.U1:
-                case ElementType.U2:
-                case ElementType.U4:
-                case ElementType.U8:
-                    return true;
-            }
-
-            return false;
-        }
-
         public static bool IsStruct(this TypeSig typeSig)
         {
             var typeDef = typeSig.TryGetTypeDef();

--- a/ILCompiler/Compiler/CodeGenerators/CopyHelper.cs
+++ b/ILCompiler/Compiler/CodeGenerators/CopyHelper.cs
@@ -108,41 +108,54 @@ namespace ILCompiler.Compiler.CodeGenerators
 
             if (bytesToCopy == 1)
             {
-                assembler.Ld(R8.A, I16.IX, (short)(ixOffset));
-
-                assembler.Ld(R8.L, R8.A);
                 if (signExtend)
                 {
+                    assembler.Ld(R8.A, I16.IX, (short)(ixOffset));
+                    assembler.Ld(R8.E, R8.A);
+
                     assembler.Add(R8.A, R8.A);
                     assembler.Sbc(R8.A, R8.A);
                     assembler.Ld(R8.H, R8.A);
+                    assembler.Ld(R8.L, R8.A);
                     assembler.Push(R16.HL);
-                    assembler.Ld(R8.L, R8.H);
+
+                    assembler.Ld(R8.L, R8.E);
+                    assembler.Push(R16.HL);
                 }
                 else
                 {
                     assembler.Ld(R8.H, 0);
+                    assembler.Ld(R8.L, I16.IX, (short)(ixOffset));
                     assembler.Push(R16.HL);
+
                     assembler.Ld(R16.HL, 0);
+                    assembler.Push(R16.HL);
                 }
-                assembler.Push(R16.HL);
             }
             else
             {
-                assembler.Ld(R8.H, I16.IX, (short)(ixOffset + 1));
-                assembler.Ld(R8.L, I16.IX, (short)(ixOffset));
-                assembler.Push(R16.HL);
-
                 if (signExtend)
                 {
+                    assembler.Ld(R8.H, I16.IX, (short)(ixOffset + 1));
+                    assembler.Ld(R8.L, I16.IX, (short)(ixOffset));
+                    assembler.Push(R16.HL);
+                    assembler.Pop(R16.DE);
+
                     assembler.Add(R16.HL, R16.HL);  // move sign bit into carry flag
                     assembler.Sbc(R16.HL, R16.HL);  // hl is now 0000 or FFFF
+                    assembler.Push(R16.HL);
+
+                    assembler.Push(R16.DE);
                 }
                 else
                 {
                     assembler.Ld(R16.HL, 0);
+                    assembler.Push(R16.HL);
+
+                    assembler.Ld(R8.H, I16.IX, (short)(ixOffset + 1));
+                    assembler.Ld(R8.L, I16.IX, (short)(ixOffset));
+                    assembler.Push(R16.HL);
                 }
-                assembler.Push(R16.HL);
             }
 
             if (changeToIX != 0)

--- a/ILCompiler/Compiler/CodeGenerators/CopyHelper.cs
+++ b/ILCompiler/Compiler/CodeGenerators/CopyHelper.cs
@@ -90,6 +90,68 @@ namespace ILCompiler.Compiler.CodeGenerators
             assembler.Push(R16.HL);
         }
 
+        public static void CopySmallToStack(Assembler assembler, int bytesToCopy, int ixOffset, bool signExtend)
+        {
+            Debug.Assert(bytesToCopy == 1 || bytesToCopy == 2);
+            int changeToIX = 0;
+            int originalIxOffset = ixOffset;
+
+            if (ixOffset + bytesToCopy < -127)
+            {
+                var delta = ixOffset + 1;
+                assembler.Ld(R16.DE, (short)delta);
+                assembler.Add(I16.IX, R16.DE);
+                changeToIX += delta;
+
+                ixOffset -= delta;
+            }
+
+            if (bytesToCopy == 1)
+            {
+                assembler.Ld(R8.A, I16.IX, (short)(ixOffset));
+
+                assembler.Ld(R8.L, R8.A);
+                if (signExtend)
+                {
+                    assembler.Add(R8.A, R8.A);
+                    assembler.Sbc(R8.A, R8.A);
+                    assembler.Ld(R8.H, R8.A);
+                    assembler.Push(R16.HL);
+                    assembler.Ld(R8.L, R8.H);
+                }
+                else
+                {
+                    assembler.Ld(R8.H, 0);
+                    assembler.Push(R16.HL);
+                    assembler.Ld(R16.HL, 0);
+                }
+                assembler.Push(R16.HL);
+            }
+            else
+            {
+                assembler.Ld(R8.H, I16.IX, (short)(ixOffset + 1));
+                assembler.Ld(R8.L, I16.IX, (short)(ixOffset));
+                assembler.Push(R16.HL);
+
+                if (signExtend)
+                {
+                    assembler.Add(R16.HL, R16.HL);  // move sign bit into carry flag
+                    assembler.Sbc(R16.HL, R16.HL);  // hl is now 0000 or FFFF
+                }
+                else
+                {
+                    assembler.Ld(R16.HL, 0);
+                }
+                assembler.Push(R16.HL);
+            }
+
+            if (changeToIX != 0)
+            {
+                assembler.Ld(R16.DE, (short)(-changeToIX));
+                assembler.Add(I16.IX, R16.DE);
+            }
+        }
+
         public static void CopyFromIXToStack(Assembler assembler, int size, int ixOffset = 0, bool restoreIX = false)
         {
             int changeToIX = 0;

--- a/ILCompiler/Compiler/CodeGenerators/CopyHelper.cs
+++ b/ILCompiler/Compiler/CodeGenerators/CopyHelper.cs
@@ -124,11 +124,11 @@ namespace ILCompiler.Compiler.CodeGenerators
                 }
                 else
                 {
-                    assembler.Ld(R8.H, 0);
-                    assembler.Ld(R8.L, I16.IX, (short)(ixOffset));
+                    assembler.Ld(R16.HL, 0);
                     assembler.Push(R16.HL);
 
-                    assembler.Ld(R16.HL, 0);
+                    assembler.Ld(R8.H, 0);
+                    assembler.Ld(R8.L, I16.IX, (short)(ixOffset));
                     assembler.Push(R16.HL);
                 }
             }

--- a/ILCompiler/Compiler/CodeGenerators/LocalVariableCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/LocalVariableCodeGenerator.cs
@@ -11,9 +11,16 @@ namespace ILCompiler.Compiler.CodeGenerators
             var variable = context.LocalVariableTable[entry.LocalNumber];
             var size = variable.ExactSize;
 
-            // Loading a local variable/argument
-            Debug.Assert(size % 2 == 0);
-            CopyHelper.CopyFromIXToStack(context.Assembler, size, -variable.StackOffset, restoreIX: true);
+            if (variable.Type.IsSmall())
+            {
+                CopyHelper.CopySmallToStack(context.Assembler, variable.Type.IsByte() ? 1 : 2, -variable.StackOffset, !variable.Type.IsUnsigned());
+            }
+            else
+            {
+                // Loading a local variable/argument
+                Debug.Assert(size % 2 == 0);
+                CopyHelper.CopyFromIXToStack(context.Assembler, size, -variable.StackOffset, restoreIX: true);
+            }
         }
     }
 }

--- a/ILCompiler/Compiler/DnlibExtensions.cs
+++ b/ILCompiler/Compiler/DnlibExtensions.cs
@@ -2,6 +2,7 @@
 using dnlib.DotNet.Emit;
 using ILCompiler.Common.TypeSystem.IL;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace ILCompiler.Compiler
 {
@@ -10,6 +11,58 @@ namespace ILCompiler.Compiler
         public static T OperandAs<T>(this Instruction instruction)
         {
             return (T)instruction.Operand;
+        }
+
+        public static VarType GetVarType(this TypeSig typeSig)
+        {
+            var typeDefOrRef = typeSig.TryGetTypeDefOrRef();
+            var typeDef = typeDefOrRef.ResolveTypeDef();
+
+            if (typeDef != null && typeDef.IsEnum)
+            {
+                return GetVarType(typeDef.GetEnumUnderlyingType());
+            }
+
+            switch (typeSig.ElementType)
+            {
+                case ElementType.Boolean: 
+                    return VarType.Bool;
+
+                case ElementType.Char:
+                case ElementType.I1:
+                    return VarType.Byte;
+                case ElementType.U1:
+                    return VarType.SByte;
+
+                case ElementType.I2:
+                    return VarType.Short;
+                case ElementType.U2:
+                    return VarType.UShort;
+
+                case ElementType.I4:
+                    return VarType.Int;
+                case ElementType.U4:
+                    return VarType.UInt;
+
+                case ElementType.Ptr:
+                case ElementType.I:
+                    return VarType.Ptr;
+
+                case ElementType.ValueType:
+                    return VarType.Struct;
+
+                case ElementType.Class:
+                case ElementType.String:
+                case ElementType.Array:
+                case ElementType.SZArray:
+                    return VarType.Ref;
+
+                case ElementType.ByRef:
+                    return VarType.ByRef;
+
+                default:
+                    throw new NotSupportedException($"ElementType : {typeSig.ElementType} cannot be converted to VarType");
+            }
         }
 
         public static int GetExactSize(this TypeSig type)

--- a/ILCompiler/Compiler/DnlibExtensions.cs
+++ b/ILCompiler/Compiler/DnlibExtensions.cs
@@ -28,11 +28,11 @@ namespace ILCompiler.Compiler
                 case ElementType.Boolean: 
                     return VarType.Bool;
 
-                case ElementType.Char:
                 case ElementType.I1:
-                    return VarType.Byte;
-                case ElementType.U1:
                     return VarType.SByte;
+                case ElementType.U1:
+                case ElementType.Char:
+                    return VarType.Byte;
 
                 case ElementType.I2:
                     return VarType.Short;

--- a/ILCompiler/Compiler/EvaluationStack/LocalVariableEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/LocalVariableEntry.cs
@@ -12,7 +12,7 @@ namespace ILCompiler.Compiler.EvaluationStack
 
         public override StackEntry Duplicate()
         {
-            return new LocalVariableEntry(LocalNumber, Kind, ExactSize);
+            return new LocalVariableEntry(LocalNumber, Kind, ExactSize) { Type = Type };
         }
 
         public override void Accept(IStackEntryVisitor visitor)

--- a/ILCompiler/Compiler/EvaluationStack/StackEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/StackEntry.cs
@@ -33,6 +33,8 @@ namespace ILCompiler.Compiler.EvaluationStack
     {
         public StackValueKind Kind { get; }
 
+        public VarType Type { get; set; }
+
         public int? ExactSize { get; }
 
         public StackEntry? Next { get; set; }

--- a/ILCompiler/Compiler/Importer/LoadVarImporter.cs
+++ b/ILCompiler/Compiler/Importer/LoadVarImporter.cs
@@ -22,6 +22,7 @@ namespace ILCompiler.Compiler.Importer
             var localNumber = importer.ParameterCount + index;
             var localVariable = importer.LocalVariableTable[localNumber];
             var node = new LocalVariableEntry(localNumber, localVariable.Kind, localVariable.ExactSize);
+            node.Type = localVariable.Type;
             importer.PushExpression(node);
         }
 

--- a/ILCompiler/Compiler/LocalVariableDescriptor.cs
+++ b/ILCompiler/Compiler/LocalVariableDescriptor.cs
@@ -8,6 +8,8 @@ namespace ILCompiler.Compiler
 
         public StackValueKind Kind { get; set; }
 
+        public VarType Type { get; set; }
+
         public int ExactSize { get; set; }
 
         public int StackOffset { get; set; }

--- a/ILCompiler/Compiler/MethodCompiler.cs
+++ b/ILCompiler/Compiler/MethodCompiler.cs
@@ -42,6 +42,7 @@ namespace ILCompiler.Compiler
                     IsTemp = false,
                     Name = method.Parameters[parameterIndex].Name,
                     ExactSize = method.Parameters[parameterIndex].Type.GetExactSize(),
+                    Type = method.Parameters[parameterIndex].Type.GetVarType(),
                 };
                 _localVariableTable.Add(local);
             }
@@ -58,6 +59,7 @@ namespace ILCompiler.Compiler
                         IsTemp = false,
                         Name = body.Variables[variableIndex].Name,
                         ExactSize = body.Variables[variableIndex].Type.GetExactSize(),
+                        Type = body.Variables[variableIndex].Type.GetVarType(),
                     };
                     _localVariableTable.Add(local);
                 }

--- a/ILCompiler/Compiler/TypeList.cs
+++ b/ILCompiler/Compiler/TypeList.cs
@@ -2,6 +2,61 @@
 
 namespace ILCompiler.Compiler
 {
+    public enum VarType
+    {
+        Void,
+
+        Bool,
+        Byte,
+        SByte,
+
+        Short,
+        UShort,
+
+        Int,
+        UInt,
+
+        //Long,
+        //ULong,
+
+        //Float,
+        //Double,
+
+        Ref,        // Object references
+        ByRef,
+        Struct,     // Custom Value Types
+
+        Ptr,        // Unmanaged pointers, NativeInt, NativeUInt
+    }
+
+    public static class VarTypeExtensions
+    {
+        public static bool IsSmall(this VarType type)
+        {
+            return type >= VarType.Bool && type <= VarType.UShort;
+        }
+
+        public static bool IsByte(this VarType type)
+        {
+            return type >= VarType.Bool && type <= VarType.SByte;
+        }
+
+        public static bool IsShort(this VarType type)
+        {
+            return type == VarType.Short || type == VarType.UShort;
+        }
+
+        public static bool IsSmallInt(this VarType type)
+        {
+            return type >= VarType.Byte && type <= VarType.UShort;
+        }
+
+        public static bool IsUnsigned(this VarType type)
+        {
+            return type == VarType.Bool || type == VarType.Byte || type == VarType.UShort || type == VarType.UInt;
+        }
+    }
+
     public static class TypeList
     {
         public static int GetExactSize(StackValueKind kind)

--- a/Tests/ILCompiler.IntegrationTests/il_bvt/ldloc_stloc.il
+++ b/Tests/ILCompiler.IntegrationTests/il_bvt/ldloc_stloc.il
@@ -7,7 +7,7 @@
 .method public static int32 Main() {
 .entrypoint
 .maxstack 10
-.locals (int32, int16, int8)
+.locals (int32, int16, uint8)
 
 	ldc.i4	0x7FFFFFFF
 	stloc	0
@@ -20,6 +20,13 @@
 	stloc   1
 	ldc.i4  0x1
 	ldloc   1
+	ceq
+	brfalse fail
+
+	ldc.i4  0x1
+	stloc   2
+	ldc.i4  0x1
+	ldloc   2
 	ceq
 	brfalse fail
 

--- a/Tests/ILCompiler.IntegrationTests/il_bvt/ldloc_stloc.il
+++ b/Tests/ILCompiler.IntegrationTests/il_bvt/ldloc_stloc.il
@@ -7,13 +7,22 @@
 .method public static int32 Main() {
 .entrypoint
 .maxstack 10
-.locals (int32)
+.locals (int32, int16, int8)
+
 	ldc.i4	0x7FFFFFFF
 	stloc	0
 	ldc.i4	0x7FFFFFFF
 	ldloc	0
 	ceq
 	brfalse fail
+
+	ldc.i4  0x1
+	stloc   1
+	ldc.i4  0x1
+	ldloc   1
+	ceq
+	brfalse fail
+
 pass:
 	ldc.i4 0x0000
 	ret

--- a/Z80Assembler/Assembler.Instructions.cs
+++ b/Z80Assembler/Assembler.Instructions.cs
@@ -74,6 +74,11 @@ namespace Z80Assembler
             AddInstruction(new Instruction(Opcode.Sbc, target.ToString() + ", " + source.ToString()));
         }
 
+        public void Sbc(R8Type target, R8Type source)
+        {
+            AddInstruction(new Instruction(Opcode.Sbc, target.ToString() + ", " + source.ToString()));
+        }
+
         public void Cpl()
         {
             AddInstruction(new Instruction(Opcode.Cpl));


### PR DESCRIPTION
Add VarType to start having better representation of types < 4 bytes in size so for example we can optimise storage space for locals/arguments/fields in structs/classes etc...

Currently just using var type to prove concepts with local variables - modified code for ldloc to treat small types e.g. bool, char, byte, sbyte, int16, uint16 such that the raw data is read from stack frame location for local and then either extended or sign extended.

Note size of local vars in stack frame is currently unchanged e.g. small types will still occupy 4 bytes.

However, this is laying the ground work for proper field layouts in structs/classes.