### PR TITLE
Implement ldnull opcode

### DIFF
--- a/ILCompiler/Compiler/Importer/LoadNullImporter.cs
+++ b/ILCompiler/Compiler/Importer/LoadNullImporter.cs
@@ -1,0 +1,20 @@
+﻿using dnlib.DotNet.Emit;
+using ILCompiler.Compiler.EvaluationStack;
+using ILCompiler.Interfaces;
+
+namespace ILCompiler.Compiler.Importer
+{
+    public class LoadNullImporter : IOpcodeImporter
+    {
+        public bool Import(Instruction instruction, ImportContext context, IILImporterProxy importer)
+        {
+            if (instruction.OpCode.Code != Code.Ldnull) return false;
+
+            var node = new NativeIntConstantEntry(0);
+            node.Type = VarType.Ref;
+            importer.PushExpression(node);
+
+            return true;
+        }
+    }
+}

--- a/ILCompiler/Compiler/Importer/NewobjImporter.cs
+++ b/ILCompiler/Compiler/Importer/NewobjImporter.cs
@@ -85,7 +85,7 @@ namespace ILCompiler.Compiler.Importer
                     var op1 = new AllocObjEntry(allocSize, objVarType);
 
                     // Store allocated memory address into a temp local variable
-                    var lclNum = importer.GrabTemp(VarType.Ptr, objSize);
+                    var lclNum = importer.GrabTemp(VarType.Ref, objSize);
                     var asg = new StoreLocalVariableEntry(lclNum, false, op1);
                     importer.ImportAppendTree(asg);
 
@@ -95,7 +95,7 @@ namespace ILCompiler.Compiler.Importer
 
                     // Push a local variable entry corresponding to the object here
                     var node = new LocalVariableEntry(lclNum, objVarType, objSize);
-                    node.Type = VarType.Ptr;
+                    node.Type = VarType.Ref;
                     importer.PushExpression(node);
                 }
             }

--- a/ILCompiler/Compiler/Importer/ServiceCollectionExtensions.cs
+++ b/ILCompiler/Compiler/Importer/ServiceCollectionExtensions.cs
@@ -38,6 +38,7 @@ namespace ILCompiler.Compiler.Importer
             services.AddSingleton<IOpcodeImporter, StoreElemImporter>();
             services.AddSingleton<IOpcodeImporter, LoadLengthImporter>();
             services.AddSingleton<IOpcodeImporter, LoadArgAddressImporter>();
+            services.AddSingleton<IOpcodeImporter, LoadNullImporter>();
 
             return services;
         }

--- a/Tests/ILCompiler.IntegrationTests/il_bvt/ldnull.il
+++ b/Tests/ILCompiler.IntegrationTests/il_bvt/ldnull.il
@@ -1,0 +1,29 @@
+﻿.assembly extern System.Private.CoreLib as mscorlib
+{
+    .ver 0:0:0:0
+}
+.assembly TestAssembly
+{
+}
+
+.class public _ldnull
+{
+
+.method public static int32 Main() {
+.entrypoint
+.maxstack  5
+.locals ()
+
+	ldnull
+	ldnull
+	ceq
+	brfalse FAIL
+
+PASS:
+	ldc.i4 0x0000
+	ret
+FAIL:
+	ldc.i4 0x0001
+	ret
+}
+}

--- a/Tests/ILCompiler.IntegrationTests/il_bvt/newobj.il
+++ b/Tests/ILCompiler.IntegrationTests/il_bvt/newobj.il
@@ -21,8 +21,7 @@
 .maxstack 10
 
 	newobj instance void Test::.ctor()
-	ldc.i4.0	// TODO: change to ldnull once it's implemented
-	conv.i
+	ldnull
 	ceq
 	brtrue fail	// fail if allocated objref is 0
 


### PR DESCRIPTION
ldnull is treated as a native int constant of 0 with a vartype of ref

Fix newobj to use correct vartype e.g. ref, for non value types