### PR TITLE
Iniitialise statics with bytes with value 0.

### DIFF
--- a/ILCompiler/Compiler/Z80Writer.cs
+++ b/ILCompiler/Compiler/Z80Writer.cs
@@ -236,7 +236,9 @@ namespace ILCompiler.Compiler
 
                             // Need to mangle full field name here
                             _out.WriteLine(new LabelInstruction(_nameMangler.GetMangledFieldName(field)));
-                            _out.WriteLine(Instruction.Defs(fieldSize));
+
+                            // Emit fieldSize bytes with value 0
+                            _out.WriteLine(Instruction.Dc(fieldSize, 0));
                         }
                     }
                 }

--- a/Samples/GfxDemos/Program.cs
+++ b/Samples/GfxDemos/Program.cs
@@ -6,11 +6,8 @@ namespace GfxDemos
     public static class Program
     {
         public static void Main()
-        {
+        {            
             Console.Clear();
-
-            // TODO: Remove this when static constructors work
-            Pen blackPen = new Pen(Color.Black);
 
             while (true)
             {
@@ -18,7 +15,7 @@ namespace GfxDemos
                 StarBurst();
                 StarField();
                 Spiral(Pens.White);
-                FillScreen(blackPen);
+                FillScreen(Pens.Black);
             }
         }
 

--- a/Z80Assembler/Instruction.cs
+++ b/Z80Assembler/Instruction.cs
@@ -189,5 +189,11 @@ namespace Z80Assembler
         {
             return new Instruction(Opcode.Defs, size.ToString());
         }
+
+        public static Instruction Dc(int count, int value)
+        {
+            return new Instruction(Opcode.Dc, count.ToString() + ", " + value.ToString());
+        }
+
     }
 }

--- a/Z80Assembler/Opcode.cs
+++ b/Z80Assembler/Opcode.cs
@@ -33,6 +33,7 @@
         public static readonly Opcode End = new("End", true);
         public static readonly Opcode Db = new("Db", true);
         public static readonly Opcode Defs = new("Defs", true);
+        public static readonly Opcode Dc = new("Dc", true);
 
         public override string ToString()
         {


### PR DESCRIPTION
Use assembler Dc macro instead of Defs. Defs appears to set data to 0xFF and not 0x00. Remove temporary workaround in gfxdemos required due to statics not being initialised to 0xx.