### PR TITLE
Fix bug with BinaryOperators not having the correct exact size

### DIFF
--- a/ILCompiler/Compiler/EvaluationStack/BinaryOperatorEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/BinaryOperatorEntry.cs
@@ -9,7 +9,7 @@ namespace ILCompiler.Compiler.EvaluationStack
         public bool IsComparison { get; }
         public Operation Operation { get; set; }
 
-        public BinaryOperator(Operation operation, bool isComparison, StackEntry op1, StackEntry op2, VarType type) : base(type, 4)
+        public BinaryOperator(Operation operation, bool isComparison, StackEntry op1, StackEntry op2, VarType type) : base(type, type.GetTypeSize())
         {
             Operation = operation;
             IsComparison = isComparison;

--- a/Tests/ILCompiler.IntegrationTests/il_bvt/dup.il
+++ b/Tests/ILCompiler.IntegrationTests/il_bvt/dup.il
@@ -6,6 +6,7 @@
 {
 }
 .class public _dup {
+
 .method public static int32 _dup(int32) {
 .maxstack 2
 	ldarg 0
@@ -13,12 +14,21 @@
 	ceq
 	ret
 }
+
 .method public static int32 Main() {
 .entrypoint
 .maxstack 10
+.locals(int32)
 	ldc.i4 0xFAFAFAFA
 	call int32 _dup::_dup(int32)
 	brfalse fail
+
+	ldc.i4 0x00000004
+	newarr [mscorlib]System.Byte
+	dup
+	ceq
+	brfalse fail
+
 pass:
 	ldc.i4 0x0000
 	ret


### PR DESCRIPTION
Fix bug with Dup importing when value on top of evaluation stack is complex e.g. result of newarr then we can't simply duplicate this as would result in two newarr's. Change to use a spill to local and load local twice approach. Add test to cover change to dup impoter.

This means code like "var arr = new int[] { 1, 2, 3 }" should work properly.