### PR TITLE
Run build on pushes to main and creation of pull requests to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,11 @@
 name: "Build"
 
-on: [push]
+on: 
+  push:
+    branches: [ main ]
+        
+  pull_request:
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
Fix bug with github actions build workflow as only running on push and not on pull request creation.

See #53 