### PR TITLE
Use gh-pages branch for benchmarking results

### DIFF
--- a/.github/workflows/MainBuild.yml
+++ b/.github/workflows/MainBuild.yml
@@ -117,5 +117,5 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Push and deploy GitHub pages branch automatically
           auto-push: true
-          gh-pages-branch: main
+          gh-pages-branch: gh-pages
           benchmark-data-dir-path: docs/bench


### PR DESCRIPTION
Using main branch doesn't work with github-action-benchmark so reverting back to using gh-pages branch.