### PR TITLE
Inline add 16 - saves 52 t-states for cost of 1 byte in instructions.

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/BinaryOperatorCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/BinaryOperatorCodeGenerator.cs
@@ -76,7 +76,15 @@ namespace ILCompiler.Compiler.CodeGenerators
             }
             else
             {
-                if (BinaryOperatorMappings.TryGetValue(Tuple.Create(entry.Operation, operatorType), out string? routine))
+                if (operatorType == VarType.Ptr && entry.Operation == Operation.Add)
+                {
+                    // Inline 16 bit adds to avoid overhead of call 
+                    context.Emitter.Pop(HL);
+                    context.Emitter.Pop(BC);
+                    context.Emitter.Add(HL, BC);
+                    context.Emitter.Push(HL);
+                }
+                else if (BinaryOperatorMappings.TryGetValue(Tuple.Create(entry.Operation, operatorType), out string? routine))
                 {
                     context.Emitter.Call(routine);
                 }


### PR DESCRIPTION
Simple inline of 16 bit add resulting in 16 bit answer:

Non-inlined, 3 bytes of code, 46 t-states
Inlined, 4 bytes of code, 98 t-states