### PR TITLE
Improve tests by implementing Assert.Equals using Environment.Exit

### DIFF
--- a/ILCompiler/ILCompiler.csproj
+++ b/ILCompiler/ILCompiler.csproj
@@ -22,6 +22,7 @@
     <None Remove="Runtime\CPM\cls.asm" />
     <None Remove="Runtime\CPM\printchr.asm" />
     <None Remove="Runtime\delay.asm" />
+    <None Remove="Runtime\exit.asm" />
     <None Remove="Runtime\itoa.asm" />
     <None Remove="Runtime\i_add.asm" />
     <None Remove="Runtime\i_add16.asm" />
@@ -83,6 +84,7 @@
   <ItemGroup>
     <EmbeddedResource Include="Runtime\CPM\cls.asm" />
     <EmbeddedResource Include="Runtime\CPM\printchr.asm" />
+    <EmbeddedResource Include="Runtime\exit.asm" />
     <EmbeddedResource Include="Runtime\i_gt_un.asm" />
     <EmbeddedResource Include="Runtime\i_lt_un.asm" />
     <EmbeddedResource Include="Runtime\NewString.asm" />

--- a/Tests/CoreLib/CoreLib/Assert.cs
+++ b/Tests/CoreLib/CoreLib/Assert.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace CoreLib
+{
+    internal static class Assert
+    {
+        public static void Equals(bool expected, bool actual)
+        {
+            if (expected != actual)
+            {
+                Environment.Exit(1);
+            }
+        }
+
+        public static void Equals(int expected, int actual)
+        {
+            if (expected != actual)
+            {
+                Environment.Exit(1);
+            }
+        }
+    }
+}

--- a/Tests/CoreLib/CoreLib/CharTests.cs
+++ b/Tests/CoreLib/CoreLib/CharTests.cs
@@ -2,40 +2,36 @@
 {
     public class CharTests
     {
-        public static bool IsBetweenCharTests()
+        public static void IsBetweenCharTests()
         {
-            var result = true;
-            result = result && AssertEqual(true, char.IsBetween('a', 'a', 'a'));
-            result = result && AssertEqual(false, char.IsBetween((char)('a' - 1), 'a', 'a'));
-            result = result && AssertEqual(false, char.IsBetween((char)('a' + 1), 'a', 'a'));
-            result = result && AssertEqual(true, char.IsBetween('a', 'a', 'b'));
-            result = result && AssertEqual(true, char.IsBetween('b', 'a', 'b'));
-            result = result && AssertEqual(false, char.IsBetween((char)('a' - 1), 'a', 'b'));
-            result = result && AssertEqual(false, char.IsBetween((char)('b' + 1), 'a', 'b'));
-            result = result && AssertEqual(true, char.IsBetween('a', 'a', 'z'));
-            result = result && AssertEqual(true, char.IsBetween('m', 'a', 'z'));
-            result = result && AssertEqual(true, char.IsBetween('z', 'a', 'z'));
-            result = result && AssertEqual(false, char.IsBetween((char)('a' - 1), 'a', 'z'));
-            result = result && AssertEqual(false, char.IsBetween((char)('z' + 1), 'a', 'z'));
-            result = result && AssertEqual(false, char.IsBetween('b', 'c', 'd'));
-            result = result && AssertEqual(true, char.IsBetween('b', 'd', 'c'));
-            return result;
+            Assert.Equals(true, char.IsBetween('a', 'a', 'a'));
+            Assert.Equals(false, char.IsBetween((char)('a' - 1), 'a', 'a'));
+            Assert.Equals(false, char.IsBetween((char)('a' + 1), 'a', 'a'));
+            Assert.Equals(true, char.IsBetween('a', 'a', 'b'));
+            Assert.Equals(true, char.IsBetween('b', 'a', 'b'));
+            Assert.Equals(false, char.IsBetween((char)('a' - 1), 'a', 'b'));
+            Assert.Equals(false, char.IsBetween((char)('b' + 1), 'a', 'b'));
+            Assert.Equals(true, char.IsBetween('a', 'a', 'z'));
+            Assert.Equals(true, char.IsBetween('m', 'a', 'z'));
+            Assert.Equals(true, char.IsBetween('z', 'a', 'z'));
+            Assert.Equals(false, char.IsBetween((char)('a' - 1), 'a', 'z'));
+            Assert.Equals(false, char.IsBetween((char)('z' + 1), 'a', 'z'));
+            Assert.Equals(false, char.IsBetween('b', 'c', 'd'));
+            Assert.Equals(true, char.IsBetween('b', 'd', 'c'));
         }
 
-        public static bool IsAsciiDigit_WithAsciiDigits_ReturnsTrue()
+        public static void IsAsciiDigit_WithAsciiDigits_ReturnsTrue()
         {
             char[] validAsciiDigits = new char[] { '\u0030', '\u0031', '\u0032', '\u0033', '\u0034', '\u0035', '\u0036', '\u0037', '\u0038', '\u0039' };
 
-            var result = true;
             for (int i = 0; i < validAsciiDigits.Length; i++) 
             { 
                 char ch = validAsciiDigits[i];
-                result = result && AssertEqual(true, char.IsAsciiDigit(ch));
+                Assert.Equals(true, char.IsAsciiDigit(ch));
             }
-            return result;
         }
 
-        public static bool IsAsciiDigit_WithNonAsciiDigits_ReturnsFalse()
+        public static void IsAsciiDigit_WithNonAsciiDigits_ReturnsFalse()
         {
             char[] invalidAsciiDigits = new char[] 
             { 
@@ -59,15 +55,11 @@
                 '\u00a6','\u00a9','\u00ae','\u00b0', /* Other symbols */
             };
 
-            var result = true;
             for (int i = 0; i < invalidAsciiDigits.Length; i++)
             {
                 char ch = invalidAsciiDigits[i];
-                result = result && AssertEqual(false, char.IsAsciiDigit(ch));
+                Assert.Equals(false, char.IsAsciiDigit(ch));
             }
-            return result;
         }
-
-        private static bool AssertEqual(bool expected, bool actual) => expected == actual;
     }
 }

--- a/Tests/CoreLib/CoreLib/CoreLib.cs
+++ b/Tests/CoreLib/CoreLib/CoreLib.cs
@@ -3,19 +3,20 @@
     public static class CoreLib
     {
         public static int Main()
-        {
-            var result = true;
+        {          
+            CharTests.IsBetweenCharTests();
             
-            result = result && CharTests.IsBetweenCharTests();
-            
-            result = result && CharTests.IsAsciiDigit_WithAsciiDigits_ReturnsTrue();
-            result = result && CharTests.IsAsciiDigit_WithNonAsciiDigits_ReturnsFalse();
+            CharTests.IsAsciiDigit_WithAsciiDigits_ReturnsTrue();
+            CharTests.IsAsciiDigit_WithNonAsciiDigits_ReturnsFalse();
 
-            result = result && Int32Tests.Parse_Valid();
+            Int32Tests.Parse_Valid();
 
-            result = result && StringTests.NewStringTests();
+            StringTests.NewStringTests();
 
-            return result ? 0 : 1;
+            UnsafeTests.SizeOfTests();
+            UnsafeTests.RefAs();
+
+            return 0;
         }
     }
 }

--- a/Tests/CoreLib/CoreLib/Int32Tests.cs
+++ b/Tests/CoreLib/CoreLib/Int32Tests.cs
@@ -2,23 +2,17 @@
 {
     public class Int32Tests
     {
-        public static bool Parse_Valid()
+        public static void Parse_Valid()
         {
-            var result = true;
+            Assert.Equals(0, int.Parse("0"));
+            Assert.Equals(0, int.Parse("0000000000000000000000000000000000000000000000000000000000"));
+            Assert.Equals(1, int.Parse("0000000000000000000000000000000000000000000000000000000001"));
+            Assert.Equals(2147483647, int.Parse("2147483647"));
+            Assert.Equals(2147483647, int.Parse("02147483647"));
+            Assert.Equals(2147483647, int.Parse("00000000000000000000000000000000000000000000000002147483647"));
+            Assert.Equals(123, int.Parse("123\0\0"));
 
-            result = result && AssertEqual(0, int.Parse("0"));
-            result = result && AssertEqual(0, int.Parse("0000000000000000000000000000000000000000000000000000000000"));
-            result = result && AssertEqual(1, int.Parse("0000000000000000000000000000000000000000000000000000000001"));
-            result = result && AssertEqual(2147483647, int.Parse("2147483647"));
-            result = result && AssertEqual(2147483647, int.Parse("02147483647"));
-            result = result && AssertEqual(2147483647, int.Parse("00000000000000000000000000000000000000000000000002147483647"));
-            result = result && AssertEqual(123, int.Parse("123\0\0"));
-
-            result = result && AssertEqual(123, int.Parse("123"));
-
-            return result;
+            Assert.Equals(123, int.Parse("123"));
         }
-
-        private static bool AssertEqual(int expected, int actual) => expected == actual;
     }
 }

--- a/Tests/CoreLib/CoreLib/StringTests.cs
+++ b/Tests/CoreLib/CoreLib/StringTests.cs
@@ -4,14 +4,10 @@ namespace CoreLib
 {
     public class StringTests
     {
-        public static bool NewStringTests()
+        public static void NewStringTests()
         {
-            var result = true;
-
             string newString = RuntimeImports.NewString(25);
-            result = result && newString.Length == 25;
-
-            return result;
+            Assert.Equals(25, newString.Length);
         }
     }
 }

--- a/Tests/CoreLib/CoreLib/UnsafeTests.cs
+++ b/Tests/CoreLib/CoreLib/UnsafeTests.cs
@@ -1,0 +1,65 @@
+﻿using Internal.Runtime.CompilerServices;
+
+namespace CoreLib
+{
+    public class UnsafeTests
+    {
+        public static void SizeOfTests()
+        {
+            Assert.Equals(1, Unsafe.SizeOf<sbyte>());
+            Assert.Equals(1, Unsafe.SizeOf<byte>());
+            Assert.Equals(2, Unsafe.SizeOf<short>());
+            Assert.Equals(2, Unsafe.SizeOf<ushort>());
+            Assert.Equals(4, Unsafe.SizeOf<int>());
+            Assert.Equals(4, Unsafe.SizeOf<uint>());
+            Assert.Equals(4, Unsafe.SizeOf<Byte4>());
+            Assert.Equals(8, Unsafe.SizeOf<Byte4Short2>());
+        }
+
+        public static void RefAs()
+        {
+            TestBytes testBytes = new TestBytes();
+            testBytes.B0 = 0x42;
+            testBytes.B1 = 0x42;
+            testBytes.B2 = 0x42;
+            testBytes.B3 = 0x42;
+
+            ref int r = ref Unsafe.As<byte, int>(ref testBytes.B0);
+            Assert.Equals(0x42424242, r);
+
+            /*
+             * TODO: This needs ldelema to be implemented
+            byte[] b = new byte[4] { 0x42, 0x42, 0x42, 0x42 };
+            ref int r = ref Unsafe.As<byte, int>(ref b[0]);
+
+            Assert.Equals(0x42424242, r);
+            */
+        }
+    }
+
+    public class TestBytes
+    {
+        public byte B0;
+        public byte B1;
+        public byte B2;
+        public byte B3;
+    }
+
+    public struct Byte4
+    {
+        public byte B0;
+        public byte B1;
+        public byte B2;
+        public byte B3;
+    }
+
+    public struct Byte4Short2
+    {
+        public byte B0;
+        public byte B1;
+        public byte B2;
+        public byte B3;
+        public short S4;
+        public short S6;
+    }
+}

--- a/Tests/CoreLib/CoreLibTestsRunner/CoreLibTestsRunner.cs
+++ b/Tests/CoreLib/CoreLibTestsRunner/CoreLibTestsRunner.cs
@@ -35,7 +35,7 @@ namespace CoreLibTests
             Console.WriteLine($"Test {assemblyFileName} ran in {z80.TStatesElapsedSinceStart} T-states");
 
             // Validate we finished on the HALT instruction
-            Assert.AreEqual(12, z80.Registers.PC);
+            Assert.AreEqual(0x76, z80.Memory[z80.Registers.PC - 1]);
 
             // Pass returns 32 bit 0 in DEHL
             Assert.AreEqual(0, z80.Registers.DE);

--- a/Tests/Directed/DirectedTestsRunner/DirectedTestsRunner.cs
+++ b/Tests/Directed/DirectedTestsRunner/DirectedTestsRunner.cs
@@ -35,7 +35,7 @@ namespace DirectedTests
             Console.WriteLine($"Test {assemblyFileName} ran in {z80.TStatesElapsedSinceStart} T-states");
 
             // Validate we finished on the HALT instruction
-            Assert.AreEqual(12, z80.Registers.PC);
+            Assert.AreEqual(0x76, z80.Memory[z80.Registers.PC - 1]);
 
             // Pass returns 32 bit 0 in DEHL
             Assert.AreEqual(0, z80.Registers.DE);

--- a/Tests/Generics/GenericsTestsRunner/GenericsTestsRunner.cs
+++ b/Tests/Generics/GenericsTestsRunner/GenericsTestsRunner.cs
@@ -35,7 +35,7 @@ namespace GenericsTests
             Console.WriteLine($"Test {assemblyFileName} ran in {z80.TStatesElapsedSinceStart} T-states");
 
             // Validate we finished on the HALT instruction
-            Assert.AreEqual(12, z80.Registers.PC);
+            Assert.AreEqual(0x76, z80.Memory[z80.Registers.PC - 1]);
 
             // Pass returns 32 bit 0 in DEHL
             Assert.AreEqual(0, z80.Registers.DE);

--- a/Tests/Regression/Regression/RegressionTests.cs
+++ b/Tests/Regression/Regression/RegressionTests.cs
@@ -2,20 +2,15 @@
 {
     public static int Main()
     {
-        var result = 0;
-
-        result = Bug87();
-        if (result != 0) return 87;
+        Bug87();
 
         return 0;
     }
 
-    public static int Bug87()
+    public static void Bug87()
     {
         char[] test = new char[1] { 'a' };
         Bug87_Method(test[0]);
-
-        return 0;
     }
 
     private static void Bug87_Method(char ch)

--- a/Tests/Regression/RegressionTestsRunner/RegressionTestsRunner.cs
+++ b/Tests/Regression/RegressionTestsRunner/RegressionTestsRunner.cs
@@ -35,7 +35,7 @@ namespace RegressionTests
             Console.WriteLine($"Test {assemblyFileName} ran in {z80.TStatesElapsedSinceStart} T-states");
 
             // Validate we finished on the HALT instruction
-            Assert.AreEqual(12, z80.Registers.PC);
+            Assert.AreEqual(0x76, z80.Memory[z80.Registers.PC - 1]);
 
             // Pass returns 32 bit 0 in DEHL
             Assert.AreEqual(0, z80.Registers.DE);


### PR DESCRIPTION
Use Environment.Exit as a poor mans exception to implement an Assert class to improve tests.
Add exit.asm into ILCompiler csproj - forgot to do this in PR #144 
Add some tests for Unsafe class