### PR TITLE
Simple implementation of Console.ReadLine for Trs-80

### DIFF
--- a/ILCompiler/ILCompiler.csproj
+++ b/ILCompiler/ILCompiler.csproj
@@ -61,6 +61,7 @@
     <None Remove="Runtime\TRS80\cls.asm" />
     <None Remove="Runtime\TRS80\getdatetime.asm" />
     <None Remove="Runtime\TRS80\printchr.asm" />
+    <None Remove="Runtime\TRS80\readline.asm" />
     <None Remove="Runtime\TRS80\write.asm" />
     <None Remove="Runtime\TRS80\ticks.asm" />
 	<None Remove="Runtime\TRS80\setres.asm" />
@@ -121,6 +122,7 @@
     <EmbeddedResource Include="Runtime\TRS80\cls.asm" />
     <EmbeddedResource Include="Runtime\TRS80\printchr.asm" />
     <EmbeddedResource Include="Runtime\TRS80\getdatetime.asm" />
+    <EmbeddedResource Include="Runtime\TRS80\readline.asm" />
     <EmbeddedResource Include="Runtime\TRS80\write.asm" />
     <EmbeddedResource Include="Runtime\ZXSpectrum\cls.asm" />
     <EmbeddedResource Include="Runtime\ZXSpectrum\getdatetime.asm" />

--- a/ILCompiler/Runtime/TRS80/readline.asm
+++ b/ILCompiler/Runtime/TRS80/readline.asm
@@ -1,0 +1,66 @@
+; read a line (upto 240 characters) of text
+READLINE:
+
+	; Use rom routine to read text - no chars beyond 240 chars are allowed to be entered
+	LD HL, INPUTBUF
+	LD B, 240
+	CALL 40H
+
+	; B is string length
+	; HL is string buffer
+
+	; Now need to heap alloc a proper dotnet string and copy characters
+	; String has 2 bytes for length, followed by characters which are utf-16 so 2 bytes per character
+
+	; Put actual entered string length into BC
+	LD C, B
+	LD B, 0
+
+	PUSH BC	; Save actual entered string size
+
+	INC C	; Add 2 bytes as String heap objects use first 2 bytes to hold length of string
+	INC C
+
+	; Allocate string object on heap
+	PUSH BC
+	CALL HEAPALLOC
+
+	POP HL		; Pointer to heap allocated string
+	POP DE		; Ignore MSW as will be 0 on 16 bit architectures
+	POP BC		; Length of string
+	POP DE		; Return Address
+
+	PUSH DE		; Save return address
+	PUSH HL		; Save pointer to string object on heap
+
+	; Put length into first 2 bytes of string object
+	LD (HL), C
+	INC HL
+	LD (HL), 0
+	INC HL
+
+	; Copy characters from input buffer to heap allocated string object
+	LD DE, INPUTBUF
+COPYCHAR:
+	LD A, (DE)
+	LD (HL), A		; Character from input buffer goes first
+	INC HL
+	LD (HL), 0		; Extra byte as dotnet chars as utf-16
+	INC HL
+
+	INC DE			; Move to next char in input buffer
+	DEC C
+	JP NZ, COPYCHAR	; Continue copying till all chars done
+
+	POP HL		; Pointer to heap allocated string
+	POP DE		; Return address
+
+	LD BC, 0
+
+	PUSH BC		; MSW of heap allocated string object - always 0 as we only have 64kb of addressable memory
+	PUSH HL		; LSW of heap allocated string obejct
+
+	PUSH DE		; Restore return address
+	RET
+
+INPUTBUF:	DEFS 240

--- a/System.Private.CoreLib/Pal/Console.Trs80.cs
+++ b/System.Private.CoreLib/Pal/Console.Trs80.cs
@@ -4,6 +4,9 @@ namespace System
 {
     public static partial class Console
     {
+        [DllImport(Libraries.Runtime, EntryPoint = "READLINE")]
+        public static unsafe extern String ReadLine();
+
         [DllImport(Libraries.Runtime, EntryPoint = "SetXY")]
         public static unsafe extern void SetConsoleCursorPosition(sbyte x, sbyte y);
 


### PR DESCRIPTION
Uses the built in rom routine - but with added code to allocate real String object on heap and initialise its data based on what the rom routine read in.

Has hard limit of 240 characters - but note the string objects on the heap will be sized based on what the user actually entered