### PR TITLE
Switch to using main branch for benchmark files rather than gh-pages

### DIFF
--- a/.github/workflows/MainBuild.yml
+++ b/.github/workflows/MainBuild.yml
@@ -117,3 +117,5 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Push and deploy GitHub pages branch automatically
           auto-push: true
+          gh-pages-branch: main
+          benchmark-data-dir-path: docs/bench


### PR DESCRIPTION
Use main instead of gh-pages branch for publishing benchmark results
Move benchmarks to docs/bench folder