### PR TITLE
Refactor EETypeNode to StaticsNode

### DIFF
--- a/ILCompiler/Compiler/DependencyAnalysis/DependencyAnalyser.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/DependencyAnalyser.cs
@@ -82,12 +82,7 @@ namespace ILCompiler.Compiler.DependencyAnalysis
                     return;
                 }
 
-                var declaringType = fieldDef.DeclaringType;
-
-                if (declaringType != null)
-                {
-                    _dependencies.Add(_nodeFactory.TypeNode(declaringType));
-                }
+                _dependencies.Add(_nodeFactory.TypeNode(fieldDef));
             }
         }
 

--- a/ILCompiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -5,18 +5,18 @@ namespace ILCompiler.Compiler.DependencyAnalysis
 {
     public class NodeFactory
     {
-        private IDictionary<string, EETypeNode> _typeNodesByFullName = new Dictionary<string, EETypeNode>();
+        private IDictionary<string, StaticsNode> _staticNodesByFullName = new Dictionary<string, StaticsNode>();
         private IDictionary<string, Z80MethodCodeNode> _methodNodesByFullName = new Dictionary<string, Z80MethodCodeNode>();
         
-        public EETypeNode TypeNode(TypeDef type)
+        public StaticsNode TypeNode(FieldDef field)
         {
-            if (!_typeNodesByFullName.TryGetValue(type.FullName, out var typeNode))
+            if (!_staticNodesByFullName.TryGetValue(field.FullName, out var staticNode))
             {
-                typeNode = new EETypeNode(type);
-                _typeNodesByFullName[type.FullName] = typeNode;
+                staticNode = new StaticsNode(field);
+                _staticNodesByFullName[field.FullName] = staticNode;
             }
 
-            return typeNode;
+            return staticNode;
         }
 
         public Z80MethodCodeNode MethodNode(MethodSpec calleeMethod, MethodDesc callerMethod)

--- a/ILCompiler/Compiler/DependencyAnalysis/StaticsNode.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/StaticsNode.cs
@@ -2,17 +2,17 @@
 
 namespace ILCompiler.Compiler.DependencyAnalysis
 {
-    public class EETypeNode : IDependencyNode
+    public class StaticsNode : IDependencyNode
     {
         public bool Analysed { get; set; }
 
         public bool Compiled { get; set; }
 
-        public TypeDef Type { get; private set; }
+        public FieldDef Field { get; private set; }
 
-        public EETypeNode(TypeDef type)
+        public StaticsNode(FieldDef field)
         {
-            Type = type;
+            Field = field;
             Dependencies = new List<IDependencyNode>();
         }
 

--- a/ILCompiler/Compiler/Z80Writer.cs
+++ b/ILCompiler/Compiler/Z80Writer.cs
@@ -239,24 +239,18 @@ namespace ILCompiler.Compiler
             var dependencies = DependencyNodeHelpers.GetFlattenedDependencies(node);
             foreach (var dependentNode in dependencies)
             {
-                // If the type has static fields then need to reserve space for these fields
-                if (dependentNode is EETypeNode typeNode)
+                // For static field dependencies we need to reserve appropriate space for the field
+                if (dependentNode is StaticsNode typeNode)
                 {
-                    var typeDef = typeNode.Type;
-                    foreach (var field in typeDef.Fields)
-                    {
-                        if (field.IsStatic)
-                        {
-                            var fieldSize = field.FieldType.GetInstanceFieldSize();
-                            _logger.LogDebug("Reserving {fieldSize} bytes for static field {field.FullName}", fieldSize, field.FullName);
+                    var field = typeNode.Field;
+                    var fieldSize = field.FieldType.GetInstanceFieldSize();
+                    _logger.LogDebug("Reserving {fieldSize} bytes for static field {field.FullName}", fieldSize, field.FullName);
 
-                            // Need to mangle full field name here
-                            OutputLabel(_nameMangler.GetMangledFieldName(field));
+                    // Need to mangle full field name here
+                    OutputLabel(_nameMangler.GetMangledFieldName(field));
 
-                            // Emit fieldSize bytes with value 0
-                            _out.WriteLine(Instruction.Create(Opcode.Dc, (ushort)fieldSize, 0));
-                        }
-                    }
+                    // Emit fieldSize bytes with value 0
+                    _out.WriteLine(Instruction.Create(Opcode.Dc, (ushort)fieldSize, 0));
                 }
             }
         }


### PR DESCRIPTION
Really using EETypeNode to represent dependencies on static fields so rename EETypeNode to StaticsNode.
Change this class to hold the FieldDef for the actual field too - as this is the true dependency.
Modify code emitter to simply take the FieldDef from a StaticsNode and reserve appropriate space for it named based on the field name.