### PR TITLE
Fix Out of Memory and Return Code messages now that print expects EEtype in first 2 bytes

### DIFF
--- a/ILCompiler/Compiler/Z80Writer.cs
+++ b/ILCompiler/Compiler/Z80Writer.cs
@@ -143,10 +143,9 @@ namespace ILCompiler.Compiler
             _out.WriteLine(Instruction.Db("O u t   o f   m e m o r y "));
         }
 
-        private const string RetCodeMsgLabel = "RETCODEMSG";
         private void OutputReturnCodeMessage()
         {
-            OutputLabel(RetCodeMsgLabel);
+            OutputLabel("RETCODEMSG");
             _out.WriteLine(Instruction.Db(12));
             _out.WriteLine(Instruction.Db(0)); // Length of message
             _out.WriteLine(Instruction.Db("R e t u r n   C o d e : "));
@@ -159,7 +158,7 @@ namespace ILCompiler.Compiler
             if (_configuration.PrintReturnCode)
             {
                 // Write string "Return Code:"
-                _out.WriteLine(Instruction.Ld(R16.HL, RetCodeMsgLabel));
+                _out.WriteLine(Instruction.Ld(R16.HL, "RETCODEMSG - 2"));
                 _out.WriteLine(Instruction.Call("PRINT"));
                 _calls.Add("PRINT");
 

--- a/ILCompiler/Runtime/NewArray.asm
+++ b/ILCompiler/Runtime/NewArray.asm
@@ -79,7 +79,7 @@ newarr_nomul16:
 	RET
 
 newarr_oom:
-	LD HL, OOM_MSG
+	LD HL, OOM_MSG - 2
 	CALL PRINT
 
 	; Panic exit

--- a/ILCompiler/Runtime/NewObject.asm
+++ b/ILCompiler/Runtime/NewObject.asm
@@ -44,7 +44,7 @@ NewObject:
 
 NewObject_NoSpace:
 
-	LD HL, OOM_MSG
+	LD HL, OOM_MSG - 2
 	CALL PRINT
 
 	; Panic exit

--- a/System.Private.CoreLib/Pal/Console.cs
+++ b/System.Private.CoreLib/Pal/Console.cs
@@ -51,6 +51,12 @@ namespace System
             Write(Environment.NewLine);
         }
 
+        public static void WriteLine(char value)
+        {
+            Write(value);
+            WriteLine();
+        }
+
         public static void WriteLine(Int32 value)
         {
             Write(value);
@@ -65,7 +71,6 @@ namespace System
 
         public static void WriteLine(string str)
         {
-            // TODO: Really want to use string concatenation here but not sure that will work yet
             Write(str);
             WriteLine();
         }


### PR DESCRIPTION
Also Add WriteLine(char) to Console.