### PR TITLE
Fix dependency analysis of generic methods

### DIFF
--- a/ILCompiler/Common/TypeSystem/Common/InstantiatedMethod.cs
+++ b/ILCompiler/Common/TypeSystem/Common/InstantiatedMethod.cs
@@ -18,6 +18,8 @@ namespace ILCompiler.Common.TypeSystem.Common
 
         public override TypeSig ReturnType => GenericTypeInstantiator.Instantiate(_methodDef.ReturnType, _genericParameters);
 
+        public IList<TypeSig> GenericParameters => _genericParameters;
+
         public override TypeSig ResolveType(TypeSig type)
         {
             return GenericTypeInstantiator.Instantiate(type, _genericParameters);

--- a/ILCompiler/Compiler/DependencyAnalysis/DependencyAnalyser.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/DependencyAnalyser.cs
@@ -95,11 +95,22 @@ namespace ILCompiler.Compiler.DependencyAnalysis
             var method = instruction.Operand as IMethod;
             if (method != null)
             {
-                var methodNode = _nodeFactory.MethodNode(method);
-                if (methodNode != null)
+                Z80MethodCodeNode methodNode;
+                if (method.IsMethodSpec && _method is InstantiatedMethod)
                 {
-                    _dependencies.Add(methodNode);
+                    // If call is to a generic method and the calling method has type parameters then we
+                    // use these to resolve the generic type parameters of the method being called
+                    var methodParameters = ((InstantiatedMethod)_method).GenericParameters;
+
+                    var methodSpec = (MethodSpec)method;
+                    methodNode = _nodeFactory.MethodNode(methodSpec, methodParameters);
                 }
+                else
+                {
+                    methodNode = _nodeFactory.MethodNode(method);
+                }
+
+                _dependencies.Add(methodNode);
             }
         }
     }

--- a/ILCompiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -19,21 +19,25 @@ namespace ILCompiler.Compiler.DependencyAnalysis
             return typeNode;
         }
 
+        public Z80MethodCodeNode MethodNode(MethodSpec methodSpec, IList<TypeSig> genericArguments)
+        {
+            var methodDef = methodSpec.Method.ResolveMethodDefThrow();
+
+            if (!_methodNodesByFullName.TryGetValue(methodSpec.FullName, out var methodNode))
+            {
+                methodNode = new Z80MethodCodeNode(new InstantiatedMethod(methodDef, genericArguments, methodSpec.FullName));
+                _methodNodesByFullName[methodSpec.FullName] = methodNode;
+            }
+
+            return methodNode;
+        }
+
         public Z80MethodCodeNode MethodNode(IMethod method)
         {
             if (method.IsMethodSpec)
             {
                 var methodSpec = (MethodSpec)method;
-                IList<TypeSig> genericArguments = methodSpec.GenericInstMethodSig.GenericArguments;
-                var methodDef = methodSpec.Method.ResolveMethodDefThrow();
-
-                if (!_methodNodesByFullName.TryGetValue(methodSpec.FullName, out var methodNode))
-                {
-                    methodNode = new Z80MethodCodeNode(new InstantiatedMethod(methodDef, genericArguments, methodSpec.FullName));
-                    _methodNodesByFullName[methodSpec.FullName] = methodNode;
-                }
-
-                return methodNode;
+                return MethodNode(methodSpec, methodSpec.GenericInstMethodSig.GenericArguments);
             }
             else
             {

--- a/Tests/Generics/GenericMethods/Simple1.cs
+++ b/Tests/Generics/GenericMethods/Simple1.cs
@@ -34,6 +34,11 @@ public static class Simple_Generic_Method_Test
         b = temp;
     }
 
+    private static void SwapIndirect<T>(ref T a, ref T b)
+    {
+        Swap<T>(ref a, ref b);
+    }
+
     public static int Main()
     {
         int x = 12;
@@ -41,6 +46,10 @@ public static class Simple_Generic_Method_Test
         Swap<int>(ref x, ref y);
         if (x != 17) return 1;
         if (y != 12) return 1;
+
+        SwapIndirect<int>(ref x, ref y);
+        if (x != 12) return 1;
+        if (y != 17) return 1;
 
         var iarray = new int[5] { 1, 2, 3, 4, 5 };
         Reverse<int>(iarray);


### PR DESCRIPTION
In dependency analysis when a generic method is called use calling methods type parameters if any to resolve called methods generic types.

This fixes issue with chaining calls of generic methods.

Also added simple test to validate fix.