### PR TITLE
Fix bugs with generic methods

### DIFF
--- a/ILCompiler/Common/TypeSystem/Common/GenericTypeInstantiator.cs
+++ b/ILCompiler/Common/TypeSystem/Common/GenericTypeInstantiator.cs
@@ -4,6 +4,30 @@ namespace ILCompiler.Common.TypeSystem.Common
 {
     internal class GenericTypeInstantiator
     {
+        public static TypeSig Instantiate(TypeSig type, IMethod calleeMethod, MethodDesc callerMethod) 
+        {
+            if (type.ContainsGenericParameter) 
+            {
+                IList<TypeSig> callerMethodGenericParameters = new List<TypeSig>();
+                if (callerMethod is InstantiatedMethod method)
+                {
+                    callerMethodGenericParameters = method.GenericParameters;
+                }
+
+                var resolvedGenericParameters = new List<TypeSig>();
+                foreach (var genericParameter in ((MethodSpec)calleeMethod).GenericInstMethodSig.GenericArguments)
+                {
+                    resolvedGenericParameters.Add(GenericTypeInstantiator.Instantiate(genericParameter, callerMethodGenericParameters));
+                }
+
+                return Instantiate(type, resolvedGenericParameters);
+            }
+            else
+            {
+                return type;
+            }
+        }
+
         public static TypeSig Instantiate(TypeSig type, IList<TypeSig> genericMethodParameters)
         {
             TypeSig result = type;

--- a/ILCompiler/Compiler/DependencyAnalysis/DependencyAnalyser.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/DependencyAnalyser.cs
@@ -96,14 +96,9 @@ namespace ILCompiler.Compiler.DependencyAnalysis
             if (method != null)
             {
                 Z80MethodCodeNode methodNode;
-                if (method.IsMethodSpec && _method is InstantiatedMethod)
+                if (method.IsMethodSpec)
                 {
-                    // If call is to a generic method and the calling method has type parameters then we
-                    // use these to resolve the generic type parameters of the method being called
-                    var methodParameters = ((InstantiatedMethod)_method).GenericParameters;
-
-                    var methodSpec = (MethodSpec)method;
-                    methodNode = _nodeFactory.MethodNode(methodSpec, methodParameters);
+                    methodNode = _nodeFactory.MethodNode((MethodSpec)method, _method);
                 }
                 else
                 {

--- a/ILCompiler/Compiler/Importer/CallImporter.cs
+++ b/ILCompiler/Compiler/Importer/CallImporter.cs
@@ -4,7 +4,6 @@ using ILCompiler.Common.TypeSystem.Common;
 using ILCompiler.Common.TypeSystem.IL;
 using ILCompiler.Compiler.EvaluationStack;
 using ILCompiler.Interfaces;
-using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ILCompiler.Compiler.Importer
 {
@@ -70,12 +69,8 @@ namespace ILCompiler.Compiler.Importer
 
                 var parameter = methodToCall.Parameters[parameterCount - (i - firstArgIndex) - 1];
                 var parameterType = parameter.Type;
-                if (parameter.Type.IsGenericMethodParameter)
-                {
-                    var methodSpec = (MethodSpec)method;
-                    parameterType = GenericTypeInstantiator.Instantiate(parameterType, methodSpec.GenericInstMethodSig.GenericArguments);
-                }
 
+                parameterType = GenericTypeInstantiator.Instantiate(parameterType, method, context.Method);
                 var parameterVarType = parameterType.GetVarType();
                 if (parameterVarType.IsSmall())
                 {
@@ -103,8 +98,7 @@ namespace ILCompiler.Compiler.Importer
             string targetMethod;
             if (methodToCall.HasGenericParameters)
             {
-                var methodSpec = (MethodSpec)method;
-                targetMethod = context.NameMangler.GetMangledMethodName(methodSpec);
+                targetMethod = context.NameMangler.GetMangledMethodName((MethodSpec)method, context.Method);
             }
             else if (methodToCall.IsPinvokeImpl)
             {
@@ -120,7 +114,7 @@ namespace ILCompiler.Compiler.Importer
             }
 
             int returnBufferArgIndex = 0;
-            var returnType = methodToCall.ReturnType;
+            var returnType = GenericTypeInstantiator.Instantiate(methodToCall.ReturnType, method, context.Method);
             if (methodToCall.HasReturnType)
             {
                 if (returnType.IsStruct())

--- a/ILCompiler/Compiler/NameMangler.cs
+++ b/ILCompiler/Compiler/NameMangler.cs
@@ -20,6 +20,26 @@ namespace ILCompiler.Compiler
             return GetMangledMethodName(method.FullName);
         }
 
+        public string GetMangledMethodName(MethodSpec calleeMethod, MethodDesc callerMethod)
+        {
+            var calleeMethodDef = calleeMethod.Method.ResolveMethodDefThrow();
+
+            IList<TypeSig> callerMethodGenericParameters = new List<TypeSig>();
+            if (callerMethod is InstantiatedMethod method)
+            {
+                callerMethodGenericParameters = method.GenericParameters;
+            }
+
+            var resolvedGenericParameters = new List<TypeSig>();
+            foreach (var genericParameter in ((MethodSpec)calleeMethod).GenericInstMethodSig.GenericArguments)
+            {
+                resolvedGenericParameters.Add(GenericTypeInstantiator.Instantiate(genericParameter, callerMethodGenericParameters));
+            }
+
+            var fullMethodName = FullNameFactory.MethodFullName(calleeMethodDef.DeclaringType?.FullName, calleeMethodDef.Name, calleeMethodDef.MethodSig, null, resolvedGenericParameters);
+            return GetMangledMethodName(fullMethodName);
+        }
+
         public string GetMangledMethodName(MethodDef method)
         {
             return GetMangledMethodName(method.FullName);

--- a/ILCompiler/Interfaces/INameMangler.cs
+++ b/ILCompiler/Interfaces/INameMangler.cs
@@ -5,7 +5,7 @@ namespace ILCompiler.Interfaces
 {
     public interface INameMangler
     {
-        public string GetMangledMethodName(MethodSpec method);
+        public string GetMangledMethodName(MethodSpec calleemethod, MethodDesc callerMethod);
         public string GetMangledMethodName(MethodDef method);
         public string GetMangledMethodName(MethodDesc method);
         public string GetMangledFieldName(FieldDef field);


### PR DESCRIPTION
When resolving parameter types for generic methods the already resolved types of the caller method must be used first.
Method name after parameter resolution must be used in deciding if method is an existing one in the dependency graph or not and also in the name mangling for code generation e.g. method to call and label for methods.
Return type for generic methods also requires resolution in similar manner to the method parameters.