### PR TITLE
Handle Localloc alignment properly

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/LocalHeapCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/LocalHeapCodeGenerator.cs
@@ -31,12 +31,15 @@ namespace ILCompiler.Compiler.CodeGenerators
                 // Divide BC by 2
                 context.Assembler.ShiftRightLogical(R8.B);
                 context.Assembler.RotateRight(R8.C);
+                context.Assembler.ShiftRightLogical(R8.B);
+                context.Assembler.RotateRight(R8.C);
 
                 // Start of Zeroing loop
                 var initLoopLabel = context.NameMangler.GetUniqueName();
                 context.Assembler.AddInstruction(new LabelInstruction(initLoopLabel));
 
-                // Zero a byte
+                // Zero two zero bytes
+                context.Assembler.Push(R16.HL);
                 context.Assembler.Push(R16.HL);
 
                 // Decrement byte count

--- a/ILCompiler/Compiler/CodeGenerators/LocalHeapCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/LocalHeapCodeGenerator.cs
@@ -5,32 +5,39 @@ namespace ILCompiler.Compiler.CodeGenerators
 {
     internal class LocalHeapCodeGenerator : ICodeGenerator<LocalHeapEntry>
     {
+        private const int StackAlign = 4;
         public void GenerateCode(LocalHeapEntry entry, CodeGeneratorContext context)
         {
             // Use the 16 bit size on top of the stack to determine the amount of localloc to do
-            context.Assembler.Pop(R16.BC);
+            context.Assembler.Pop(R16.HL);
 
-            context.Assembler.Ld(R16.HL, 0);
-            context.Assembler.Add(R16.HL, R16.SP);
+            // Round up number of bytes to allocate to a StackAlign boundary
+            // BC = (HL + (StackAlign - 1)) & ~(StackAlign - 1)
+            context.Assembler.Ld(R16.DE, (short)(StackAlign - 1));
+            context.Assembler.Add(R16.HL, R16.DE);
+            context.Assembler.Ld(R16.DE, (short)~(StackAlign - 1));
+            context.Assembler.Ld(R8.A, R8.H);
+            context.Assembler.And(R8.D);
+            context.Assembler.Ld(R8.B, R8.A);
+            context.Assembler.Ld(R8.A, R8.L);
+            context.Assembler.And(R8.E);
+            context.Assembler.Ld(R8.C, R8.A);
 
-            if (!context.Method.Body.InitLocals)
-            {
-                context.Assembler.And(R8.A);
-                context.Assembler.Sbc(R16.HL, R16.BC);
-            }
-            else
+            if (context.Method.Body.InitLocals)
             {
                 // zero space on stack
+                context.Assembler.Ld(R16.HL, 0);
+
+                // Divide BC by 2
+                context.Assembler.ShiftRightLogical(R8.B);
+                context.Assembler.RotateRight(R8.C);
 
                 // Start of Zeroing loop
                 var initLoopLabel = context.NameMangler.GetUniqueName();
                 context.Assembler.AddInstruction(new LabelInstruction(initLoopLabel));
 
-                // Move to next byte to zero remembering that stack grows downwards
-                context.Assembler.Dec(R16.HL);
-
                 // Zero a byte
-                context.Assembler.LdInd(R16.HL, 0);
+                context.Assembler.Push(R16.HL);
 
                 // Decrement byte count
                 context.Assembler.Dec(R16.BC);
@@ -40,13 +47,23 @@ namespace ILCompiler.Compiler.CodeGenerators
 
                 // More bytes to zero then loop
                 context.Assembler.Jp(Condition.NonZero, initLoopLabel);
-            }
 
-            context.Assembler.Ld(R16.SP, R16.HL);
+                context.Assembler.Ld(R16.HL, 0);
+                context.Assembler.Add(R16.HL, R16.SP);
+            }
+            else
+            {
+                context.Assembler.Ld(R16.HL, 0);
+                context.Assembler.Add(R16.HL, R16.SP);
+
+                context.Assembler.And(R8.A);
+                context.Assembler.Sbc(R16.HL, R16.BC);
+
+                context.Assembler.Ld(R16.SP, R16.HL);
+            }
 
             // Push address of newly allocated space
             context.Assembler.Push(R16.HL);
-
         }
     }
 }

--- a/Tests/ILCompiler.IntegrationTests/il_bvt/localloc.il
+++ b/Tests/ILCompiler.IntegrationTests/il_bvt/localloc.il
@@ -11,9 +11,6 @@
 .maxstack 10
 .locals (native int)
 
-/*
-// TODO: This isn't right as stind.i is going to try and store a native int 
-// into the 1 byte allocated on the stack but needs 2 bytes.
 	ldc.i4 0x1
 	localloc
 	stloc 0
@@ -26,7 +23,6 @@
 	ldc.i4 0x8
 	conv.i
 	bne.un fail
-*/
 
 	ldc.i4	0x1
 	localloc

--- a/Z80Assembler/Assembler.Instructions.cs
+++ b/Z80Assembler/Assembler.Instructions.cs
@@ -152,6 +152,15 @@ namespace Z80Assembler
             AddInstruction(new Instruction(Opcode.Or, target.ToString()));
         }
 
+        public void RotateRight(R8Type target)
+        {
+            AddInstruction(new Instruction(Opcode.Rr, target.ToString()));
+        }
+        public void ShiftRightLogical(R8Type target)
+        {
+            AddInstruction(new Instruction(Opcode.Srl, target.ToString()));
+        }
+
         public void And(R8Type target)
         {
             AddInstruction(new Instruction(Opcode.And, target.ToString()));

--- a/Z80Assembler/Opcode.cs
+++ b/Z80Assembler/Opcode.cs
@@ -28,6 +28,8 @@
         public static readonly Opcode Inc = new("Inc");
         public static readonly Opcode Dec = new("Dec");
         public static readonly Opcode Cpl = new("Cpl");
+        public static readonly Opcode Rr = new("Rr");
+        public static readonly Opcode Srl = new("Srl");
 
         public static readonly Opcode Org = new("Org");
         public static readonly Opcode End = new("End");


### PR DESCRIPTION
Round space to allocate up to factor of 4 bytes.
Improve code gen for zeroing allocated stack space given that it is guaranteed to be a factor of 4 now.