### PR TITLE
Fix nullable warnings in Wumpus

### DIFF
--- a/Samples/Wumpus/Game.cs
+++ b/Samples/Wumpus/Game.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Wumpus
 {
@@ -21,17 +22,19 @@ namespace Wumpus
         public Game()
         {
             _rooms = new CaveBuilder().Build();
+
+            ResetGame();
         }
 
         public void Play()
         {
             while (true)
             {
-                ResetGame();
                 while (!_resetGame)
                 {
                     RunTheGame();
                 }
+                ResetGame();
             }
         }
 
@@ -219,6 +222,7 @@ namespace Wumpus
 
         private int RandomRoom() => _rand.Next(20);
 
+        [MemberNotNull(nameof(_wumpusRoom), nameof(_currentRoom))]
         private void ResetGame()
         {
             for (var i = 0; i < _rooms.Length; i++)

--- a/System.Private.CoreLib/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
+++ b/System.Private.CoreLib/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    public sealed class MemberNotNullAttribute : Attribute 
+    {
+        public MemberNotNullAttribute(string member) => Members = new[] { member };
+
+        public MemberNotNullAttribute(params string[] members) => Members = members;
+
+        public string[] Members { get; }
+    }
+}

--- a/System.Private.CoreLib/System/ParamArrayAttribute.cs
+++ b/System.Private.CoreLib/System/ParamArrayAttribute.cs
@@ -1,0 +1,8 @@
+﻿namespace System
+{
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = true, AllowMultiple = false)]
+    public sealed class ParamArrayAttribute : Attribute
+    {
+        public ParamArrayAttribute() { }
+    }
+}


### PR DESCRIPTION
Fix some nullable warning in Wumpus with slight code refactoring and also using compiler attributes as static analysis in Roslyn not quite smart enough to determine that fields are set in the constructor via helper method.