### PR TITLE
Add simple Int32.Parse method with tests

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/CopyHelper.cs
+++ b/ILCompiler/Compiler/CodeGenerators/CopyHelper.cs
@@ -200,7 +200,7 @@ namespace ILCompiler.Compiler.CodeGenerators
                 var bytesToCopy = size > 2 ? 2 : size;
                 size -= 2;
 
-                if (ixOffset + bytesToCopy <= 127)
+                if (ixOffset < 128)
                 {
                     var delta = ixOffset + 1;
                     assembler.Ld(R16.DE, (short)delta);

--- a/ILCompiler/Compiler/ILImporter.cs
+++ b/ILCompiler/Compiler/ILImporter.cs
@@ -1,5 +1,4 @@
-﻿using dnlib.DotNet;
-using ILCompiler.Common.TypeSystem.Common;
+﻿using ILCompiler.Common.TypeSystem.Common;
 using ILCompiler.Compiler.EvaluationStack;
 using ILCompiler.Compiler.Importer;
 using ILCompiler.Interfaces;
@@ -286,21 +285,24 @@ namespace ILCompiler.Compiler
 
             if (entryStack != null)
             {
-                // Check the entry stack and the current stack are equivalent,
-                // i.e. have same length and elements are identical
+                // III.1.8.1.3 Merging Stack States
 
+                // The number of slots in each stack state must be the same
                 if (entryStack.Length != _stack.Length)
                 {
                     throw new InvalidProgramException();
                 }
 
+                //  ECMA Common Language Infrastructure(CLI) standard, V6, Partition III, CIL Instruction Set
+                // in section III.1.8.1.3 "Merging stack states", describes how stack states should be merged.
+                // For the case where the types are assignable either way (e.g. as for int32 and native int),
+                // the merging must keep the first type found.
                 for (int i = 0; i < entryStack.Length; i++)
                 {
+                    // TODO: Use Compatibility function from ECMA standard here
                     if (entryStack[i].Type != _stack[i].Type)
                     {
-                        // FIXME: This comparison needs to be more intelligent. For example
-                        // If one branch has bool and the other int then this is okay
-                        // throw new InvalidProgramException();
+                        //throw new InvalidProgramException();
                     }
                 }
             }

--- a/System.Private.CoreLib/System/Int32.cs
+++ b/System.Private.CoreLib/System/Int32.cs
@@ -2,5 +2,19 @@
 {
     public struct Int32
     {
+        public static int Parse(string s)
+        {
+            int result = 0;
+            for (int i = 0; i < s.Length; i++) 
+            { 
+                char c = s[i];
+                if (char.IsAsciiDigit(c))
+                {
+                    result = result * 10 + (c - '0');
+                }
+            }
+
+            return result;
+        }
     }
 }

--- a/Tests/CoreLib/CoreLib/CoreLib.cs
+++ b/Tests/CoreLib/CoreLib/CoreLib.cs
@@ -5,9 +5,14 @@
         public static int Main()
         {
             var result = true;
+            
             result = result && CharTests.IsBetweenCharTests();
+            
             result = result && CharTests.IsAsciiDigit_WithAsciiDigits_ReturnsTrue();
             result = result && CharTests.IsAsciiDigit_WithNonAsciiDigits_ReturnsFalse();
+
+            result = result && Int32Tests.Parse_Valid();
+
             return result ? 0 : 1;
         }
     }

--- a/Tests/CoreLib/CoreLib/Int32Tests.cs
+++ b/Tests/CoreLib/CoreLib/Int32Tests.cs
@@ -1,0 +1,24 @@
+﻿namespace CoreLib
+{
+    public class Int32Tests
+    {
+        public static bool Parse_Valid()
+        {
+            var result = true;
+
+            result = result && AssertEqual(0, int.Parse("0"));
+            result = result && AssertEqual(0, int.Parse("0000000000000000000000000000000000000000000000000000000000"));
+            result = result && AssertEqual(1, int.Parse("0000000000000000000000000000000000000000000000000000000001"));
+            result = result && AssertEqual(2147483647, int.Parse("2147483647"));
+            result = result && AssertEqual(2147483647, int.Parse("02147483647"));
+            result = result && AssertEqual(2147483647, int.Parse("00000000000000000000000000000000000000000000000002147483647"));
+            result = result && AssertEqual(123, int.Parse("123\0\0"));
+
+            result = result && AssertEqual(123, int.Parse("123"));
+
+            return result;
+        }
+
+        private static bool AssertEqual(int expected, int actual) => expected == actual;
+    }
+}


### PR DESCRIPTION
This will finally allow some example programs to read and parse input numbers and act using them e.g. program to calculate a fibonacci number etc..

Also made a better bug fix for an error in CopyHelper when data being copied would spill beyond the -128 offset allowed by index registers on Z80.

Improved comments in ImportFallThrough about merging stack states to refer to appropriate sections in ECMA 335.