### PR TITLE
Temporarily remove code to zero locals

### DIFF
--- a/ILCompiler/Compiler/CodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerator.cs
@@ -236,6 +236,7 @@ namespace ILCompiler.Compiler
                 
                 if (_context.Method.Body.InitLocals)
                 {
+                    /*
                     // TODO: This should loop through the locals and only init those flagged as must init
                     // but this requires SSA and use/def analysis which we don't have yet.
                     // So for now just init all the locals
@@ -258,6 +259,7 @@ namespace ILCompiler.Compiler
                     assembler.Or(R8.C);
 
                     assembler.Jp(Condition.NonZero, initLoopLabel);
+                    */
                 }
             }
         }

--- a/Tests/ILCompiler.IntegrationTests/il_bvt/AutoInit.il
+++ b/Tests/ILCompiler.IntegrationTests/il_bvt/AutoInit.il
@@ -14,6 +14,7 @@
 .locals (int32,int32,int32,int32,int32,int32,int32,int32,int32,int32,int32,int32,int32,int32,int32,int32)
 .maxstack  2
 
+/*
 	ldc.i4 0x1
 	stloc 0x1
 	ldc.i4 0x3
@@ -66,6 +67,7 @@
 	ldc.i4	0x40
 	ceq
 	brfalse FAIL
+*/
 
 PASS:
 	ldc.i4 0x0000


### PR DESCRIPTION
Temporarily remove code to zero locals to see effect this has on the continuous benchmarks