### PR TITLE
Support more types for arrays

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/CastCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/CastCodeGenerator.cs
@@ -71,6 +71,10 @@ namespace ILCompiler.Compiler.CodeGenerators
             {
                 // Nothing to do
             }
+            else if (actualType == VarType.UInt && desiredType == VarType.Int)
+            {
+                // Nothing to do
+            }
             else
             {
                 throw new NotImplementedException($"Implicit cast from {actualType} to {desiredType} not supported");

--- a/ILCompiler/Compiler/EvaluationStack/StoreIndEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/StoreIndEntry.cs
@@ -6,8 +6,6 @@
         public StackEntry Op1 { get; }
         public uint FieldOffset { get; }
 
-        public bool TargetInHeap { get; set; }
-
         public StoreIndEntry(StackEntry addr, StackEntry op1, uint fieldOffset = 0, int? size = 4) : base(VarType.Void, size)
         {
             Addr = addr;
@@ -17,7 +15,7 @@
 
         public override StackEntry Duplicate()
         {
-            return new StoreIndEntry(Addr, Op1.Duplicate(), FieldOffset, ExactSize) { TargetInHeap = this.TargetInHeap };
+            return new StoreIndEntry(Addr, Op1.Duplicate(), FieldOffset, ExactSize);
         }
 
         public override void Accept(IStackEntryVisitor visitor)

--- a/ILCompiler/Compiler/Importer/LoadElemImporter.cs
+++ b/ILCompiler/Compiler/Importer/LoadElemImporter.cs
@@ -8,7 +8,13 @@ namespace ILCompiler.Compiler.Importer
     {
         public bool CanImport(Code code)
         {
-            return code == Code.Ldelem_I4;
+            return code == Code.Ldelem_I 
+                || code == Code.Ldelem_I1 
+                || code == Code.Ldelem_I2 
+                || code == Code.Ldelem_I4
+                || code == Code.Ldelem_U1
+                || code == Code.Ldelem_U2
+                || code == Code.Ldelem_U4;
         }
 
         public void Import(Instruction instruction, ImportContext context, IILImporterProxy importer)
@@ -16,9 +22,27 @@ namespace ILCompiler.Compiler.Importer
             var op1 = importer.PopExpression();
             var op2 = importer.PopExpression();
 
-            var node = new IndexRefEntry(op1, op2, 4, VarType.Int);
+            var elemType = GetType(instruction.OpCode.Code);
+            var exactSize = elemType.GetTypeSize();
+
+            var node = new IndexRefEntry(op1, op2, exactSize, elemType);
 
             importer.PushExpression(node);
+        }
+
+        private static VarType GetType(Code code)
+        {
+            return code switch
+            {
+                Code.Ldelem_I1 => VarType.SByte,
+                Code.Ldelem_I2 => VarType.Short,
+                Code.Ldelem_I4 => VarType.Int,
+                Code.Ldelem_I => VarType.Ptr,
+                Code.Ldelem_U1 => VarType.Byte,
+                Code.Ldelem_U2 => VarType.UShort,
+                Code.Ldelem_U4 => VarType.UInt,
+                _ => throw new NotImplementedException(),
+            };
         }
     }
 }

--- a/ILCompiler/Compiler/Importer/StoreElemImporter.cs
+++ b/ILCompiler/Compiler/Importer/StoreElemImporter.cs
@@ -8,30 +8,48 @@ namespace ILCompiler.Compiler.Importer
 {
     public class StoreElemImporter : IOpcodeImporter
     {
-        public bool CanImport(Code code) => code == Code.Stelem_I4;
+        public bool CanImport(Code code) => code == Code.Stelem_I || code == Code.Stelem_I1 || code == Code.Stelem_I2 || code == Code.Stelem_I4;
 
         public void Import(Instruction instruction, ImportContext context, IILImporterProxy importer)
         {
+            var elemType = GetType(instruction.OpCode.Code);
+            var elemSize = elemType.GetTypeSize();
+
             var value = importer.PopExpression();
+            if (value.Type != elemType)
+            {
+                value = new CastEntry(value, elemType);
+            }
+
             var indexOp = importer.PopExpression();
             var arrayOp = importer.PopExpression();
 
-            var elemSize = 4;
-
-            StackEntry addr = indexOp;
+            var cast = new CastEntry(indexOp, VarType.Ptr);
+            StackEntry addr = cast;
             if (elemSize > 1)
             {
                 // elemSize * index
                 var size = new NativeIntConstantEntry((short)elemSize);
-                var cast = new CastEntry(indexOp, VarType.Ptr);
-                indexOp = cast;
-                addr = new BinaryOperator(Operation.Mul, isComparison: false, size, indexOp, VarType.Ptr);
+                addr = new BinaryOperator(Operation.Mul, isComparison: false, size, addr, VarType.Ptr);
             }
 
             addr = new BinaryOperator(Operation.Add, isComparison: false, arrayOp, addr, VarType.Ptr);
 
-            var op = new StoreIndEntry(addr, value) { TargetInHeap = true };
+            var op = new StoreIndEntry(addr, value, 0, elemSize);
             importer.ImportAppendTree(op);
         }
+
+        private static VarType GetType(Code code)
+        {
+            return code switch
+            {
+                Code.Stelem_I1 => VarType.SByte,
+                Code.Stelem_I2 => VarType.Short,
+                Code.Stelem_I4 => VarType.Int,
+                Code.Stelem_I => VarType.Ptr,
+                _ => throw new NotImplementedException(),
+            };
+        }
+
     }
 }

--- a/ILCompiler/Compiler/Morpher.cs
+++ b/ILCompiler/Compiler/Morpher.cs
@@ -71,7 +71,7 @@ namespace ILCompiler.Compiler
                     break;
 
                 case StoreIndEntry sie:
-                    tree = new StoreIndEntry(sie.Addr, MorphTree(sie.Op1), sie.FieldOffset, sie.ExactSize) { TargetInHeap = sie.TargetInHeap };
+                    tree = new StoreIndEntry(sie.Addr, MorphTree(sie.Op1), sie.FieldOffset, sie.ExactSize);
                     break;
 
                 case StoreLocalVariableEntry slve:
@@ -105,18 +105,17 @@ namespace ILCompiler.Compiler
 
         private static StackEntry MorphArrayIndex(IndexRefEntry tree)
         {
-            StackEntry addr = tree.IndexOp;
+            var cast = new CastEntry(tree.IndexOp, VarType.Ptr);
+            StackEntry addr = cast;
             if (tree.ElemSize > 1)
             {
                 // elemSize * index
                 var size = new NativeIntConstantEntry((short)tree.ElemSize);
-                var cast = new CastEntry(tree.IndexOp, VarType.Ptr);
-                var indexOp = cast;
-                addr = new BinaryOperator(Operation.Mul, isComparison: false, size, indexOp, VarType.Ptr);
+                addr = new BinaryOperator(Operation.Mul, isComparison: false, size, addr, VarType.Ptr);
             }
 
             addr = new BinaryOperator(Operation.Add, isComparison: false, tree.ArrayOp, addr, VarType.Ptr);
-            addr = new IndirectEntry(addr, tree.Type, tree.ExactSize);
+            addr = new IndirectEntry(addr, tree.Type, tree.ElemSize);
 
             return addr;
         }

--- a/ILCompiler/Compiler/Morpher.cs
+++ b/ILCompiler/Compiler/Morpher.cs
@@ -67,7 +67,12 @@ namespace ILCompiler.Compiler
                     break;
 
                 case ReturnEntry re:
-                    tree = new ReturnEntry(re.Return, re.ReturnBufferArgIndex, re.ReturnTypeExactSize);
+                    var returnValue = re.Return;
+                    if (returnValue != null)
+                    {
+                        returnValue = MorphTree(returnValue);
+                    }
+                    tree = new ReturnEntry(returnValue, re.ReturnBufferArgIndex, re.ReturnTypeExactSize);
                     break;
 
                 case StoreIndEntry sie:

--- a/Tests/ILCompiler.IntegrationTests/il_bvt/array_tests.il
+++ b/Tests/ILCompiler.IntegrationTests/il_bvt/array_tests.il
@@ -10,34 +10,95 @@
 .method public static int32 Main() {
 .entrypoint
 .maxstack  5
-.locals (int32[])
+.locals (int32[], int8[], int16[])
 	ldc.i4 0x00000004
 	newarr [mscorlib]System.Int32
 	stloc 0
 
 	ldloc 0
 	ldc.i4 0x00
-	ldc.i4 0x25
+	ldc.i4 0x7fffffff
 	stelem.i4
 
 	ldloc 0
 	ldc.i4 0x00
 	ldelem.i4
 
-	ldc.i4 0x25
+	ldc.i4 0x7fffffff
 	ceq
 	brfalse FAIL
 
 	ldloc 0
 	ldc.i4 0x01
-	ldc.i4 0x08
+	ldc.i4 0x80000000
 	stelem.i4
 
 	ldloc 0
 	ldc.i4 0x01
 	ldelem.i4
 
+	ldc.i4 0x80000000
+	ceq
+	brfalse FAIL
+
+	ldc.i4 0x00000004
+	newarr [mscorlib]System.Byte
+	stloc 1
+
+	ldloc 1
+	ldc.i4 0x00
+	ldc.i4 0x25
+	stelem.i1
+
+	ldloc 1
+	ldc.i4 0x00
+	ldelem.i1
+
+	ldc.i4 0x25
+	ceq
+	brfalse FAIL
+
+	ldloc 1
+	ldc.i4 0x01
 	ldc.i4 0x08
+	stelem.i1
+
+	ldloc 1
+	ldc.i4 0x01
+	ldelem.i1
+
+	ldc.i4 0x08
+	ceq
+	brfalse FAIL
+
+	ldc.i4 0x00000004
+	newarr [mscorlib]System.Int16
+	stloc 2
+
+	ldloc 2
+	ldc.i4 0x00
+	ldc.i4 0x00007fff
+	stelem.i2
+
+	ldloc 2
+	ldc.i4 0x00
+	ldelem.i2
+
+	ldc.i4 0x00007fff
+	ceq
+	brfalse FAIL
+
+
+	ldloc 2
+	ldc.i4 0x01
+	ldc.i4 0x0000ffff
+	stelem.i2
+
+	ldloc 2
+	ldc.i4 0x01
+	ldelem.i2
+
+	ldc.i4 0xffffffff	// negative value is sign extended
 	ceq
 	brfalse FAIL
 

--- a/Tests/ILCompiler.IntegrationTests/il_bvt/array_tests.il
+++ b/Tests/ILCompiler.IntegrationTests/il_bvt/array_tests.il
@@ -7,99 +7,250 @@
 }
 .class public array_tests
 {
-.method public static int32 Main() {
-.entrypoint
+.method public static int32 I8(int32, int32, int32) {
 .maxstack  5
-.locals (int32[], int8[], int16[])
+.locals (int8[])
+
+	ldc.i4 0x00000004
+	newarr [mscorlib]System.Byte
+	stloc 0
+
+	ldloc 0
+	ldarg.0
+	ldarg.1
+	stelem.i1
+
+	ldloc 0
+	ldarg.0
+	ldelem.i1
+
+	ldarg.2
+	ceq
+	ret
+}
+
+.method public static int32 U8(int32, uint32, uint32) {
+.maxstack  5
+.locals (int8[])
+
+	ldc.i4 0x00000004
+	newarr [mscorlib]System.Byte
+	stloc 0
+
+	ldloc 0
+	ldarg.0
+	ldarg.1
+	stelem.i1
+
+	ldloc 0
+	ldarg.0
+	ldelem.u1
+
+	ldarg.2
+	ceq
+	ret
+}
+
+
+.method public static int32 I(int32, int32, int32) {
+.maxstack  5
+.locals (int16[])
+
+	ldc.i4 0x00000004
+	newarr [mscorlib]System.Int16
+	stloc 0
+
+	ldloc 0
+	ldarg.0
+	ldarg.1
+	conv.i
+	stelem.i
+
+	ldloc 0
+	ldarg.0
+	ldelem.i
+
+	ldarg.2
+	conv.i
+	ceq
+	ret
+}
+
+.method public static int32 I16(int32, int32, int32) {
+.maxstack  5
+.locals (int16[])
+
+	ldc.i4 0x00000004
+	newarr [mscorlib]System.Int16
+	stloc 0
+
+	ldloc 0
+	ldarg.0
+	ldarg.1
+	stelem.i2
+
+	ldloc 0
+	ldarg.0
+	ldelem.i2
+
+	ldarg.2
+	ceq
+	ret
+}
+
+.method public static int32 U16(int32, uint32, uint32) {
+.maxstack  5
+.locals (int16[])
+
+	ldc.i4 0x00000004
+	newarr [mscorlib]System.Int16
+	stloc 0
+
+	ldloc 0
+	ldarg.0
+	ldarg.1
+	stelem.i2
+
+	ldloc 0
+	ldarg.0
+	ldelem.u2
+
+	ldarg.2
+	ceq
+	ret
+}
+
+.method public static int32 I32(int32, int32, int32) {
+.maxstack  5
+.locals (int32[])
+
 	ldc.i4 0x00000004
 	newarr [mscorlib]System.Int32
 	stloc 0
 
 	ldloc 0
-	ldc.i4 0x00
-	ldc.i4 0x7fffffff
+	ldarg.0
+	ldarg.1
 	stelem.i4
 
 	ldloc 0
-	ldc.i4 0x00
+	ldarg.0
 	ldelem.i4
 
-	ldc.i4 0x7fffffff
+	ldarg.2
 	ceq
-	brfalse FAIL
+	ret
+}
+
+.method public static int32 U32(int32, uint32, uint32) {
+.maxstack  5
+.locals (int32[])
+
+	ldc.i4 0x00000004
+	newarr [mscorlib]System.Int32
+	stloc 0
 
 	ldloc 0
-	ldc.i4 0x01
-	ldc.i4 0x80000000
+	ldarg.0
+	ldarg.1
 	stelem.i4
 
 	ldloc 0
-	ldc.i4 0x01
-	ldelem.i4
+	ldarg.0
+	ldelem.u4
 
-	ldc.i4 0x80000000
+	ldarg.2
 	ceq
-	brfalse FAIL
+	ret
+}
 
-	ldc.i4 0x00000004
-	newarr [mscorlib]System.Byte
-	stloc 1
+.method public static int32 Main() {
+.entrypoint
+.maxstack  5
+.locals ()
 
-	ldloc 1
 	ldc.i4 0x00
 	ldc.i4 0x25
-	stelem.i1
-
-	ldloc 1
-	ldc.i4 0x00
-	ldelem.i1
-
 	ldc.i4 0x25
-	ceq
+	call int32 array_tests::I8(int32, int32, int32)
 	brfalse FAIL
 
-	ldloc 1
 	ldc.i4 0x01
-	ldc.i4 0x08
-	stelem.i1
-
-	ldloc 1
-	ldc.i4 0x01
-	ldelem.i1
-
-	ldc.i4 0x08
-	ceq
+	ldc.i4 0xff
+	ldc.i4 0xffffffff	// negative value is sign extended
+	call int32 array_tests::I8(int32, int32, int32)
 	brfalse FAIL
 
-	ldc.i4 0x00000004
-	newarr [mscorlib]System.Int16
-	stloc 2
+	ldc.i4 0x00
+	ldc.i4 0x25
+	ldc.i4 0x25
+	call int32 array_tests::U8(int32, uint32, uint32)
+	brfalse FAIL
 
-	ldloc 2
+	ldc.i4 0x01
+	ldc.i4 0xff
+	ldc.i4 0xff
+	call int32 array_tests::U8(int32, uint32, uint32)
+	brfalse FAIL
+
 	ldc.i4 0x00
 	ldc.i4 0x00007fff
-	stelem.i2
-
-	ldloc 2
-	ldc.i4 0x00
-	ldelem.i2
-
 	ldc.i4 0x00007fff
-	ceq
+	call int32 array_tests::I16(int32, int32, int32)
 	brfalse FAIL
 
-
-	ldloc 2
 	ldc.i4 0x01
 	ldc.i4 0x0000ffff
-	stelem.i2
-
-	ldloc 2
-	ldc.i4 0x01
-	ldelem.i2
-
 	ldc.i4 0xffffffff	// negative value is sign extended
-	ceq
+	call int32 array_tests::I16(int32, int32, int32)
+	brfalse FAIL
+
+	ldc.i4 0x00
+	ldc.i4 0x00007fff
+	ldc.i4 0x00007fff
+	call int32 array_tests::U16(int32, uint32, uint32)
+	brfalse FAIL
+
+	ldc.i4 0x01
+	ldc.i4 0x0000ffff
+	ldc.i4 0x0000ffff
+	call int32 array_tests::U16(int32, uint32, uint32)
+	brfalse FAIL
+
+	ldc.i4 0x00
+	ldc.i4 0x00007fff
+	ldc.i4 0x00007fff
+	call int32 array_tests::I(int32, int32, int32)
+	brfalse FAIL
+
+	ldc.i4 0x01
+	ldc.i4 0x0000ffff
+	ldc.i4 0x0000ffff
+	call int32 array_tests::I(int32, int32, int32)
+	brfalse FAIL
+
+	ldc.i4 0x00
+	ldc.i4 0x7fffffff
+	ldc.i4 0x7fffffff
+	call int32 array_tests::I32(int32, int32, int32)
+	brfalse FAIL
+
+	ldc.i4 0x01
+	ldc.i4 0x80000000
+	ldc.i4 0x80000000
+	call int32 array_tests::I32(int32, int32, int32)
+	brfalse FAIL
+
+	ldc.i4 0x00
+	ldc.i4 0x7fffffff
+	ldc.i4 0x7fffffff
+	call int32 array_tests::U32(int32, uint32, uint32)
+	brfalse FAIL
+
+	ldc.i4 0x01
+	ldc.i4 0x80000000
+	ldc.i4 0x80000000
+	call int32 array_tests::U32(int32, uint32, uint32)
 	brfalse FAIL
 
 PASS:


### PR DESCRIPTION
Add support for ldelem for types i, i1, i2, i4, u1, u2, u4
Add support for stelem for types i, i1, i2, i4

This pretty much fixes issue #16 but need to consider separate issue for supporting custom class and struct types.