### PR TITLE
Index displacement tidyup

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/StoreLocalVariableCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/StoreLocalVariableCodeGenerator.cs
@@ -1,6 +1,5 @@
 ﻿using ILCompiler.Compiler.EvaluationStack;
 using System.Diagnostics;
-using Z80Assembler;
 
 namespace ILCompiler.Compiler.CodeGenerators
 {
@@ -15,23 +14,7 @@ namespace ILCompiler.Compiler.CodeGenerators
                 // Copy from stack to IX truncating to required size
                 var bytesToCopy = variable.Type.IsByte() ? 1 : 2;
 
-                // pop lsw
-                context.Assembler.Pop(R16.HL);
-
-                // pop msw and ignore it as for small data types we
-                // truncate the value
-                context.Assembler.Pop(R16.DE);
-
-                var ixOffset = -variable.StackOffset;
-
-                // TODO: Deal with offset being outside of +128/-127 range that can be 
-                // used with IX indexing address mode
-
-                if (bytesToCopy == 2)
-                {
-                    context.Assembler.Ld(I16.IX, (short)(ixOffset + 1), R8.H);
-                }
-                context.Assembler.Ld(I16.IX, (short)(ixOffset + 0), R8.L);
+                CopyHelper.CopyStackToSmall(context.Assembler, bytesToCopy, -variable.StackOffset);
             }
             else
             {

--- a/Tests/ILCompiler.IntegrationTests/ILBvtTests.cs
+++ b/Tests/ILCompiler.IntegrationTests/ILBvtTests.cs
@@ -77,7 +77,8 @@ namespace CSharp80.Tests.BVT
             var ilCompilerPath = @"ILCompiler.exe";
             var arguments = $"--ignoreUnknownCil false --printReturnCode false --integrationTests true --corelibPath {corelibPath} --outputFile {asmFileName} {exeFileName}";
 
-            RunProcess(ilCompilerPath, arguments);
+            var compiled = RunProcess(ilCompilerPath, arguments);
+            Assert.IsTrue(compiled, "IL Failed to compile");
         }
 
         private void Assemble(string ilFileName)
@@ -88,7 +89,7 @@ namespace CSharp80.Tests.BVT
             RunProcess(ilAsmPath, ilFileName);
         }
 
-        private void RunProcess(string filename, string arguments)
+        private bool RunProcess(string filename, string arguments)
         {
             using (var process = new Process())
             {
@@ -107,8 +108,12 @@ namespace CSharp80.Tests.BVT
                     Console.WriteLine($"Process failed");
                     Console.WriteLine(output);
                     Console.WriteLine(errors);
+
+                    return false;
                 }
             }
+
+            return true;
         }
 
 

--- a/Tests/ILCompiler.IntegrationTests/il_bvt/ldloc_stloc.il
+++ b/Tests/ILCompiler.IntegrationTests/il_bvt/ldloc_stloc.il
@@ -3,23 +3,54 @@
     .ver 4:0:0:0
     .publickeytoken = (B7 7A 5C 56 19 34 E0 89)
 }
+
+.class public sealed _struct extends System.ValueType
+{
+	.field public int32 I1
+	.field public int32 I2
+	.field public int32 I3
+	.field public int32 I4
+	.field public int32 I5
+	.field public int32 I6
+	.field public int32 I7
+	.field public int32 I8
+	.field public int32 I9
+	.field public int32 I10
+	.field public int32 I11
+	.field public int32 I12
+	.field public int32 I13
+	.field public int32 I14
+	.field public int32 I15
+	.field public int32 I16
+	.field public int32 I17
+	.field public int32 I18
+	.field public int32 I19
+	.field public int32 I20
+	.field public int32 I21
+	.field public int32 I22
+	.field public int32 I23
+	.field public int32 I24
+	.field public int32 I25
+	.field public int32 I26
+	.field public int32 I27
+	.field public int32 I28
+	.field public int32 I29
+	.field public int32 I30
+	.field public int32 I31
+	.field public int32 I32
+}
+
 .class ldloc_stloc {
 .method public static int32 Main() {
 .entrypoint
 .maxstack 10
-.locals (int32, int16, uint8)
+.locals (valuetype _struct, int32, int16, uint8)
+
 
 	ldc.i4	0x7FFFFFFF
-	stloc	0
+	stloc	1
 	ldc.i4	0x7FFFFFFF
-	ldloc	0
-	ceq
-	brfalse fail
-
-	ldc.i4  0x1
-	stloc   1
-	ldc.i4  0x1
-	ldloc   1
+	ldloc	1
 	ceq
 	brfalse fail
 
@@ -27,6 +58,13 @@
 	stloc   2
 	ldc.i4  0x1
 	ldloc   2
+	ceq
+	brfalse fail
+
+	ldc.i4  0x1
+	stloc   3
+	ldc.i4  0x1
+	ldloc   3
 	ceq
 	brfalse fail
 


### PR DESCRIPTION
Move adhoc code for copying small data types from stack to memory into copy helper
Improve code in copy helper dealing with IX offsets falling beyond bounds of -127/+128
Improve tests covering copying code