### PR TITLE
Record var type on indirect and storeind nodes

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/IndirectCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/IndirectCodeGenerator.cs
@@ -26,13 +26,20 @@ namespace ILCompiler.Compiler.CodeGenerators
                     context.Assembler.Push(R16.HL);
                 }
 
-                if (entry.SourceInHeap)
+                if (entry.Type.IsSmall())
                 {
-                    CopyHelper.CopyFromHeapToStack(context.Assembler, size, (short)entry.Offset, false);
+                    CopyHelper.CopySmallToStack(context.Assembler, size, (short)entry.Offset, !entry.Type.IsUnsigned());
                 }
                 else
                 {
-                    CopyHelper.CopyFromIXToStack(context.Assembler, size, (short)entry.Offset, false);
+                    if (entry.SourceInHeap)
+                    {
+                        CopyHelper.CopyFromHeapToStack(context.Assembler, size, (short)entry.Offset, false);
+                    }
+                    else
+                    {
+                        CopyHelper.CopyFromIXToStack(context.Assembler, size, (short)entry.Offset, false);
+                    }
                 }
 
                 // Restore IX

--- a/ILCompiler/Compiler/CodeGenerators/StoreIndCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/StoreIndCodeGenerator.cs
@@ -17,13 +17,20 @@ namespace ILCompiler.Compiler.CodeGenerators
 
                 short offset = (short)entry.FieldOffset;
 
-                if (entry.TargetInHeap)
+                if (entry.Type.IsSmall())
                 {
-                    CopyHelper.CopyFromStackToHeap(context.Assembler, exactSize, offset);
+                    CopyHelper.CopyStackToSmall(context.Assembler, exactSize, offset);
                 }
                 else
                 {
-                    CopyHelper.CopyFromStackToIX(context.Assembler, exactSize, offset);
+                    if (entry.TargetInHeap)
+                    {
+                        CopyHelper.CopyFromStackToHeap(context.Assembler, exactSize, offset);
+                    }
+                    else
+                    {
+                        CopyHelper.CopyFromStackToIX(context.Assembler, exactSize, offset);
+                    }
                 }
 
                 context.Assembler.Push(R16.BC);

--- a/ILCompiler/Compiler/Importer/LoadFieldImporter.cs
+++ b/ILCompiler/Compiler/Importer/LoadFieldImporter.cs
@@ -56,6 +56,10 @@ namespace ILCompiler.Compiler.Importer
             var fieldSize = fieldDef.FieldType.GetExactSize();
 
             var node = new IndirectEntry(obj, kind, fieldSize, fieldSize, fieldOffset);
+
+            var varType = fieldDef.DeclaringType.ToTypeSig().GetVarType();
+            node.Type = varType;
+
             importer.PushExpression(node);
         }
     }

--- a/ILCompiler/Compiler/Importer/StoreFieldImporter.cs
+++ b/ILCompiler/Compiler/Importer/StoreFieldImporter.cs
@@ -35,7 +35,11 @@ namespace ILCompiler.Compiler.Importer
             var fieldSize = fieldDef.FieldType.GetExactSize();
             var fieldOffset = fieldDef.FieldOffset ?? 0;
 
-            importer.ImportAppendTree(new StoreIndEntry(addr, value, WellKnownType.Int32, fieldOffset, fieldSize));
+            var node = new StoreIndEntry(addr, value, WellKnownType.Int32, fieldOffset, fieldSize);
+            var varType = fieldDef.DeclaringType.ToTypeSig().GetVarType();
+            node.Type = varType;
+
+            importer.ImportAppendTree(node);
         }
     }
 }


### PR DESCRIPTION
Use var type on these nodes to check if field type is small 
For small types generate proper code to deal with smaller data type size.