### PR TITLE
Implement ldind.u2 and ldind.u4 and add bvt tests

### DIFF
--- a/ILCompiler/Common/TypeSystem/Common/TargetDetails.cs
+++ b/ILCompiler/Common/TypeSystem/Common/TargetDetails.cs
@@ -87,6 +87,8 @@ namespace ILCompiler.Common.TypeSystem.Common
                 case ElementType.I4:
                 case ElementType.U4:
                     return new LayoutInt(4);
+                case ElementType.Pinned:
+                    return GetWellKnownTypeSize(type.Next);
                 case ElementType.I:
                 case ElementType.U:
                 case ElementType.Ptr:

--- a/ILCompiler/Compiler/DnlibExtensions.cs
+++ b/ILCompiler/Compiler/DnlibExtensions.cs
@@ -60,6 +60,9 @@ namespace ILCompiler.Compiler
                 case ElementType.Object:
                     return VarType.Ref;
 
+                case ElementType.Pinned:
+                    return GetVarType(typeSig.Next);
+
                 case ElementType.ByRef:
                     return VarType.ByRef;
 

--- a/ILCompiler/Compiler/Importer/LoadIndirectImporter.cs
+++ b/ILCompiler/Compiler/Importer/LoadIndirectImporter.cs
@@ -24,6 +24,12 @@ namespace ILCompiler.Compiler.Importer
                 case Code.Ldind_I2:
                     type = VarType.Short;
                     break;
+                case Code.Ldind_U2:
+                    type = VarType.UShort;
+                    break;
+                case Code.Ldind_U4:
+                    type = VarType.UInt;
+                    break;
                 case Code.Ldind_I4:
                     type = VarType.Int;
                     break;

--- a/ILCompiler/ILCompiler.csproj
+++ b/ILCompiler/ILCompiler.csproj
@@ -58,6 +58,7 @@
     <None Remove="Runtime\keyavail.asm" />
     <None Remove="Runtime\l_inc_dehl.asm" />
     <None Remove="Runtime\newarr.asm" />
+    <None Remove="Runtime\NewString.asm" />
     <None Remove="Runtime\print.asm" />
     <None Remove="Runtime\stoi.asm" />
     <None Remove="Runtime\TRS80\cls.asm" />
@@ -82,6 +83,7 @@
   <ItemGroup>
     <EmbeddedResource Include="Runtime\CPM\cls.asm" />
     <EmbeddedResource Include="Runtime\CPM\printchr.asm" />
+    <EmbeddedResource Include="Runtime\NewString.asm" />
     <EmbeddedResource Include="Runtime\i_gt_un.asm" />
     <EmbeddedResource Include="Runtime\i_lt_un.asm" />
     <EmbeddedResource Include="Runtime\print.asm" />
@@ -149,11 +151,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Z80Assembler\Z80Assembler.csproj" />
+	  <ProjectReference Include="..\Z80Assembler\Z80Assembler.csproj" />
   </ItemGroup>
 
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
     <Exec Command="copy /a $(ProjectDir)Runtime\*.asm $(ProjectDir)csharprt.asm&#xD;&#xA;copy /a $(ProjectDir)Runtime\CPM\*.asm $(ProjectDir)cpmrt.asm&#xD;&#xA;copy /a $(ProjectDir)Runtime\TRS80\*.asm $(ProjectDir)trs80rt.asm&#xD;&#xA;copy /a $(ProjectDir)Runtime\ZXSpectrum\*.asm $(ProjectDir)zxspectrum.asm" />
   </Target>
-
+	
 </Project>

--- a/ILCompiler/Runtime/NewString.asm
+++ b/ILCompiler/Runtime/NewString.asm
@@ -1,0 +1,38 @@
+; Create a new string of the specified length
+;
+; Uses: HL, DE, BC
+
+NewString:	
+	POP HL		; Save return address
+
+	POP BC		; Get size of string to allocate
+	POP DE
+
+	PUSH HL		; Save return address on stack
+
+	PUSH BC		; Same original size
+
+	INC BC
+	SLA C
+	RL B
+
+	PUSH BC
+
+	CALL HEAPALLOC	; Allocate object
+
+	POP HL		; Address of new object as 32 bits
+	POP BC
+
+	POP BC		; Restore original size
+
+	POP DE		; Get return address
+
+	PUSH HL		; Return value is address of new string
+
+	LD (HL), C	; Set the size for the new string in the first 2 bytes
+	INC HL
+	LD (HL), B
+
+	PUSH DE		; Restore return address
+
+	RET

--- a/ILCompiler/Runtime/TRS80/readline.asm
+++ b/ILCompiler/Runtime/TRS80/readline.asm
@@ -20,9 +20,9 @@ READLINE:
 
 	; Required size = (actual size + 1) * 2, as we need 2 initial bytes tos hold the length
 	; and then each character itself will need 2 bytes as we are using utf-16
-	INC C	; Add 1
+	INC BC	; Add 1
 	SLA C	; Multiply size by 2
-	RL D
+	RL B
 
 	; Allocate string object on heap
 	PUSH BC

--- a/ILCompiler/Runtime/ZXSpectrum/readline.asm
+++ b/ILCompiler/Runtime/ZXSpectrum/readline.asm
@@ -64,9 +64,9 @@ READOVER:
 
 	; Required size = (actual size + 1) * 2, as we need 2 initial bytes tos hold the length
 	; and then each character itself will need 2 bytes as we are using utf-16
-	INC C	; Add 1
+	INC BC	; Add 1
 	SLA C	; Multiply size by 2
-	RL D
+	RL B
 
 	; Allocate string object on heap
 	PUSH BC

--- a/System.Private.CoreLib/System/Buffer.cs
+++ b/System.Private.CoreLib/System/Buffer.cs
@@ -1,0 +1,15 @@
+﻿namespace System
+{
+    internal class Buffer
+    {
+        internal static unsafe void Memmove(byte* dest, byte* src, int len)
+        {
+            for (int i = 0; i < len; i++) 
+            {
+                *dest = *src;
+                dest++;
+                src++;
+            }
+        }
+    }
+}

--- a/System.Private.CoreLib/System/Runtime/RuntimeImports.cs
+++ b/System.Private.CoreLib/System/Runtime/RuntimeImports.cs
@@ -1,0 +1,11 @@
+﻿using System.Runtime.InteropServices;
+
+namespace System.Runtime
+{
+    public static class RuntimeImports
+    {
+
+        [DllImport(Libraries.Runtime, EntryPoint = "NewString")]
+        public static unsafe extern string NewString(int length);
+    }
+}

--- a/System.Private.CoreLib/System/String.Manipulation.cs
+++ b/System.Private.CoreLib/System/String.Manipulation.cs
@@ -1,0 +1,31 @@
+﻿using System.Runtime;
+
+namespace System
+{
+    public partial class String
+    {
+        public unsafe static string Concat(string str0, string str1)
+        {
+            string result = RuntimeImports.NewString(str0.Length + str1.Length);
+
+            FillStringChecked(result, 0, str0);
+            FillStringChecked(result, str0.Length, str1);
+
+            return result;
+        }
+
+        private unsafe static void FillStringChecked(string dest, int destPos, string src)
+        {
+            // TODO: Reimplement using unsafe intrinsics
+            fixed (char* destPtr = &(dest._firstChar))
+            {
+                var destination = destPtr + destPos;
+
+                fixed (char* srcPtr = &(src._firstChar))
+                {
+                    Buffer.Memmove((byte*)destination, (byte*)srcPtr, src.Length * 2);
+                }
+            }
+        }
+    }
+}

--- a/System.Private.CoreLib/System/String.cs
+++ b/System.Private.CoreLib/System/String.cs
@@ -1,8 +1,6 @@
-﻿using System.Runtime.CompilerServices;
-
-namespace System
+﻿namespace System
 {
-    public sealed class String
+    public sealed partial class String
     {
         // The layout of the string type is a contract with the compiler
 

--- a/Tests/ILCompiler.IntegrationTests/il_bvt/ldind_stind.il
+++ b/Tests/ILCompiler.IntegrationTests/il_bvt/ldind_stind.il
@@ -36,14 +36,26 @@
 	stind.i2
 
 	ldloca 1
-	ldind.i2
+	ldind.u2
 	ldc.i4 0x00002222
 	ceq
 	brfalse fail
 
+	ldloca 1
+	ldind.i2
+	ldc.i4 0x00002222
+	ceq
+	brfalse fail
+	
 	ldloca 2
 	ldc.i4 0x44444444
 	stind.i4
+
+	ldloca.2
+	ldind.u4
+	ldc.i4 0x44444444
+	ceq
+	brfalse fail
 
 	ldloca 2
 	ldind.i4

--- a/Tests/ILCompiler.IntegrationTests/il_bvt/ldind_stind.il
+++ b/Tests/ILCompiler.IntegrationTests/il_bvt/ldind_stind.il
@@ -51,7 +51,7 @@
 	ldc.i4 0x44444444
 	stind.i4
 
-	ldloca.2
+	ldloca 2
 	ldind.u4
 	ldc.i4 0x44444444
 	ceq


### PR DESCRIPTION
Extend GetVarType and GetWellKnownTypeSize to handle pinned types 
Fix bugs in Console.Readline assembly code
Add RuntimeImports class with assembly code implementation of NewString 
Add String.Concat implementation