### PR TITLE
Optimize NewObject

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/AllocObjCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/AllocObjCodeGenerator.cs
@@ -9,8 +9,8 @@ namespace ILCompiler.Compiler.CodeGenerators
         public void GenerateCode(AllocObjEntry entry, CodeGeneratorContext context)
         {
             // Allocate memory on the heap using simple zero GC/increment a pointer approach
-            context.Emitter.Ld(HL, entry.MangledEETypeName);
-            context.Emitter.Push(HL);
+            context.Emitter.Ld(BC, entry.MangledEETypeName);
+            context.Emitter.Ld(DE, (ushort)entry.Size);
             context.Emitter.Call("NewObject");
         }
     }

--- a/ILCompiler/Compiler/DependencyAnalysis/DependencyAnalyser.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/DependencyAnalyser.cs
@@ -137,7 +137,7 @@ namespace ILCompiler.Compiler.DependencyAnalysis
 
             if (declaringTypeSig.IsArray)
             {
-                // TODO: Will need to review this when changing NewArray assembly to take EEType instead of size
+                // TODO: Will need to review this when changing NewArray assembly routine to take EEType instead of size
             }
             else
             {

--- a/ILCompiler/Compiler/EvaluationStack/AllocObjEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/AllocObjEntry.cs
@@ -5,9 +5,10 @@
         public int Size { get; }
         public string MangledEETypeName { get; }
 
-        public AllocObjEntry(string mangledEETypeName, VarType objType) : base(objType)
+        public AllocObjEntry(string mangledEETypeName, int objSize, VarType objType) : base(objType)
         {
             MangledEETypeName = mangledEETypeName;
+            Size = objSize;
         }
 
         public override void Accept(IStackEntryVisitor visitor)
@@ -17,7 +18,7 @@
 
         public override StackEntry Duplicate()
         {
-            return new AllocObjEntry(MangledEETypeName, Type);
+            return new AllocObjEntry(MangledEETypeName, Size, Type);
         }
     }
 }

--- a/ILCompiler/Compiler/Importer/NewobjImporter.cs
+++ b/ILCompiler/Compiler/Importer/NewobjImporter.cs
@@ -100,10 +100,13 @@ namespace ILCompiler.Compiler.Importer
                     }
                     else
                     {
-                        // Allocate memory for object
                         var mangledEETypeName = context.NameMangler.GetMangledTypeName(declType);
 
-                        var op1 = new AllocObjEntry(mangledEETypeName, objVarType);
+                        // Determine required size on GC heap
+                        var allocSize = objType.GetInstanceByteCount();
+
+                        // Allocate memory for object
+                        var op1 = new AllocObjEntry(mangledEETypeName, allocSize, objVarType);
 
                         // Store allocated memory address into a temp local variable
                         var lclNum = importer.GrabTemp(VarType.Ref, objSize);

--- a/ILCompiler/Runtime/NewObject.asm
+++ b/ILCompiler/Runtime/NewObject.asm
@@ -1,33 +1,17 @@
 ; This routine allocates a new object using the EE Type pointer on top of the stack
 ;
-; Uses: HL, DE, BC, IX
+; Uses: HL, DE, BC
+;
+; On entry: BC = EETypePtr, DE = size to be allocated
 
 NewObject:	
-	POP BC		; Save return address
-
-	;get EE Type pointer into DE
-	POP DE
-
 	; Put address of allocated memory onto stack
 	LD HL, (HEAPNEXT)
 	PUSH HL
 
-	PUSH BC		; put return address back
-
-	PUSH IX		; Save IX
-
-	PUSH DE		; Move DE into IX
-	POP IX
-
-	; Load base size into DE
-	LD D, (IX+1)
-	LD E, (IX+0)
-
 	; Move next available heap address by size of object to allocate
 	ADD HL, DE
-
-	; Save HeapNext
-	PUSH HL	
+	PUSH HL
 
 	; Check if Heap has collided with stack
 	PUSH HL
@@ -42,15 +26,17 @@ NewObject:
 
 	; Store new next available address in HEAPNEXT	
 	POP HL
-	LD (HEAPNEXT), HL	;
+	LD (HEAPNEXT), HL
 
-	PUSH IX		; Move EE Type pointer into BC
-	POP BC
+	; Swap address of allocated memory and return address
+	POP HL	; Address of allocated memory
+	POP DE	; Return address
+	PUSH HL
+	PUSH DE
+
 	LD (HL), B	; Set EE Type pointer in newly allocated space
 	INC HL
 	LD (HL), C
-
-	POP IX		; Restore IX
 
 	RET
 


### PR DESCRIPTION
Revert to taking size as a parameter
Pass parameters in registers instead of on the stack