### PR TITLE
Include base class fields when laying out fields

### DIFF
--- a/ILCompiler/Common/TypeSystem/Common/TypeDefExtensions.cs
+++ b/ILCompiler/Common/TypeSystem/Common/TypeDefExtensions.cs
@@ -1,0 +1,38 @@
+﻿using dnlib.DotNet;
+
+namespace ILCompiler.Common.TypeSystem.Common
+{
+    public static class TypeDefExtensions
+    {
+        private static IDictionary<TypeDef, ComputedInstanceFieldLayout> _fieldLayoutsByType = new Dictionary<TypeDef, ComputedInstanceFieldLayout>();
+        public static ComputedInstanceFieldLayout InstanceFieldLayout(this TypeDef typedef, MetadataFieldLayoutAlgorithm layoutAlgorithm)
+        {
+            if (!_fieldLayoutsByType.TryGetValue(typedef, out var fieldLayout))
+            {
+                fieldLayout = layoutAlgorithm.ComputeInstanceLayout(typedef);
+                _fieldLayoutsByType.Add(typedef, fieldLayout);
+            }
+
+            return fieldLayout;
+        }
+
+        public static LayoutInt InstanceFieldSize(this TypeDef typedef, MetadataFieldLayoutAlgorithm fieldLayoutAlgorithm) 
+        {
+            return typedef.InstanceFieldLayout(fieldLayoutAlgorithm).FieldSize;
+        }
+
+        public static LayoutInt InstanceFieldAlignment(this TypeDef typedef, MetadataFieldLayoutAlgorithm fieldLayoutAlgorithm)
+        {
+            return typedef.InstanceFieldLayout(fieldLayoutAlgorithm).FieldAlignment;
+        }
+
+        public static LayoutInt InstanceByteCountUnaligned(this TypeDef typedef, MetadataFieldLayoutAlgorithm fieldLayoutAlgorithm)
+        {
+            return typedef.InstanceFieldLayout(fieldLayoutAlgorithm).ByteCountUnaligned;
+        }
+        public static LayoutInt InstanceByteAlignment(this TypeDef typedef, MetadataFieldLayoutAlgorithm fieldLayoutAlgorithm)
+        {
+            return typedef.InstanceFieldLayout(fieldLayoutAlgorithm).ByteCountAlignment;
+        }
+    }
+}

--- a/ILCompiler/Compiler/CodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerator.cs
@@ -166,6 +166,10 @@ namespace ILCompiler.Compiler
 
                 var stringData = keyValuePair.Value;
 
+                // TODO: This needs to the EEType for String
+                assembler.Db(0);
+                assembler.Db(0);
+
                 byte lsb = (byte)(stringData.Length & 0xFF);
                 byte msb = (byte)((stringData.Length >> 8) & 0xFF);
 

--- a/ILCompiler/Compiler/DnlibExtensions.cs
+++ b/ILCompiler/Compiler/DnlibExtensions.cs
@@ -85,7 +85,7 @@ namespace ILCompiler.Compiler
             var typeDefOrRef = type.ToTypeDefOrRef();
             var typeDef = typeDefOrRef.ResolveTypeDef();
 
-            var computedLayout = fieldLayoutAlgorithm.ComputeInstanceLayout(typeDef);
+            var computedLayout = typeDef.InstanceFieldLayout(fieldLayoutAlgorithm);
 
             if (computedLayout.Offsets != null)
             {
@@ -124,8 +124,7 @@ namespace ILCompiler.Compiler
 
             if (typeDef != null) 
             {
-                var computedLayout = fieldLayoutAlgorithm.ComputeInstanceLayout(typeDef);
-
+                var computedLayout = typeDef.InstanceFieldLayout(fieldLayoutAlgorithm);
                 if (computedLayout.Offsets != null)
                 {
                     foreach (var fieldAndOffset in computedLayout.Offsets)

--- a/ILCompiler/Compiler/EvaluationStack/IndexRefEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/IndexRefEntry.cs
@@ -5,13 +5,16 @@
         public StackEntry IndexOp { get; }
         public StackEntry ArrayOp { get; }
 
+        public short FirstElementOffset { get; }
+
         public int ElemSize { get; }
 
-        public IndexRefEntry(StackEntry indexOp, StackEntry arrayOp, int elemSize, VarType type) : base(type)
+        public IndexRefEntry(StackEntry indexOp, StackEntry arrayOp, int elemSize, VarType type, short firstElementOffset) : base(type)
         {
             IndexOp = indexOp;
             ArrayOp = arrayOp;
             ElemSize = elemSize;
+            FirstElementOffset = firstElementOffset;
         }
 
         public override void Accept(IStackEntryVisitor visitor)
@@ -21,7 +24,7 @@
 
         public override StackEntry Duplicate()
         {
-            return new IndexRefEntry(IndexOp.Duplicate(), ArrayOp.Duplicate(), ElemSize, Type);
+            return new IndexRefEntry(IndexOp.Duplicate(), ArrayOp.Duplicate(), ElemSize, Type, FirstElementOffset);
         }
     }
 }

--- a/ILCompiler/Compiler/Importer/CallImporter.cs
+++ b/ILCompiler/Compiler/Importer/CallImporter.cs
@@ -293,10 +293,12 @@ namespace ILCompiler.Compiler.Importer
 
                 case "get_Chars":
                     {
+                        const short StringCharsOffset = 2;
+
                         var arrayOp = arguments[0];
                         var indexOp = arguments[1];
 
-                        var node = new IndexRefEntry(indexOp, arrayOp, 2, VarType.UShort);
+                        var node = new IndexRefEntry(indexOp, arrayOp, 2, VarType.UShort, StringCharsOffset);
                         importer.PushExpression(node);
 
                         return true;

--- a/ILCompiler/Compiler/Importer/LoadElemImporter.cs
+++ b/ILCompiler/Compiler/Importer/LoadElemImporter.cs
@@ -64,7 +64,7 @@ namespace ILCompiler.Compiler.Importer
             var op1 = importer.PopExpression();
             var op2 = importer.PopExpression();
 
-            var node = new IndexRefEntry(op1, op2, elemSize, elemType);
+            var node = new IndexRefEntry(op1, op2, elemSize, elemType, 0);
 
             importer.PushExpression(node);
 

--- a/ILCompiler/Compiler/Morpher.cs
+++ b/ILCompiler/Compiler/Morpher.cs
@@ -123,9 +123,9 @@ namespace ILCompiler.Compiler
                 addr = new BinaryOperator(Operation.Mul, isComparison: false, size, addr, VarType.Ptr);
             }
 
-            // addr + arraySizeOffset + (elemSize * index)
-            var arraySizeOffset = new NativeIntConstantEntry(2);
-            addr = new BinaryOperator(Operation.Add, isComparison: false, addr, arraySizeOffset, VarType.Ptr);
+            // addr + arraySizeOffset + firstElemOffset + (elemSize * index)
+            var offset = new NativeIntConstantEntry((short)(2 + tree.FirstElementOffset));
+            addr = new BinaryOperator(Operation.Add, isComparison: false, addr, offset, VarType.Ptr);
             addr = new BinaryOperator(Operation.Add, isComparison: false, MorphTree(tree.ArrayOp), addr, VarType.Ptr);
             addr = new IndirectEntry(addr, tree.Type, tree.ElemSize);
 

--- a/ILCompiler/Runtime/NewString.asm
+++ b/ILCompiler/Runtime/NewString.asm
@@ -2,17 +2,21 @@
 ;
 ; Uses: HL, DE, BC
 
+; TODO: Use this in readline too
+STRING_BASE_SIZE		EQU	2
+
 NewString:	
-	PUSH HL		; Length passed in HL
-	POP BC
+	PUSH HL		; Save original size
 
-	PUSH BC		; Save original size
+	; Compute overall size (align(base size + (element size * elements), 4))
+	INC HL		; Multiply elements * element size
+	SLA L
+	RL H
 
-	INC BC		; Multiply size by 2 as using UTF-16 so 2 bytes per character
-	SLA C
-	RL B
+	LD BC, STRING_BASE_SIZE		; Add base size
+	ADD HL, BC
 
-	PUSH BC
+	PUSH HL
 	CALL NewObject	; Allocate object
 	POP HL		; Address of new object
 
@@ -21,6 +25,9 @@ NewString:
 	POP DE		; Get return address
 
 	PUSH HL		; Return value is address of new string
+	
+	INC HL		; Skip base size
+	INC HL
 
 	LD (HL), C	; Set the size for the new string in the first 2 bytes
 	INC HL

--- a/ILCompiler/Runtime/TRS80/readline.asm
+++ b/ILCompiler/Runtime/TRS80/readline.asm
@@ -35,6 +35,9 @@ READLINE:
 	PUSH DE		; Save return address
 	PUSH HL		; Save pointer to string object on heap
 
+	INC HL		; Add base size
+	INC HL
+
 	; Put length into first 2 bytes of string object
 	LD (HL), C
 	INC HL

--- a/ILCompiler/Runtime/ZXSpectrum/readline.asm
+++ b/ILCompiler/Runtime/ZXSpectrum/readline.asm
@@ -79,6 +79,9 @@ READOVER:
 	PUSH DE		; Save return address
 	PUSH HL		; Save pointer to string object on heap
 
+	INC HL		; Add base size
+	INC HL
+
 	; Put length into first 2 bytes of string object
 	LD (HL), C
 	INC HL

--- a/ILCompiler/Runtime/print.asm
+++ b/ILCompiler/Runtime/print.asm
@@ -1,4 +1,7 @@
 PRINT:
+	LD BC, 2		; Add base size
+	ADD HL, BC
+
 	LD E, (HL)	; Get string length into DE
 	INC HL
 	LD D, (HL)

--- a/Tests/ILCompiler.UnitTests/InstanceFieldLayoutTests.cs
+++ b/Tests/ILCompiler.UnitTests/InstanceFieldLayoutTests.cs
@@ -43,9 +43,10 @@ namespace ILCompiler.UnitTests
             var target = new TargetDetails(TargetArchitecture.Z80);
             var metadataFieldLayoutAlgorithm = new MetadataFieldLayoutAlgorithm(target);
 
-            var computedFieldLayout = metadataFieldLayoutAlgorithm.ComputeInstanceLayout(typeDef);
+            var computedFieldLayout = typeDef.InstanceFieldLayout(metadataFieldLayoutAlgorithm);
 
             // Byte count
+            // Base Class       2 + 2 padding
             // MyInt            4
             // MyBool           1 + 1 padding
             // MyChar           2
@@ -53,13 +54,13 @@ namespace ILCompiler.UnitTests
             // MyByteArray      2
             // MyClass1SelfRef  2
             // -------------------
-            //                  14 
+            //                  18 
 
             var instanceByteCountUnaligned = computedFieldLayout.ByteCountUnaligned;
             var instanceByteAlignment = computedFieldLayout.ByteCountAlignment;
             var instanceByteCount = LayoutInt.AlignUp(instanceByteCountUnaligned, instanceByteAlignment, target);
 
-            Assert.AreEqual(14, instanceByteCount.AsInt);
+            Assert.AreEqual(18, instanceByteCount.AsInt);
 
             foreach (var fieldAndOffset in computedFieldLayout.Offsets)
             {
@@ -70,22 +71,22 @@ namespace ILCompiler.UnitTests
                 switch (field.Name)
                 {
                     case "MyInt":
-                        Assert.AreEqual(0, fieldAndOffset.Offset.AsInt);
-                        break;
-                    case "MyBool":
                         Assert.AreEqual(4, fieldAndOffset.Offset.AsInt);
                         break;
-                    case "MyChar":
-                        Assert.AreEqual(6, fieldAndOffset.Offset.AsInt);
-                        break;
-                    case "MyString":
+                    case "MyBool":
                         Assert.AreEqual(8, fieldAndOffset.Offset.AsInt);
                         break;
-                    case "MyByteArray":
+                    case "MyChar":
                         Assert.AreEqual(10, fieldAndOffset.Offset.AsInt);
                         break;
-                    case "MyClass1SelfRef":
+                    case "MyString":
                         Assert.AreEqual(12, fieldAndOffset.Offset.AsInt);
+                        break;
+                    case "MyByteArray":
+                        Assert.AreEqual(14, fieldAndOffset.Offset.AsInt);
+                        break;
+                    case "MyClass1SelfRef":
+                        Assert.AreEqual(16, fieldAndOffset.Offset.AsInt);
                         break;
                     default:
                         Assert.Fail();
@@ -102,7 +103,7 @@ namespace ILCompiler.UnitTests
             var target = new TargetDetails(TargetArchitecture.Z80);
             var metadataFieldLayoutAlgorithm = new MetadataFieldLayoutAlgorithm(target);
 
-            var computedFieldLayout = metadataFieldLayoutAlgorithm.ComputeInstanceLayout(typeDef);
+            var computedFieldLayout = typeDef.InstanceFieldLayout(metadataFieldLayoutAlgorithm);
 
             // Byte count
             // bool     b1      1
@@ -157,7 +158,7 @@ namespace ILCompiler.UnitTests
             var target = new TargetDetails(TargetArchitecture.Z80);
             var metadataFieldLayoutAlgorithm = new MetadataFieldLayoutAlgorithm(target);
 
-            var computedFieldLayout = metadataFieldLayoutAlgorithm.ComputeInstanceLayout(typeDef);
+            var computedFieldLayout = typeDef.InstanceFieldLayout(metadataFieldLayoutAlgorithm);
 
             // Byte count
             // struct   MyStruct0   12


### PR DESCRIPTION
- Create extension methods for accessing field layout results 
- Enhance IndexRefEntry to allow extra first element offset 
- Use first element offset in get_Chars now that first 2 bytes are the EEType 
- Fix constant stirng data code gen to include space for string EEType 
- Initial changes to native code for strings to deal with presence of EEType 
- Update Field layout tests to factor in presence of EEType