### PR TITLE
Improve Store local code gen to deal with "small" data types by truncating small types

### DIFF
--- a/ILCompiler/Compiler/Importer/StoreVarImporter.cs
+++ b/ILCompiler/Compiler/Importer/StoreVarImporter.cs
@@ -27,7 +27,9 @@ namespace ILCompiler.Compiler.Importer
                 throw new NotSupportedException("Storing variables other than short, int32 ,object refs, or valuetypes not supported yet");
             }
             var localNumber = importer.ParameterCount + index;
+            var localVariable = importer.LocalVariableTable[localNumber];
             var node = new StoreLocalVariableEntry(localNumber, false, value);
+            node.Type = localVariable.Type;
             importer.ImportAppendTree(node, true);
         }
 


### PR DESCRIPTION
When storing to a local (or arg) current code gen will store all 4 bytes even if the data type is small e.g. int8, uint8, int16, uint16. This PR improves the code gen so that only the data byte(s) are actually stored into the local/arg in the stack frame.

Note that given that the stack frame slots are sized to be 4 bytes anyway at the moment this doesn't make a whole lot of difference but will come into play when field layout for value types/classes comes into play later on with ldfld, stfld.

Not sure at this point if I'll change the layout for stack frame locals/args to respect the small types but gives a nice gentle introduction to dealing with the small types before changing the field layout/ldfld/stfld code.

Note: current stloc code gen can't cope with stack frame offsets that'll push the IX indexing offset outside of the +128/-127 range. I decided against fixing this in this PR as I think all of the code in CopyHelper doing this needs a revisit anyway.