### PR TITLE
Support static field load/store

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/ServiceCollectionExtensions.cs
+++ b/ILCompiler/Compiler/CodeGenerators/ServiceCollectionExtensions.cs
@@ -28,6 +28,7 @@ namespace ILCompiler.Compiler.CodeGenerators
             services.AddSingleton<ICodeGenerator<AllocObjEntry>, AllocObjCodeGenerator>();
             services.AddSingleton<ICodeGenerator<LocalHeapEntry>, LocalHeapCodeGenerator>();
             services.AddSingleton<ICodeGenerator<PutArgTypeEntry>, PutArgTypeCodeGenerator>();
+            services.AddSingleton<ICodeGenerator<StaticFieldEntry>,  StaticFieldCodeGenerator>();
 
             return services;
         }

--- a/ILCompiler/Compiler/CodeGenerators/StaticFieldCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/StaticFieldCodeGenerator.cs
@@ -1,0 +1,16 @@
+﻿using ILCompiler.Compiler.EvaluationStack;
+using Z80Assembler;
+
+namespace ILCompiler.Compiler.CodeGenerators
+{
+    internal class StaticFieldCodeGenerator : ICodeGenerator<StaticFieldEntry>
+    {
+        public void GenerateCode(StaticFieldEntry entry, CodeGeneratorContext context)
+        {
+            var mangledFieldName = entry.Name;
+
+            context.Assembler.Ld(R16.HL, mangledFieldName);
+            context.Assembler.Push(R16.HL);
+        }
+    }
+}

--- a/ILCompiler/Compiler/DependencyAnalysis/DependencyAnalyser.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/DependencyAnalyser.cs
@@ -67,7 +67,7 @@ namespace ILCompiler.Compiler.DependencyAnalysis
         private void ImportFieldAccess(Instruction instruction, bool isStatic)
         {
             var fieldDefOrRef = instruction.Operand as IField;
-            var fieldDef = fieldDefOrRef.ResolveFieldDef();
+            var fieldDef = fieldDefOrRef.ResolveFieldDefThrow();
 
             if (isStatic || fieldDef.IsStatic)
             {

--- a/ILCompiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -6,6 +6,8 @@ namespace ILCompiler.Compiler.DependencyAnalysis
     {
         public bool Analysed { get; set; }
 
+        public bool Compiled { get; set; }
+
         public TypeDef Type { get; private set; }
 
         public EETypeNode(TypeDef type)

--- a/ILCompiler/Compiler/DependencyAnalysis/IDependencyNode.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/IDependencyNode.cs
@@ -4,5 +4,6 @@
     {
         public bool Analysed { get; set; }
         public IList<IDependencyNode> Dependencies { get; set; }
+        public bool Compiled { get; set; }
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/GenericStackEntryAdapter.cs
+++ b/ILCompiler/Compiler/EvaluationStack/GenericStackEntryAdapter.cs
@@ -117,5 +117,10 @@
         {
             _genericStackEntryVisitor.Visit<PutArgTypeEntry>(entry);
         }
+
+        public void Visit(StaticFieldEntry entry)
+        {
+            _genericStackEntryVisitor.Visit<StaticFieldEntry>(entry);
+        }
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/IStackEntryVisitor.cs
+++ b/ILCompiler/Compiler/EvaluationStack/IStackEntryVisitor.cs
@@ -28,7 +28,7 @@
         public void Visit(AllocObjEntry entry);
         public void Visit(LocalHeapEntry entry);
         public void Visit(IndexRefEntry entry);
-
         public void Visit(PutArgTypeEntry entry);
+        public void Visit(StaticFieldEntry entry);
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/StaticFieldEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/StaticFieldEntry.cs
@@ -1,0 +1,22 @@
+﻿namespace ILCompiler.Compiler.EvaluationStack
+{
+    public class StaticFieldEntry : StackEntry
+    {
+        public string Name { get; }
+
+        public StaticFieldEntry(String name) : base(VarType.Ptr, 2)
+        {
+            Name = name;
+        }
+
+        public override StaticFieldEntry Duplicate()
+        {
+            return new StaticFieldEntry(Name);
+        }
+
+        public override void Accept(IStackEntryVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
+    }
+}

--- a/ILCompiler/Compiler/Flowgraph.cs
+++ b/ILCompiler/Compiler/Flowgraph.cs
@@ -125,6 +125,11 @@ namespace ILCompiler.Compiler
             SetNext(entry);
         }
 
+        public void Visit(StaticFieldEntry entry)
+        {
+            SetNext(entry);
+        }
+
         public void Visit(CallEntry entry)
         {
             foreach (var argument in entry.Arguments)

--- a/ILCompiler/Compiler/Importer/AddressOfFieldImporter.cs
+++ b/ILCompiler/Compiler/Importer/AddressOfFieldImporter.cs
@@ -12,7 +12,7 @@ namespace ILCompiler.Compiler.Importer
             if (instruction.OpCode.Code != Code.Ldflda) return false;
 
             var fieldDefOrRef = instruction.Operand as IField;
-            var fieldDef = fieldDefOrRef.ResolveFieldDef();
+            var fieldDef = fieldDefOrRef.ResolveFieldDefThrow();
 
             var obj = importer.PopExpression();
 

--- a/ILCompiler/Compiler/Importer/LoadFieldImporter.cs
+++ b/ILCompiler/Compiler/Importer/LoadFieldImporter.cs
@@ -9,10 +9,12 @@ namespace ILCompiler.Compiler.Importer
     {
         public bool Import(Instruction instruction, ImportContext context, IILImporterProxy importer)
         {
-            if (instruction.OpCode != OpCodes.Ldfld) return false;
+            if (instruction.OpCode != OpCodes.Ldfld && instruction.OpCode != OpCodes.Ldsfld) return false;
+
+            var isLoadStatic = instruction.OpCode == OpCodes.Ldsfld;
 
             var fieldDefOrRef = instruction.Operand as IField;
-            var fieldDef = fieldDefOrRef.ResolveFieldDef();
+            var fieldDef = fieldDefOrRef.ResolveFieldDefThrow();
 
             // Ensure fields have all offsets calculated
             if (fieldDef.FieldOffset == null)
@@ -22,33 +24,42 @@ namespace ILCompiler.Compiler.Importer
 
             var fieldOffset = fieldDef.FieldOffset ?? 0;
 
-            var obj = importer.PopExpression();
-
-            if (obj.Type == VarType.Struct)
+            StackEntry obj;
+            if (isLoadStatic)
             {
-                if (obj is LocalVariableEntry)
-                {
-                    obj = new LocalVariableAddressEntry((obj.As<LocalVariableEntry>()).LocalNumber);
-                }
-                else if (obj is IndirectEntry)
-                {
-                    // If the object is itself an IndirectEntry e.g. resulting from a Ldfld
-                    // then we should merge the Ldfld's together
-
-                    // e.g. Ldfld SimpleVector::N
-                    //      Ldfld Nested::Length
-                    // will get converted into a single IndirectEntry node with the field offset
-                    // being the combination of the field offsets for N and Length
-
-                    var previousIndirect = obj.As<IndirectEntry>();
-                    fieldOffset = previousIndirect.Offset + fieldOffset;
-                    obj = previousIndirect.Op1;
-                }
+                var mangledFieldName = context.NameMangler.GetMangledFieldName(fieldDef);
+                obj = new StaticFieldEntry(mangledFieldName);
             }
-
-            if (obj.Type != VarType.Ref && obj.Type != VarType.ByRef && obj.Type != VarType.Ptr)
+            else
             {
-                throw new NotImplementedException($"LoadFieldImporter does not support {obj.Type}");
+                obj = importer.PopExpression();
+
+                if (obj.Type == VarType.Struct)
+                {
+                    if (obj is LocalVariableEntry)
+                    {
+                        obj = new LocalVariableAddressEntry((obj.As<LocalVariableEntry>()).LocalNumber);
+                    }
+                    else if (obj is IndirectEntry)
+                    {
+                        // If the object is itself an IndirectEntry e.g. resulting from a Ldfld
+                        // then we should merge the Ldfld's together
+
+                        // e.g. Ldfld SimpleVector::N
+                        //      Ldfld Nested::Length
+                        // will get converted into a single IndirectEntry node with the field offset
+                        // being the combination of the field offsets for N and Length
+
+                        var previousIndirect = obj.As<IndirectEntry>();
+                        fieldOffset = previousIndirect.Offset + fieldOffset;
+                        obj = previousIndirect.Op1;
+                    }
+                }
+
+                if (obj.Type != VarType.Ref && obj.Type != VarType.ByRef && obj.Type != VarType.Ptr)
+                {
+                    throw new NotImplementedException($"LoadFieldImporter does not support {obj.Type}");
+                }
             }
 
             var fieldSize = fieldDef.FieldType.GetInstanceFieldSize();

--- a/ILCompiler/Compiler/LIRDumper.cs
+++ b/ILCompiler/Compiler/LIRDumper.cs
@@ -155,6 +155,11 @@ namespace ILCompiler.Compiler
             _sb.AppendLine($"       fieldAddr {entry.Name}");
         }
 
+        public void Visit(StaticFieldEntry entry)
+        {
+            _sb.AppendLine($"       staticField {entry.Name}");
+        }
+
         public void Visit(SwitchEntry entry)
         {
             _sb.AppendLine($"       ┌──▌  t{entry.Op1.TreeID}");

--- a/ILCompiler/Compiler/NameMangler.cs
+++ b/ILCompiler/Compiler/NameMangler.cs
@@ -10,6 +10,11 @@ namespace ILCompiler.Compiler
 
         private static int nextMethodId = 0;
 
+        private readonly Dictionary<String, String> _mangledFieldNames = new Dictionary<String, String>();
+
+        private static int nextFieldId = 0;
+
+
         public string GetMangledMethodName(MethodSpec method)
         {
             return GetMangledMethodName(method.FullName);
@@ -34,6 +39,24 @@ namespace ILCompiler.Compiler
 
             mangledName = $"m{nextMethodId++}";
             _mangledMethodNames.Add(fullName, mangledName);
+
+            return mangledName;
+        }
+
+        public string GetMangledFieldName(FieldDef field)
+        {
+            return GetMangledFieldName(field.FullName);
+        }
+
+        private string GetMangledFieldName(string fullName)
+        {
+            if (_mangledFieldNames.TryGetValue(fullName, out string? mangledName))
+            {
+                return mangledName;
+            }
+
+            mangledName = $"f{nextFieldId++}";
+            _mangledFieldNames.Add(fullName, mangledName);
 
             return mangledName;
         }

--- a/ILCompiler/Compiler/TreeDumper.cs
+++ b/ILCompiler/Compiler/TreeDumper.cs
@@ -192,6 +192,11 @@ namespace ILCompiler.Compiler
             _indent--;
         }
 
+        public void Visit(StaticFieldEntry entry)
+        {
+            Print($"STATIC_FLD {entry.Name}");
+        }
+
         public void Visit(AllocObjEntry entry)
         {
             Print($"ALLOCOBJ {entry.Size}");

--- a/ILCompiler/Interfaces/INameMangler.cs
+++ b/ILCompiler/Interfaces/INameMangler.cs
@@ -8,5 +8,6 @@ namespace ILCompiler.Interfaces
         public string GetMangledMethodName(MethodSpec method);
         public string GetMangledMethodName(MethodDef method);
         public string GetMangledMethodName(MethodDesc method);
+        public string GetMangledFieldName(FieldDef field);
     }
 }

--- a/Tests/ILCompiler.IntegrationTests/il_bvt/field_tests.il
+++ b/Tests/ILCompiler.IntegrationTests/il_bvt/field_tests.il
@@ -2,7 +2,7 @@
 {
     .ver 0:0:0:0
 }
-.assembly TestAssembly
+.assembly field_tests
 {
 }
 
@@ -19,8 +19,52 @@
 	.field public int32* Ptr
 }
 
-.class Program 
+.class public field_tests 
 {
+	.field public int8 i1Field
+	.field public int16 i2Field
+	.field public int32 i4Field
+	.field public class field_tests ptrField
+
+	.field public static int8 i1SField
+	.field public static int16 i2SField
+	.field public static int32 i4SField
+	.field public static class field_tests ptrSField
+
+	.method public void initialize() {
+	.maxstack 10
+
+		ldarg 0
+		ldc.i4 0x1
+		stfld int8 field_tests::i1Field
+
+		ldarg 0
+		ldc.i4 0x2
+		stfld int16 field_tests::i2Field
+
+		ldarg 0
+		ldc.i4 0x4
+		stfld int32 field_tests::i4Field
+
+		ldarg 0
+		ldarg 0
+		stfld class field_tests field_tests::ptrField
+
+		ldc.i4 0x1
+		stsfld int8 field_tests::i1SField
+
+		ldc.i4 0x2
+		stsfld int16 field_tests::i2SField
+
+		ldc.i4 0x4
+		stsfld int32 field_tests::i4SField
+
+		ldarg 0
+		stsfld class field_tests field_tests::ptrSField
+
+		ret
+	}
+
 	.method public static int32 Main() 
 	{
 		.entrypoint
@@ -28,7 +72,8 @@
 		.locals init 
 		(
 			[0] valuetype SimpleStruct 'vector',
-			[1] int32
+			[1] int32,
+			[2] class field_tests
 		)
 
 	   ldloca.s 0
@@ -64,6 +109,56 @@
 	   ldloc.1
 	   ceq
 	   brfalse fail
+
+	   newobj instance void field_tests::.ctor()
+	   dup
+	   stloc 2
+	   call instance void field_tests::initialize()
+	   ldloc 2
+	   ldfld int8 field_tests::i1Field
+	   ldc.i4 0x1
+	   ceq
+	   brfalse fail
+
+	   ldloc 2
+	   ldfld int16 field_tests::i2Field
+	   ldc.i4 0x2
+	   ceq
+	   brfalse fail
+
+	   ldloc 2
+	   ldfld int32 field_tests::i4Field
+	   ldc.i4 0x4
+	   ceq
+	   brfalse fail
+
+	   /* TODO: Fix this when isinst is implemented
+	   ldloc 2
+	   ldfld class field_tests field_tests::ptrField
+	   isinst field_tests
+	   brfalse fail
+	   */
+
+	   ldsfld int8 field_tests::i1SField
+	   ldc.i4 0x1
+	   ceq
+	   brfalse fail
+
+	   ldsfld int16 field_tests::i2SField
+	   ldc.i4 0x2
+	   ceq
+	   brfalse fail
+
+	   ldsfld int32 field_tests::i4SField
+	   ldc.i4 0x4
+	   ceq
+	   brfalse fail
+
+	   /* TODO: Fix this when isinst is implemented
+	   ldsfld class field_tests field_tests::ptrSField
+	   isinst field_tests
+	   brfalse fail
+	   */
 
 	pass:
 		ldc.i4 0x0000


### PR DESCRIPTION
Initial attempt at implement static fields.
Prior to main code gen the dependency graph is traversed to find static fields and for each one the mangled name of the field is emitted followed by db(0)'s to reserve space for the field. Any accesses to the field simply load the address of the corresponding mangled name onto the stack.
Extended field_tests to cover static fields