### PR TITLE
Load Field with struct on stack from array was failing.

### DIFF
--- a/ILCompiler/Compiler/EvaluationStack/IndexRefEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/IndexRefEntry.cs
@@ -9,7 +9,7 @@
 
         public int ElemSize { get; }
 
-        public IndexRefEntry(StackEntry indexOp, StackEntry arrayOp, int elemSize, VarType type, short firstElementOffset) : base(type)
+        public IndexRefEntry(StackEntry indexOp, StackEntry arrayOp, int elemSize, VarType type, short firstElementOffset) : base(type, elemSize)
         {
             IndexOp = indexOp;
             ArrayOp = arrayOp;

--- a/ILCompiler/Compiler/Importer/LoadFieldImporter.cs
+++ b/ILCompiler/Compiler/Importer/LoadFieldImporter.cs
@@ -36,24 +36,7 @@ namespace ILCompiler.Compiler.Importer
 
                 if (obj.Type == VarType.Struct)
                 {
-                    if (obj is LocalVariableEntry)
-                    {
-                        obj = new LocalVariableAddressEntry((obj.As<LocalVariableEntry>()).LocalNumber);
-                    }
-                    else if (obj is IndirectEntry)
-                    {
-                        // If the object is itself an IndirectEntry e.g. resulting from a Ldfld
-                        // then we should merge the Ldfld's together
-
-                        // e.g. Ldfld SimpleVector::N
-                        //      Ldfld Nested::Length
-                        // will get converted into a single IndirectEntry node with the field offset
-                        // being the combination of the field offsets for N and Length
-
-                        var previousIndirect = obj.As<IndirectEntry>();
-                        fieldOffset = previousIndirect.Offset + fieldOffset;
-                        obj = previousIndirect.Op1;
-                    }
+                    obj = GetStructAddress(ref fieldOffset, obj, importer);
                 }
 
                 if (obj.Type != VarType.Ref && obj.Type != VarType.ByRef && obj.Type != VarType.Ptr)
@@ -69,6 +52,41 @@ namespace ILCompiler.Compiler.Importer
             importer.PushExpression(node);
 
             return true;
+        }
+
+        private static StackEntry GetStructAddress(ref uint fieldOffset, StackEntry structVal, IILImporterProxy importer)
+        {
+            // If the object is a struct, what we really want is
+            // for the field to operate on the address of the struct.
+
+            // See Compiler::impGetStructAddr in importer.cpp in ryujit
+
+            if (structVal is LocalVariableEntry)
+            {
+                return new LocalVariableAddressEntry((structVal.As<LocalVariableEntry>()).LocalNumber);
+            }
+            else if (structVal is IndirectEntry)
+            {
+                // If the object is itself an IndirectEntry e.g. resulting from a Ldfld
+                // then we should merge the Ldfld's together
+
+                // e.g. Ldfld SimpleVector::N
+                //      Ldfld Nested::Length
+                // will get converted into a single IndirectEntry node with the field offset
+                // being the combination of the field offsets for N and Length
+
+                var previousIndirect = structVal.As<IndirectEntry>();
+                fieldOffset = previousIndirect.Offset + fieldOffset;
+                return previousIndirect.Op1;
+            }            
+
+            // Copy the struct to a new temp local variable
+            // and then return the address of the new temp local variable
+            var lclNum = importer.GrabTemp(structVal.Type, structVal.ExactSize);
+            var asg = new StoreLocalVariableEntry(lclNum, false, structVal);
+            importer.ImportAppendTree(asg);
+
+            return new LocalVariableAddressEntry(lclNum);
         }
     }
 }

--- a/Tests/ILCompiler.IntegrationTests/il_bvt/ldelema.il
+++ b/Tests/ILCompiler.IntegrationTests/il_bvt/ldelema.il
@@ -197,12 +197,10 @@
 .maxstack  5
 .locals ()
 
-/*
 	ldc.i4 0x00
 	ldc.i4 0x72
 	call int32 array_tests::StructTest(int32, int32)
 	brfalse FAIL
-*/
 
 	ldc.i4 0x00
 	ldc.i4 0x72


### PR DESCRIPTION
To resolve this added default behaviour in LoadFieldImporter which will copy the struct from the stack to a local variable and push the address of the local variable.

This enables the previously commented out test in ldelem.il using arrays of structs to now pass.