### PR TITLE
Fix bug in spilling stack

### DIFF
--- a/ILCompiler/Compiler/ILImporter.cs
+++ b/ILCompiler/Compiler/ILImporter.cs
@@ -229,7 +229,7 @@ namespace ILCompiler.Compiler
                 tempNumber = GrabTemp(entry.Type, entry.ExactSize);
             }
 
-            var node = new StoreLocalVariableEntry(tempNumber.Value, false, entry);
+            var node = new StoreLocalVariableEntry(tempNumber.Value, false, entry.Duplicate());
             ImportAppendTree(node);
 
             return new LocalVariableEntry(tempNumber.Value, entry.Type, entry.ExactSize);

--- a/Tests/Regression/Regression/RegressionTests.cs
+++ b/Tests/Regression/Regression/RegressionTests.cs
@@ -9,6 +9,8 @@
             nuint testValue = 123;
             Assert.Equals(testValue, MethodCall_WithNuintParameter_CompilesWithoutErrors(testValue));
 
+            Assert.Equals(1, Bug210_SpillStack());
+
             return 0;
         }
 
@@ -21,6 +23,15 @@
         private static char Bug87_Method(char ch)
         {
             return ch;
+        }
+
+        private static int Bug210_SpillStack()
+        {
+            int x = 0;
+            int y = 1;
+            x += y == 1 ? 1 : 0;
+
+            return x;
         }
 
         private static nuint MethodCall_WithNuintParameter_CompilesWithoutErrors(nuint n)


### PR DESCRIPTION
Not duplicating stack tree node when spilling into new temp - resulting in odd behaviour in flowgraph due to shared node across statements