### PR TITLE
Refactor of NewXXX assembly to deal with EETypePtr properly

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/AllocObjCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/AllocObjCodeGenerator.cs
@@ -12,6 +12,7 @@ namespace ILCompiler.Compiler.CodeGenerators
             context.Emitter.Ld(BC, entry.MangledEETypeName);
             context.Emitter.Ld(DE, (ushort)entry.Size);
             context.Emitter.Call("NewObject");
+            context.Emitter.Push(HL);
         }
     }
 }

--- a/ILCompiler/Compiler/Importer/LoadElemAddressImporter.cs
+++ b/ILCompiler/Compiler/Importer/LoadElemAddressImporter.cs
@@ -33,7 +33,7 @@ namespace ILCompiler.Compiler.Importer
             }
 
             // addr + arraySizeOffset + (elemSize * index)
-            var arraySizeOffset = new NativeIntConstantEntry(2);
+            var arraySizeOffset = new NativeIntConstantEntry(4);
             addr = new BinaryOperator(Operation.Add, isComparison: false, addr, arraySizeOffset, VarType.Ptr);
             addr = new BinaryOperator(Operation.Add, isComparison: false, op2, addr, VarType.Ptr);
 

--- a/ILCompiler/Compiler/Importer/LoadElemImporter.cs
+++ b/ILCompiler/Compiler/Importer/LoadElemImporter.cs
@@ -64,7 +64,7 @@ namespace ILCompiler.Compiler.Importer
             var op1 = importer.PopExpression();
             var op2 = importer.PopExpression();
 
-            var node = new IndexRefEntry(op1, op2, elemSize, elemType, 0);
+            var node = new IndexRefEntry(op1, op2, elemSize, elemType, 2);
 
             importer.PushExpression(node);
 

--- a/ILCompiler/Compiler/Importer/LoadLengthImporter.cs
+++ b/ILCompiler/Compiler/Importer/LoadLengthImporter.cs
@@ -10,8 +10,10 @@ namespace ILCompiler.Compiler.Importer
         {
             if (instruction.OpCode.Code != Code.Ldlen) return false;
 
-            var op1 = importer.PopExpression();
-            var node = new IndirectEntry(op1, VarType.UShort, 2);
+            var addr = importer.PopExpression();
+            var arraySizeOffset = new NativeIntConstantEntry(2);
+            addr = new BinaryOperator(Operation.Add, isComparison: false, addr, arraySizeOffset, VarType.Ptr);
+            var node = new IndirectEntry(addr, VarType.UShort, 2);
             importer.PushExpression(node);
             return true;
         }

--- a/ILCompiler/Compiler/Importer/NewarrImporter.cs
+++ b/ILCompiler/Compiler/Importer/NewarrImporter.cs
@@ -17,11 +17,15 @@ namespace ILCompiler.Compiler.Importer
             typeSig = context.Method.ResolveType(typeSig);
             var arrayElementSize = typeSig.GetInstanceFieldSize();
 
+            var elemTypeDef = (instruction.Operand as ITypeDefOrRef).ResolveTypeDefThrow();
+            var mangledEETypeName = context.NameMangler.GetMangledTypeName(elemTypeDef);
+            var eeTypeNode = new NativeIntConstantEntry(mangledEETypeName);
+
             // Instead of creating new node type specifically for arrays
             // could leverage existing CallEntry node to call arbitrary helper functions
             // can use this then for other helper functions too
 
-            var args = new List<StackEntry>() { op2, new Int32ConstantEntry(arrayElementSize) };
+            var args = new List<StackEntry>() { op2, new Int32ConstantEntry(arrayElementSize), eeTypeNode };
             var node = new CallEntry("NewArray", args, VarType.Ref, 2);
             importer.PushExpression(node);
 

--- a/ILCompiler/Compiler/Importer/StoreElemImporter.cs
+++ b/ILCompiler/Compiler/Importer/StoreElemImporter.cs
@@ -63,7 +63,7 @@ namespace ILCompiler.Compiler.Importer
             }
 
             // addr + arraySizeOffset + (elemSize * index)
-            var arraySizeOffset = new NativeIntConstantEntry(2);
+            var arraySizeOffset = new NativeIntConstantEntry(4);
             addr = new BinaryOperator(Operation.Add, isComparison: false, addr, arraySizeOffset, VarType.Ptr);
             addr = new BinaryOperator(Operation.Add, isComparison: false, arrayOp, addr, VarType.Ptr);
 

--- a/ILCompiler/Runtime/NewString.asm
+++ b/ILCompiler/Runtime/NewString.asm
@@ -1,50 +1,48 @@
-; Create a new string of the specified length
+; Allocate a new string
 ;
-; Uses: HL, DE, BC
+; Uses: HL, BC, DE
+;
+; On entry: HL = element count, EETypePtr on stack
+; On exit: HL = pointer to allocated object
 
-; TODO: Use this in readline too
-STRING_BASE_SIZE		EQU 4	; EE TYPE + SIZE = 4 bytes
+NewString:
 
-NewString:	
+	; Save return address
+	POP AF
+	EX AF, AF'
 
-	; On entry HL = original size, stack has EEType
+	; EETypePtr
+	POP BC
 
-	POP DE		; Return Address
-	POP BC		; EEType
-	PUSH DE		; Restore Return Address
-
-	PUSH HL		; Original Size
-
-	; Compute overall size (align(base size + (element size * elements), 4))	
-	INC HL
-	SLA L
-	RL H
-
-	; Add base string size
-	LD DE, STRING_BASE_SIZE
-	ADD HL, DE
-
-	; Move size in bytes to DE
+	; Move element count to DE
 	LD D, H
 	LD E, L
 
-	; Allocate the string on the heap and set the EEType
+	; Save element count
+	PUSH HL
+
+	; Compute overall size (base size + (element size * elements)) where element size = 2, base size = 4
+	INC DE
+	INC DE
+	SLA E
+	RL D
+
+	; Allocate object
 	CALL NEWOBJECT
 
-	POP HL		; Address of allocated string
-	POP BC		; Original size
+	; HL = pointer to allocated object
 
-	POP DE		; Save return address
+	POP DE
+	PUSH HL
 
-	PUSH HL		; Address of allocated string
-
-	INC HL		; skip EE Type
+	; Set the new object's element count
 	INC HL
-
-	LD (HL), C	; Set the size for the new string
 	INC HL
-	LD (HL), B
+	LD (HL), E
+	INC HL
+	LD (HL), D
 
-	PUSH DE		; Restores return address
+	EX AF, AF'
+	PUSH AF		; Restore return address
 
 	RET


### PR DESCRIPTION
Have to pass EETypePtr through to these routines
Modified code for dealing with arrays to deal with extra 2 bytes before the array length
NewArray and NewString use NewObject for heavy lifting
Code tests allocated memory to make sure it doesn't collide with the stack which is the effective max heap