### PR TITLE
Refactor FillStringChecked to use Buffer class

### DIFF
--- a/System.Private.CoreLib/System/Buffer.cs
+++ b/System.Private.CoreLib/System/Buffer.cs
@@ -1,7 +1,39 @@
-﻿namespace System
+﻿using Internal.Runtime.CompilerServices;
+
+namespace System
 {
     internal class Buffer
     {
+        internal static void Memmove<T>(ref T destination, ref T source, nuint elementCount)
+        {
+            //_Memmove(ref destination, ref source, elementCount);
+            Memmove(ref Unsafe.As<T, byte>(ref destination), ref Unsafe.As<T, byte>(ref source), elementCount * (nuint)Unsafe.SizeOf<T>());
+        }
+
+        private static void Memmove(ref byte dest, ref byte src, nuint len)
+        {
+            _Memmove(ref dest, ref src, len);
+        }
+
+        private static unsafe void _Memmove(ref byte dest, ref byte src, nuint len)
+        {
+            fixed (byte* pDest = &dest)
+            fixed (byte* pSrc = &src)
+            {
+                __Memmove(pDest, pSrc, len);
+            }
+        }
+
+        internal static unsafe void __Memmove(byte* dest, byte* src, nuint len)
+        {
+            for (nuint i = 0; i < len; i++)
+            {
+                *dest = *src;
+                dest++;
+                src++;
+            }
+        }
+
         internal static unsafe void Memmove(byte* dest, byte* src, int len)
         {
             for (int i = 0; i < len; i++) 

--- a/System.Private.CoreLib/System/String.Manipulation.cs
+++ b/System.Private.CoreLib/System/String.Manipulation.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime;
+﻿using Internal.Runtime.CompilerServices;
+using System.Runtime;
 
 namespace System
 {
@@ -15,17 +16,11 @@ namespace System
         }
 
         private unsafe static void FillStringChecked(string dest, int destPos, string src)
-        {
-            // TODO: Reimplement using unsafe intrinsics
-            fixed (char* destPtr = &(dest._firstChar))
-            {
-                var destination = destPtr + destPos;
-
-                fixed (char* srcPtr = &(src._firstChar))
-                {
-                    Buffer.Memmove((byte*)destination, (byte*)srcPtr, src.Length * 2);
-                }
-            }
+        {     
+            Buffer.Memmove(
+                ref Unsafe.Add(ref dest._firstChar, destPos),
+                ref src._firstChar,
+                (uint)src.Length);
         }
     }
 }


### PR DESCRIPTION
Enhance Buffer class to use generic methods and unsafe intrinsics and use in FillStringChecked