### PR TITLE
Add constructed EETypeNode

### DIFF
--- a/ILCompiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -1,0 +1,23 @@
+﻿using dnlib.DotNet;
+
+namespace ILCompiler.Compiler.DependencyAnalysis
+{
+    internal class ConstructedEETypeNode : IDependencyNode
+    {
+        public bool Analysed { get; set; }
+        public bool Compiled { get; set; }
+
+        public IList<IDependencyNode> Dependencies { get; set; }
+
+        public TypeDef Type { get; private set; }
+        public int BaseSize { get; private set; }
+        public string Name => Type.FullName + " constructed";
+
+        public ConstructedEETypeNode(TypeDef type, int baseSize)
+        {
+            Type = type;
+            BaseSize = baseSize;
+            Dependencies = new List<IDependencyNode>();
+        }
+    }
+}

--- a/ILCompiler/Compiler/DependencyAnalysis/DependencyAnalyser.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/DependencyAnalyser.cs
@@ -88,6 +88,37 @@ namespace ILCompiler.Compiler.DependencyAnalysis
 
         private void ImportCall(Instruction instruction)
         {
+            if (instruction.OpCode.Code == Code.Newobj)
+            {
+                if (instruction.Operand is not IMethodDefOrRef methodDefOrRef)
+                {
+                    throw new InvalidOperationException("Newobj called with Operand which isn't a IMethodDefOrRef");
+                }
+
+                var declaringTypeSig = methodDefOrRef.DeclaringType.ToTypeSig();
+
+                if (declaringTypeSig.IsArray)
+                {
+                    // TODO: Will need to review this when changing NewArray assembly to take EEType instead of size
+                }
+                else
+                {
+                    var methodToCall = methodDefOrRef.ResolveMethodDefThrow();
+                    var declType = methodToCall.DeclaringType;
+
+                    var objType = declType.ToTypeSig();
+
+                    if (!declType.IsValueType)
+                    {
+                        // Determine required size on GC heap
+                        var allocSize = objType.GetInstanceByteCount();
+
+                        var constructedEETypeNode = new ConstructedEETypeNode(declType, allocSize);
+                        _dependencies.Add(constructedEETypeNode);
+                    }
+                }
+            }
+
             var method = instruction.Operand as IMethod;
             if (method != null)
             {

--- a/ILCompiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -5,8 +5,8 @@ namespace ILCompiler.Compiler.DependencyAnalysis
 {
     public class NodeFactory
     {
-        private IDictionary<string, StaticsNode> _staticNodesByFullName = new Dictionary<string, StaticsNode>();
-        private IDictionary<string, Z80MethodCodeNode> _methodNodesByFullName = new Dictionary<string, Z80MethodCodeNode>();
+        private readonly IDictionary<string, StaticsNode> _staticNodesByFullName = new Dictionary<string, StaticsNode>();
+        private readonly IDictionary<string, Z80MethodCodeNode> _methodNodesByFullName = new Dictionary<string, Z80MethodCodeNode>();
         
         public StaticsNode TypeNode(FieldDef field)
         {

--- a/ILCompiler/Compiler/NameMangler.cs
+++ b/ILCompiler/Compiler/NameMangler.cs
@@ -14,6 +14,10 @@ namespace ILCompiler.Compiler
 
         private int nextFieldId = 0;
 
+        private readonly Dictionary<String, String> _mangledTypeNames = new Dictionary<String, String>();
+
+        private int nextTypeId = 0;
+
 
         public string GetMangledMethodName(MethodSpec method)
         {
@@ -66,6 +70,24 @@ namespace ILCompiler.Compiler
         public string GetMangledFieldName(FieldDef field)
         {
             return GetMangledFieldName(field.FullName);
+        }
+
+        public string GetMangledTypeName(TypeDef type)
+        {
+            return GetMangledTypeName(type.FullName);
+        }
+
+        private string GetMangledTypeName(string fullName)
+        {
+            if (_mangledMethodNames.TryGetValue(fullName, out string? mangledName))
+            {
+                return mangledName;
+            }
+
+            mangledName = $"t{nextTypeId++}";
+            _mangledMethodNames.Add(fullName, mangledName);
+
+            return mangledName;
         }
 
         public string GetUniqueName()

--- a/ILCompiler/Compiler/NameMangler.cs
+++ b/ILCompiler/Compiler/NameMangler.cs
@@ -79,7 +79,7 @@ namespace ILCompiler.Compiler
 
         private string GetMangledTypeName(string fullName)
         {
-            if (_mangledMethodNames.TryGetValue(fullName, out string? mangledName))
+            if (_mangledTypeNames.TryGetValue(fullName, out string? mangledName))
             {
                 return mangledName;
             }

--- a/ILCompiler/Compiler/NameMangler.cs
+++ b/ILCompiler/Compiler/NameMangler.cs
@@ -85,7 +85,7 @@ namespace ILCompiler.Compiler
             }
 
             mangledName = $"t{nextTypeId++}";
-            _mangledMethodNames.Add(fullName, mangledName);
+            _mangledTypeNames.Add(fullName, mangledName);
 
             return mangledName;
         }

--- a/ILCompiler/Interfaces/INameMangler.cs
+++ b/ILCompiler/Interfaces/INameMangler.cs
@@ -9,6 +9,7 @@ namespace ILCompiler.Interfaces
         public string GetMangledMethodName(MethodDef method);
         public string GetMangledMethodName(MethodDesc method);
         public string GetMangledFieldName(FieldDef field);
+        public string GetMangledTypeName(TypeDef type);
         public string GetUniqueName();
     }
 }


### PR DESCRIPTION
Extend dependency analysis to create ConstructedEETypeNode to represent types that are constructed e.g. newed up
Use this information in z80 code gen to write out EEType blocks - currently only contain base size but likely to extend this in the future.
Note the EEType blocks are not used yet - intent is to refactor NewObj to make use of EEType ptr instead of taking size directly