### PR TITLE
Remove copy helper methods for copying to/from heap

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/CopyHelper.cs
+++ b/ILCompiler/Compiler/CodeGenerators/CopyHelper.cs
@@ -5,37 +5,6 @@ namespace ILCompiler.Compiler.CodeGenerators
 {
     internal class CopyHelper
     {
-        // TODO: merge this into CopyFromStackToIX 
-        public static void CopyFromStackToHeap(Assembler assembler, int size, int ixOffset = 0, bool restoreIX = false)
-        {
-            // Currently only support int32 here
-            Debug.Assert(size == 4);
-
-            // Reverse endianness, stack is big endian, heap is little endian
-            assembler.Pop(R16.HL);
-            assembler.Ld(I16.IX, (short)(ixOffset + 3), R8.H);
-            assembler.Ld(I16.IX, (short)(ixOffset + 2), R8.L);
-
-            assembler.Pop(R16.HL);
-            assembler.Ld(I16.IX, (short)(ixOffset + 1), R8.H);
-            assembler.Ld(I16.IX, (short)(ixOffset + 0), R8.L);
-        }
-
-        // TODO: merge this into CopyFromIXToStack
-        public static void CopyFromHeapToStack(Assembler assembler, int size, int ixOffset = 0, bool restoreIX = false)
-        {
-            // Currently only support int32 here
-            Debug.Assert(size == 4);
-
-            assembler.Ld(R8.H, I16.IX, (short)(ixOffset + 1));
-            assembler.Ld(R8.L, I16.IX, (short)(ixOffset + 0));
-            assembler.Push(R16.HL);
-
-            assembler.Ld(R8.H, I16.IX, (short)(ixOffset + 3));
-            assembler.Ld(R8.L, I16.IX, (short)(ixOffset + 2));
-            assembler.Push(R16.HL);
-        }
-
         public static void CopyStackToSmall(Assembler assembler, int bytesToCopy, int ixOffset)
         {
             // pop lsw

--- a/ILCompiler/Compiler/CodeGenerators/IndirectCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/IndirectCodeGenerator.cs
@@ -32,14 +32,7 @@ namespace ILCompiler.Compiler.CodeGenerators
                 }
                 else
                 {
-                    if (entry.SourceInHeap)
-                    {
-                        CopyHelper.CopyFromHeapToStack(context.Assembler, size, (short)entry.Offset, false);
-                    }
-                    else
-                    {
-                        CopyHelper.CopyFromIXToStack(context.Assembler, size, (short)entry.Offset, false);
-                    }
+                    CopyHelper.CopyFromIXToStack(context.Assembler, size, (short)entry.Offset, false);
                 }
 
                 // Restore IX

--- a/ILCompiler/Compiler/CodeGenerators/StoreIndCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/StoreIndCodeGenerator.cs
@@ -23,14 +23,7 @@ namespace ILCompiler.Compiler.CodeGenerators
                 }
                 else
                 {
-                    if (entry.TargetInHeap)
-                    {
-                        CopyHelper.CopyFromStackToHeap(context.Assembler, exactSize, offset);
-                    }
-                    else
-                    {
-                        CopyHelper.CopyFromStackToIX(context.Assembler, exactSize, offset);
-                    }
+                    CopyHelper.CopyFromStackToIX(context.Assembler, exactSize, offset);
                 }
 
                 context.Assembler.Push(R16.BC);

--- a/ILCompiler/Compiler/EvaluationStack/IndirectEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/IndirectEntry.cs
@@ -11,8 +11,6 @@ namespace ILCompiler.Compiler.EvaluationStack
 
         public int DesiredSize { get; }
 
-        public bool SourceInHeap { get; set; }
-
         public IndirectEntry(StackEntry op1, StackValueKind kind, int? exactSize, int desiredSize = 4, uint offset = 0) : base(kind, exactSize)
         {
             Op1 = op1;
@@ -22,7 +20,7 @@ namespace ILCompiler.Compiler.EvaluationStack
 
         public override StackEntry Duplicate()
         {
-            return new IndirectEntry(Op1.Duplicate(), Kind, ExactSize, DesiredSize, Offset) { SourceInHeap = this.SourceInHeap };
+            return new IndirectEntry(Op1.Duplicate(), Kind, ExactSize, DesiredSize, Offset);
         }
 
         public override void Accept(IStackEntryVisitor visitor)

--- a/ILCompiler/Compiler/Morpher.cs
+++ b/ILCompiler/Compiler/Morpher.cs
@@ -52,7 +52,7 @@ namespace ILCompiler.Compiler
                     break;
 
                 case IndirectEntry ie:
-                    tree = new IndirectEntry(MorphTree(ie.Op1), ie.Kind, ie.ExactSize, ie.DesiredSize, ie.Offset) { SourceInHeap = ie.SourceInHeap };
+                    tree = new IndirectEntry(MorphTree(ie.Op1), ie.Kind, ie.ExactSize, ie.DesiredSize, ie.Offset);
                     break;
 
                 case IntrinsicEntry ie:
@@ -118,7 +118,7 @@ namespace ILCompiler.Compiler
             addr = new BinaryOperator(Operation.Add, isComparison: false, tree.ArrayOp, addr, StackValueKind.NativeInt);
 
 
-            addr = new IndirectEntry(addr, tree.Kind, tree.ExactSize) { SourceInHeap = true };
+            addr = new IndirectEntry(addr, tree.Kind, tree.ExactSize);
 
             return addr;
         }


### PR DESCRIPTION
The heap specific copy helper methods are unnecessary as can just use the existing methods that are being used to copy data from/to stack to/from elsewhere on stack. This will ensure a standard representation of data too so will make everything a bit more consistent e.g. no change in endianness based on location of the data.

Remove SourceInHeap on IndirectEntry as no longer required.