### PR TITLE
Implement SizeOf opcode

### DIFF
--- a/ILCompiler/Common/TypeSystem/IL/UnsafeIntrinsics.cs
+++ b/ILCompiler/Common/TypeSystem/IL/UnsafeIntrinsics.cs
@@ -10,6 +10,8 @@ namespace ILCompiler.Common.TypeSystem.IL
         {
             switch (method.Name)
             {
+                case "As":
+                    return EmitAs(method);
                 case "AsPointer":
                     return EmitAsPointer(method);
                 case "SizeOf":
@@ -21,6 +23,18 @@ namespace ILCompiler.Common.TypeSystem.IL
             }
 
             return null;
+        }
+
+        private static CilBody? EmitAs(MethodDesc method) 
+        {
+            var body = new CilBody();
+
+            body.Instructions.Add(OpCodes.Ldarg_0.ToInstruction());
+            body.Instructions.Add(OpCodes.Ret.ToInstruction());
+
+            body.UpdateInstructionOffsets();
+
+            return body;
         }
 
         private static CilBody? EmitAsPointer(MethodDesc method)
@@ -40,8 +54,7 @@ namespace ILCompiler.Common.TypeSystem.IL
         {
             var body = new CilBody();
 
-            body.Instructions.Add(OpCodes.Ldc_I4_0.ToInstruction()); // Replace with code below when Sizeof supported
-            //body.Instructions.Add(OpCodes.Sizeof.ToInstruction(method.ResolveType(new GenericMVar(0)).ToTypeDefOrRef()));
+            body.Instructions.Add(OpCodes.Sizeof.ToInstruction(method.ResolveType(new GenericMVar(0)).ToTypeDefOrRef()));
             body.Instructions.Add(OpCodes.Ret.ToInstruction());
 
             body.UpdateInstructionOffsets();
@@ -54,8 +67,7 @@ namespace ILCompiler.Common.TypeSystem.IL
             var body = new CilBody();
 
             body.Instructions.Add(OpCodes.Ldarg_1.ToInstruction());
-            body.Instructions.Add(OpCodes.Ldc_I4_0.ToInstruction()); // Replace with code below when Sizeof supported
-            //body.Instructions.Add(OpCodes.Sizeof.ToInstruction(method.ResolveType(new GenericMVar(0)).ToTypeDefOrRef()));
+            body.Instructions.Add(OpCodes.Sizeof.ToInstruction(method.ResolveType(new GenericMVar(0)).ToTypeDefOrRef()));
             body.Instructions.Add(OpCodes.Conv_I.ToInstruction());
             body.Instructions.Add(OpCodes.Mul.ToInstruction());
             body.Instructions.Add(OpCodes.Ldarg_0.ToInstruction());

--- a/ILCompiler/Compiler/Importer/ServiceCollectionExtensions.cs
+++ b/ILCompiler/Compiler/Importer/ServiceCollectionExtensions.cs
@@ -39,6 +39,7 @@ namespace ILCompiler.Compiler.Importer
             services.AddSingleton<IOpcodeImporter, LoadLengthImporter>();
             services.AddSingleton<IOpcodeImporter, LoadArgAddressImporter>();
             services.AddSingleton<IOpcodeImporter, LoadNullImporter>();
+            services.AddSingleton<IOpcodeImporter, SizeOfImporter>();
 
             return services;
         }

--- a/ILCompiler/Compiler/Importer/SizeOfImporter.cs
+++ b/ILCompiler/Compiler/Importer/SizeOfImporter.cs
@@ -1,0 +1,24 @@
+﻿using dnlib.DotNet;
+using dnlib.DotNet.Emit;
+using ILCompiler.Compiler.EvaluationStack;
+using ILCompiler.Interfaces;
+
+namespace ILCompiler.Compiler.Importer
+{
+    internal class SizeOfImporter : IOpcodeImporter
+    {
+        public bool Import(Instruction instruction, ImportContext context, IILImporterProxy importer)
+        {
+            if (instruction.OpCode.Code != Code.Sizeof) return false;
+
+            var typeSig = (instruction.Operand as ITypeDefOrRef).ToTypeSig();
+            typeSig = context.Method.ResolveType(typeSig);
+            VarType elemType = typeSig.GetVarType();
+            int elemSize = typeSig.GetInstanceFieldSize();
+
+            importer.PushExpression(new Int32ConstantEntry(checked((int)elemSize)));
+
+            return true;
+        }
+    }
+}

--- a/System.Private.CoreLib/Internal/Runtime/CompilerServices/Unsafe.cs
+++ b/System.Private.CoreLib/Internal/Runtime/CompilerServices/Unsafe.cs
@@ -16,6 +16,15 @@ namespace Internal.Runtime.CompilerServices
         }
 
         [Intrinsic]
+        public static ref TTo As<TFrom, TTo>(ref TFrom source)
+        {
+            throw new Exception();
+
+            // ldarg.0
+            // ret
+        }
+
+        [Intrinsic]
         public static ref T AddByteOffset<T>(ref T source, IntPtr byteOffset)
         {
             throw new Exception();

--- a/Tests/ILCompiler.IntegrationTests/il_bvt/sizeof.il
+++ b/Tests/ILCompiler.IntegrationTests/il_bvt/sizeof.il
@@ -1,0 +1,68 @@
+﻿.assembly extern System.Private.CoreLib as mscorlib
+{
+    .ver 0:0:0:0
+}
+.assembly TestAssembly
+{
+}
+
+.class public sequential ansi sealed beforefieldinit Struct0 extends System.ValueType
+{
+	.field private bool b0;
+	.field private int32 i1;
+}
+
+.class public SizeOf
+{
+
+.method public void SizeOf()
+{
+.maxstack 0
+	ret
+}
+
+.method public static int32 Main() {
+.entrypoint
+.maxstack 20
+.locals (class SizeOf)
+
+	sizeof int8
+	ldc.i4 0x1
+	bne.un fail
+
+	sizeof int16
+	ldc.i4 0x2
+	bne.un fail
+
+	sizeof int32
+	ldc.i4 0x4
+	bne.un fail
+
+	sizeof unsigned int8
+	ldc.i4 0x1
+	bne.un fail
+
+	sizeof unsigned int16
+	ldc.i4 0x2
+	bne.un fail
+
+	sizeof unsigned int32
+	ldc.i4 0x4
+	bne.un fail
+
+	sizeof SizeOf
+	ldc.i4 0x2
+	bne.un fail
+
+	sizeof Struct0
+	ldc.i4 0x8
+	bne.un fail
+
+pass:
+	ldc.i4 0x0000
+	ret
+fail:
+	ldc.i4 0x0001
+	ret
+}
+}


### PR DESCRIPTION
Add support for sizeof opcode to load size of a type in bytes
Add extra Unsafe intrinsic for reinterpreting a reference of one type as a reference of another type.