### PR TITLE
Refactor command line parsing to use new CommandLine API

### DIFF
--- a/ILCompiler/ConfigurationBinder.cs
+++ b/ILCompiler/ConfigurationBinder.cs
@@ -1,0 +1,30 @@
+﻿using ILCompiler.Interfaces;
+using System.CommandLine.Binding;
+
+namespace ILCompiler
+{
+    internal class ConfigurationBinder : BinderBase<IConfiguration>
+    {
+        private readonly ConfigurationOptions _configurationOptions;
+
+        public ConfigurationBinder(ConfigurationOptions configurationOptions)
+        {
+            _configurationOptions = configurationOptions;
+        }
+
+        protected override IConfiguration GetBoundValue(BindingContext bindingContext)
+        {
+            return new Configuration
+            {
+                IgnoreUnknownCil = bindingContext.ParseResult.GetValueForOption(_configurationOptions.IgnoreUnknownCilOption),
+                DontInlineRuntime = bindingContext.ParseResult.GetValueForOption(_configurationOptions.DontInlineRuntimeOption),
+                PrintReturnCode = bindingContext.ParseResult.GetValueForOption(_configurationOptions.PrintReturnCodeOption),
+                CorelibPath = bindingContext.ParseResult.GetValueForOption(_configurationOptions.CoreLibPathOption) ?? "",
+                IntegrationTests = bindingContext.ParseResult.GetValueForOption(_configurationOptions.IntegrationTestsOption),
+                DumpIRTrees = bindingContext.ParseResult.GetValueForOption(_configurationOptions.DumpIRTreesOption),
+                TargetArchitecture = bindingContext.ParseResult.GetValueForOption(_configurationOptions.TargetArchitectureOption),
+                StackStart = bindingContext.ParseResult.GetValueForOption(_configurationOptions.StackStartOption)
+            };
+        }
+    }
+}

--- a/ILCompiler/ConfigurationOptions.cs
+++ b/ILCompiler/ConfigurationOptions.cs
@@ -1,0 +1,29 @@
+﻿using ILCompiler.Compiler;
+using System.CommandLine;
+
+namespace ILCompiler
+{
+    internal class ConfigurationOptions
+    {
+        public readonly Option<bool> IgnoreUnknownCilOption = new(new[] { "-f", "--ignoreUnknownCil" }, "Ignore unknown cil");
+        public readonly Option<bool> DontInlineRuntimeOption = new(new[] { "-i", "--dontInlineRuntime" }, "Don't inline runtime assembly");
+        public readonly Option<bool> PrintReturnCodeOption = new(new[] { "-r", "--printReturnCode" }, "Print return code");
+        public readonly Option<string> CoreLibPathOption = new(new[] { "-cl", "--corelibPath" }, "Core lib path");
+        public readonly Option<bool> IntegrationTestsOption = new(new[] { "-it", "--integrationTests" }, "Compile for integration tests");
+        public readonly Option<bool> DumpIRTreesOption = new(new[] { "-d", "--dumpIRTrees" }, "Dump IR trees");
+        public readonly Option<TargetArchitecture> TargetArchitectureOption = new(new[] { "-a", "--targetArchitecture" }, "Target Architecture");
+        public readonly Option<int> StackStartOption = new(new[] { "-ss", "--stackStart" }, "Stack Start Address");
+
+        public void AddToCommand(Command command)
+        {
+            command.AddOption(IgnoreUnknownCilOption);
+            command.AddOption(DontInlineRuntimeOption);
+            command.AddOption(PrintReturnCodeOption);
+            command.AddOption(CoreLibPathOption);
+            command.AddOption(IntegrationTestsOption);
+            command.AddOption(DumpIRTreesOption);
+            command.AddOption(TargetArchitectureOption);
+            command.AddOption(StackStartOption);
+        }
+    }
+}

--- a/ILCompiler/ILCompiler.csproj
+++ b/ILCompiler/ILCompiler.csproj
@@ -142,7 +142,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Moved the configuration options into a new ConfigurationOptions class
Created a custom binder for IConfiguration to map from parsed configuration options
Removed naming convention binder dependency