### PR TITLE
Use EETypePtr with NewString

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/CallCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/CallCodeGenerator.cs
@@ -1,4 +1,5 @@
 ﻿using ILCompiler.Compiler.EvaluationStack;
+using System.Reflection.Metadata.Ecma335;
 using static ILCompiler.Compiler.Emit.Registers;
 
 namespace ILCompiler.Compiler.CodeGenerators
@@ -11,9 +12,9 @@ namespace ILCompiler.Compiler.CodeGenerators
             {
                 if (entry.Arguments.Count > 0)
                 {
-                    // Pass first argument in HL for 2 bytes or less
+                    // Pass last argument in HL for 2 bytes or less
                     // and in HL, DE for larger datatypes
-                    var argument = entry.Arguments[0];
+                    var argument = entry.Arguments[entry.Arguments.Count - 1];
                     context.Emitter.Pop(HL);
                     if (argument.Type == VarType.Int || argument.Type == VarType.UInt)
                     {

--- a/ILCompiler/Compiler/CodeGenerators/NativeIntConstantCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/NativeIntConstantCodeGenerator.cs
@@ -7,11 +7,19 @@ namespace ILCompiler.Compiler.CodeGenerators
     {
         public void GenerateCode(NativeIntConstantEntry entry, CodeGeneratorContext context)
         {
-            var value = (entry as NativeIntConstantEntry).Value;
-            var low = BitConverter.ToInt16(BitConverter.GetBytes(value), 0);
+            if (entry.SymbolName != String.Empty)
+            {
+                context.Emitter.Ld(HL, entry.SymbolName);
+            }
+            else
+            {
+                var value = (entry as NativeIntConstantEntry).Value;
+                var low = BitConverter.ToInt16(BitConverter.GetBytes(value), 0);
 
-            // Native ints are only 16 bit so just push low word
-            context.Emitter.Ld(HL, low);
+                // Native ints are only 16 bit so just push low word
+                context.Emitter.Ld(HL, low);
+            }
+
             context.Emitter.Push(HL);
         }
     }

--- a/ILCompiler/Compiler/DependencyAnalysis/DependencyAnalyser.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/DependencyAnalyser.cs
@@ -155,14 +155,6 @@ namespace ILCompiler.Compiler.DependencyAnalysis
 
                         method = dependentMethod;
                     }
-                    if (methodDef.IsIntrinsic())
-                    {
-                        if (methodDef.DeclaringType.Name == "EETypePtr" && methodDef.DeclaringType.Namespace == "System" && methodDef.Name == "EETypePtrOf")
-                        {
-
-                        }
-                    }
-
                     methodNode = _nodeFactory.MethodNode(method);
                 }
 

--- a/ILCompiler/Compiler/EvaluationStack/ConstantEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/ConstantEntry.cs
@@ -55,13 +55,21 @@
 
     public class NativeIntConstantEntry : ConstantEntry<short>
     {
+        public string SymbolName { get; private set; } = String.Empty;
         public NativeIntConstantEntry(short value, VarType type = VarType.Ptr) : base(type, value, VarType.Ptr.GetTypeSize())
         {
         }
 
+        public NativeIntConstantEntry(string symbol, VarType type = VarType.Ptr) : base(type, 0, VarType.Ptr.GetTypeSize())
+        {
+            SymbolName = symbol;
+        }
+
         public override StackEntry Duplicate()
         {
-            return new NativeIntConstantEntry(Value);
+            var duplicate = new NativeIntConstantEntry(Value);
+            duplicate.SymbolName = SymbolName;
+            return duplicate;
         }
 
         public override void Accept(IStackEntryVisitor visitor)

--- a/ILCompiler/Runtime/NewString.asm
+++ b/ILCompiler/Runtime/NewString.asm
@@ -3,36 +3,48 @@
 ; Uses: HL, DE, BC
 
 ; TODO: Use this in readline too
-STRING_BASE_SIZE		EQU	2
+STRING_BASE_SIZE		EQU 4	; EE TYPE + SIZE = 4 bytes
 
 NewString:	
-	PUSH HL		; Save original size
 
-	; Compute overall size (align(base size + (element size * elements), 4))
-	INC HL		; Multiply elements * element size
+	; On entry HL = original size, stack has EEType
+
+	POP DE		; Return Address
+	POP BC		; EEType
+	PUSH DE		; Restore Return Address
+
+	PUSH HL		; Original Size
+
+	; Compute overall size (align(base size + (element size * elements), 4))	
+	INC HL
 	SLA L
 	RL H
 
-	LD BC, STRING_BASE_SIZE		; Add base size
-	ADD HL, BC
+	; Add base string size
+	LD DE, STRING_BASE_SIZE
+	ADD HL, DE
 
-	PUSH HL
-	CALL NewObjectTemp	; Allocate object
-	POP HL		; Address of new object
+	; Move size in bytes to DE
+	LD D, H
+	LD E, L
 
-	POP BC		; Restore original size
+	; Allocate the string on the heap and set the EEType
+	CALL NEWOBJECT
 
-	POP DE		; Get return address
+	POP HL		; Address of allocated string
+	POP BC		; Original size
 
-	PUSH HL		; Return value is address of new string
-	
-	INC HL		; Skip base size
+	POP DE		; Save return address
+
+	PUSH HL		; Address of allocated string
+
+	INC HL		; skip EE Type
 	INC HL
 
-	LD (HL), C	; Set the size for the new string in the first 2 bytes
+	LD (HL), C	; Set the size for the new string
 	INC HL
 	LD (HL), B
 
-	PUSH DE		; Restore return address
+	PUSH DE		; Restores return address
 
 	RET

--- a/System.Private.CoreLib/System/Runtime/EETypePtr.cs
+++ b/System.Private.CoreLib/System/Runtime/EETypePtr.cs
@@ -11,12 +11,15 @@ namespace System
             _value = value;
         }
 
-        /* TODO : Need to implement this
+        internal IntPtr ToPointer()
+        {
+            return _value;
+        }
+
         [Intrinsic]
-        internal static EETypePtr EETypePtrOf<T>()
+        public static EETypePtr EETypePtrOf<T>()
         {
             throw new Exception();
         }
-        */
     }
 }

--- a/System.Private.CoreLib/System/Runtime/EETypePtr.cs
+++ b/System.Private.CoreLib/System/Runtime/EETypePtr.cs
@@ -11,11 +11,6 @@ namespace System
             _value = value;
         }
 
-        internal IntPtr ToPointer()
-        {
-            return _value;
-        }
-
         [Intrinsic]
         public static EETypePtr EETypePtrOf<T>()
         {

--- a/System.Private.CoreLib/System/Runtime/RuntimeImports.cs
+++ b/System.Private.CoreLib/System/Runtime/RuntimeImports.cs
@@ -6,6 +6,6 @@ namespace System.Runtime
     {
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport("NewString")]
-        public static unsafe extern string NewString(int length);
+        public static unsafe extern string NewString(EETypePtr pEEType, int length);
     }
 }

--- a/System.Private.CoreLib/System/String.Manipulation.cs
+++ b/System.Private.CoreLib/System/String.Manipulation.cs
@@ -7,7 +7,7 @@ namespace System
     {
         public unsafe static string Concat(string str0, string str1)
         {
-            string result = RuntimeImports.NewString(str0.Length + str1.Length);
+            string result = RuntimeImports.NewString(EETypePtr.EETypePtrOf<String>(), str0.Length + str1.Length);
 
             FillStringChecked(result, 0, str0);
             FillStringChecked(result, str0.Length, str1);

--- a/System.Private.CoreLib/System/String.cs
+++ b/System.Private.CoreLib/System/String.cs
@@ -29,7 +29,7 @@ namespace System
 
         public static string Ctor(char[] value)
         {
-            string result = RuntimeImports.NewString(value.Length);
+            string result = RuntimeImports.NewString(EETypePtr.EETypePtrOf<String>(), value.Length);
             Buffer.Memmove(ref result._firstChar, ref value[0], (uint)result.Length);
             return result;
         }

--- a/Tests/CoreLib/CoreLib/StringTests.cs
+++ b/Tests/CoreLib/CoreLib/StringTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime;
+﻿using System;
+using System.Runtime;
 
 namespace CoreLib
 {
@@ -6,7 +7,7 @@ namespace CoreLib
     {
         public static void NewStringTests()
         {
-            string newString = RuntimeImports.NewString(25);
+            string newString = RuntimeImports.NewString(EETypePtr.EETypePtrOf<String>(), 25);
             Assert.Equals(25, newString.Length);
         }
     }


### PR DESCRIPTION
Change NewString to set up the EEType in the allocated string object by using NewObject.
Code calling NewString now passes EETypePtr by using EETypePtr.EETypePtrOf<String>
EETypePtrOf<T> implemented as intrinsic doing simple lookup of EEType and encapsulating in a NativeInt node
Extended NativeInt to support int being represented by assembly symbol