### PR TITLE
Add EEType class

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/CallCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/CallCodeGenerator.cs
@@ -12,11 +12,12 @@ namespace ILCompiler.Compiler.CodeGenerators
             {
                 if (entry.Arguments.Count > 0)
                 {
-                    // Pass last argument in HL for 2 bytes or less
-                    // and in HL, DE for larger datatypes
+                    // Pass last argument in HL for Ptr type
+                    // and in HL, DE otherwise
                     var argument = entry.Arguments[entry.Arguments.Count - 1];
                     context.Emitter.Pop(HL);
-                    if (argument.Type == VarType.Int || argument.Type == VarType.UInt)
+
+                    if (argument.Type != VarType.Ptr && argument.Type != VarType.Ref) // TODO: should this also check for ByRef??
                     {
                         context.Emitter.Pop(DE);
                     }

--- a/ILCompiler/Runtime/GCGetTotalMemory.asm
+++ b/ILCompiler/Runtime/GCGetTotalMemory.asm
@@ -11,6 +11,7 @@ GCGetTotalMemory:
 	; Calculate memory used on heap
 	LD HL, (HEAPNEXT)
 	LD DE, HEAP
+	OR A
 	SBC HL, DE
 	PUSH HL		; LSW
 

--- a/ILCompiler/Runtime/NewString.asm
+++ b/ILCompiler/Runtime/NewString.asm
@@ -2,7 +2,7 @@
 ;
 ; Uses: HL, BC, DE
 ;
-; On entry: HL = element count, EETypePtr on stack
+; On entry: HL, DE = element code, EETypePtr on stack
 ; On exit: HL = pointer to allocated object
 
 NewString:

--- a/System.Private.CoreLib/Internal/Runtime/EEType.cs
+++ b/System.Private.CoreLib/Internal/Runtime/EEType.cs
@@ -1,0 +1,7 @@
+﻿namespace Internal.Runtime
+{
+    internal struct EEType
+    {
+        private ushort _uBaseSize;
+    }
+}

--- a/System.Private.CoreLib/System/Object.cs
+++ b/System.Private.CoreLib/System/Object.cs
@@ -1,7 +1,9 @@
-﻿namespace System
+﻿using Internal.Runtime;
+
+namespace System
 {
-    public class Object
+    public unsafe class Object
     {
-        public IntPtr m_pEEType;
+        internal EEType* m_pEEType;
     }
 }

--- a/System.Private.CoreLib/System/Runtime/EETypePtr.cs
+++ b/System.Private.CoreLib/System/Runtime/EETypePtr.cs
@@ -1,18 +1,12 @@
-﻿using System.Runtime.CompilerServices;
+﻿using Internal.Runtime;
+using System.Runtime.CompilerServices;
 
 namespace System
 {
-    public struct EETypePtr
+    public unsafe struct EETypePtr
     {
-        private IntPtr _value;
-
-        internal EETypePtr(IntPtr value)
-        {
-            _value = value;
-        }
-
         [Intrinsic]
-        public static EETypePtr EETypePtrOf<T>()
+        internal static EEType* EETypePtrOf<T>()
         {
             throw new Exception();
         }

--- a/System.Private.CoreLib/System/Runtime/RuntimeImports.cs
+++ b/System.Private.CoreLib/System/Runtime/RuntimeImports.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using Internal.Runtime;
+using System.Runtime.CompilerServices;
 
 namespace System.Runtime
 {
@@ -6,6 +7,6 @@ namespace System.Runtime
     {
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport("NewString")]
-        public static unsafe extern string NewString(EETypePtr pEEType, int length);
+        internal static unsafe extern string NewString(EEType* pEEType, int length);
     }
 }

--- a/System.Private.CoreLib/System/String.cs
+++ b/System.Private.CoreLib/System/String.cs
@@ -27,7 +27,7 @@ namespace System
             }
         }
 
-        public static string Ctor(char[] value)
+        internal unsafe static string Ctor(char[] value)
         {
             string result = RuntimeImports.NewString(EETypePtr.EETypePtrOf<String>(), value.Length);
             Buffer.Memmove(ref result._firstChar, ref value[0], (uint)result.Length);

--- a/Tests/CoreLib/CoreLib/AllocTests.cs
+++ b/Tests/CoreLib/CoreLib/AllocTests.cs
@@ -1,0 +1,84 @@
+﻿using System;
+
+namespace CoreLib
+{
+    public static class AllocTests
+    {
+        private class TestClass
+        {
+            private int field1;
+            private bool field2;
+            private bool field3;
+        }
+
+        // Very unsafe method to get EEType of a managed object
+        // This is not GC safe
+        static unsafe ushort GetEEType(object obj)
+        {
+            var objectptr = *(void**)Internal.Runtime.CompilerServices.Unsafe.AsPointer(ref obj);
+            var eetypeptr = *((ushort*)objectptr);
+
+            return eetypeptr;
+        }
+
+        static public void AllocSizeTests()
+        {
+            // This is not GC safe
+
+            var totalMemory = GC.GetTotalMemory();
+
+            var chars = new char[5];
+
+            // intptr   EEType      2
+            // ushort   length      2
+            // char     elements    5 x 2
+            // -----------------------
+            // Total                14
+
+            Assert.AreEquals(14, GC.GetTotalMemory() - totalMemory);
+
+            totalMemory = GC.GetTotalMemory();
+            
+            var str1 = new String(chars);
+
+            // intptr   EEType      2
+            // ushort   length      2
+            // char     elements    5 x 2
+            // -----------------------
+            // Total                14
+
+            Assert.AreEquals(14, GC.GetTotalMemory() - totalMemory);
+
+            totalMemory = GC.GetTotalMemory();
+
+            var obj = new TestClass();
+
+            // intptr   EEType      2
+            // int      field1      4
+            // bool     field2      1
+            // bool     field3      1 + 2 padding for int alignment
+            // -----------------------
+            //                      10
+
+            Assert.AreEquals(10, GC.GetTotalMemory() - totalMemory);
+        }
+
+        static public void AllocEETypeTests()
+        {
+            var str1 = new String(new char[5]);
+            var str2 = new String(new char[3]);
+
+            // Check EEType is same for both string objects
+            Assert.AreEquals(GetEEType(str1), GetEEType(str2));
+
+            var class1 = new TestClass();
+            var class2 = new TestClass();
+
+            // Check EEType is same for both instances of TestClass
+            Assert.AreEquals(GetEEType(class1), GetEEType(class2));
+
+            // Check EEType is different for String and TestClass instances
+            Assert.AreNotEquals(GetEEType(str1), GetEEType(class1));
+        }
+    }
+}

--- a/Tests/CoreLib/CoreLib/AllocTests.cs
+++ b/Tests/CoreLib/CoreLib/AllocTests.cs
@@ -21,24 +21,11 @@ namespace CoreLib
             return eetypeptr;
         }
 
-        static public void AllocSizeTests()
+        private static void AllocStringSizeTest(char[] chars)
         {
             // This is not GC safe
-
             var totalMemory = GC.GetTotalMemory();
 
-            var chars = new char[5];
-
-            // intptr   EEType      2
-            // ushort   length      2
-            // char     elements    5 x 2
-            // -----------------------
-            // Total                14
-
-            Assert.AreEquals(14, GC.GetTotalMemory() - totalMemory);
-
-            totalMemory = GC.GetTotalMemory();
-            
             var str1 = new String(chars);
 
             // intptr   EEType      2
@@ -48,8 +35,12 @@ namespace CoreLib
             // Total                14
 
             Assert.AreEquals(14, GC.GetTotalMemory() - totalMemory);
+        }
 
-            totalMemory = GC.GetTotalMemory();
+        private static void AllocObjectSizeTest()
+        {
+            // This is not GC safe
+            var totalMemory = GC.GetTotalMemory();
 
             var obj = new TestClass();
 
@@ -61,6 +52,29 @@ namespace CoreLib
             //                      10
 
             Assert.AreEquals(10, GC.GetTotalMemory() - totalMemory);
+        }
+
+        private static void AllocArraySizeTest()
+        {
+            // This is not GC safe
+            var totalMemory = GC.GetTotalMemory();
+
+            var chars = new char[5];
+
+            // intptr   EEType      2
+            // ushort   length      2
+            // char     elements    5 x 2
+            // -----------------------
+            // Total                14
+
+            Assert.AreEquals(14, GC.GetTotalMemory() - totalMemory);
+        }
+
+        static public void AllocSizeTests()
+        {
+            AllocArraySizeTest();
+            AllocStringSizeTest(new char[5]);
+            AllocObjectSizeTest();
         }
 
         static public void AllocEETypeTests()

--- a/Tests/CoreLib/CoreLib/Assert.cs
+++ b/Tests/CoreLib/CoreLib/Assert.cs
@@ -4,7 +4,7 @@ namespace CoreLib
 {
     internal static class Assert
     {
-        public static void Equals(bool expected, bool actual)
+        public static void AreEquals(bool expected, bool actual)
         {
             if (expected != actual)
             {
@@ -12,9 +12,17 @@ namespace CoreLib
             }
         }
 
-        public static void Equals(int expected, int actual)
+        public static void AreEquals(int expected, int actual)
         {
             if (expected != actual)
+            {
+                Environment.Exit(1);
+            }
+        }
+
+        public static void AreNotEquals(int expected, int actual)
+        {
+            if (expected == actual)
             {
                 Environment.Exit(1);
             }

--- a/Tests/CoreLib/CoreLib/CharTests.cs
+++ b/Tests/CoreLib/CoreLib/CharTests.cs
@@ -4,20 +4,20 @@
     {
         public static void IsBetweenCharTests()
         {
-            Assert.Equals(true, char.IsBetween('a', 'a', 'a'));
-            Assert.Equals(false, char.IsBetween((char)('a' - 1), 'a', 'a'));
-            Assert.Equals(false, char.IsBetween((char)('a' + 1), 'a', 'a'));
-            Assert.Equals(true, char.IsBetween('a', 'a', 'b'));
-            Assert.Equals(true, char.IsBetween('b', 'a', 'b'));
-            Assert.Equals(false, char.IsBetween((char)('a' - 1), 'a', 'b'));
-            Assert.Equals(false, char.IsBetween((char)('b' + 1), 'a', 'b'));
-            Assert.Equals(true, char.IsBetween('a', 'a', 'z'));
-            Assert.Equals(true, char.IsBetween('m', 'a', 'z'));
-            Assert.Equals(true, char.IsBetween('z', 'a', 'z'));
-            Assert.Equals(false, char.IsBetween((char)('a' - 1), 'a', 'z'));
-            Assert.Equals(false, char.IsBetween((char)('z' + 1), 'a', 'z'));
-            Assert.Equals(false, char.IsBetween('b', 'c', 'd'));
-            Assert.Equals(true, char.IsBetween('b', 'd', 'c'));
+            Assert.AreEquals(true, char.IsBetween('a', 'a', 'a'));
+            Assert.AreEquals(false, char.IsBetween((char)('a' - 1), 'a', 'a'));
+            Assert.AreEquals(false, char.IsBetween((char)('a' + 1), 'a', 'a'));
+            Assert.AreEquals(true, char.IsBetween('a', 'a', 'b'));
+            Assert.AreEquals(true, char.IsBetween('b', 'a', 'b'));
+            Assert.AreEquals(false, char.IsBetween((char)('a' - 1), 'a', 'b'));
+            Assert.AreEquals(false, char.IsBetween((char)('b' + 1), 'a', 'b'));
+            Assert.AreEquals(true, char.IsBetween('a', 'a', 'z'));
+            Assert.AreEquals(true, char.IsBetween('m', 'a', 'z'));
+            Assert.AreEquals(true, char.IsBetween('z', 'a', 'z'));
+            Assert.AreEquals(false, char.IsBetween((char)('a' - 1), 'a', 'z'));
+            Assert.AreEquals(false, char.IsBetween((char)('z' + 1), 'a', 'z'));
+            Assert.AreEquals(false, char.IsBetween('b', 'c', 'd'));
+            Assert.AreEquals(true, char.IsBetween('b', 'd', 'c'));
         }
 
         public static void IsAsciiDigit_WithAsciiDigits_ReturnsTrue()
@@ -27,7 +27,7 @@
             for (int i = 0; i < validAsciiDigits.Length; i++) 
             { 
                 char ch = validAsciiDigits[i];
-                Assert.Equals(true, char.IsAsciiDigit(ch));
+                Assert.AreEquals(true, char.IsAsciiDigit(ch));
             }
         }
 
@@ -58,7 +58,7 @@
             for (int i = 0; i < invalidAsciiDigits.Length; i++)
             {
                 char ch = invalidAsciiDigits[i];
-                Assert.Equals(false, char.IsAsciiDigit(ch));
+                Assert.AreEquals(false, char.IsAsciiDigit(ch));
             }
         }
     }

--- a/Tests/CoreLib/CoreLib/CoreLib.cs
+++ b/Tests/CoreLib/CoreLib/CoreLib.cs
@@ -20,7 +20,7 @@
             UnsafeTests.CopyBlockTests();
 
             AllocTests.AllocEETypeTests();
-            //AllocTests.AllocSizeTests();
+            AllocTests.AllocSizeTests();
 
             return 0;
         }

--- a/Tests/CoreLib/CoreLib/CoreLib.cs
+++ b/Tests/CoreLib/CoreLib/CoreLib.cs
@@ -19,6 +19,9 @@
             UnsafeTests.InitBlockTests();
             UnsafeTests.CopyBlockTests();
 
+            AllocTests.AllocEETypeTests();
+            AllocTests.AllocSizeTests();
+
             return 0;
         }
     }

--- a/Tests/CoreLib/CoreLib/CoreLib.cs
+++ b/Tests/CoreLib/CoreLib/CoreLib.cs
@@ -20,7 +20,7 @@
             UnsafeTests.CopyBlockTests();
 
             AllocTests.AllocEETypeTests();
-            AllocTests.AllocSizeTests();
+            //AllocTests.AllocSizeTests();
 
             return 0;
         }

--- a/Tests/CoreLib/CoreLib/Int32Tests.cs
+++ b/Tests/CoreLib/CoreLib/Int32Tests.cs
@@ -4,15 +4,15 @@
     {
         public static void Parse_Valid()
         {
-            Assert.Equals(0, int.Parse("0"));
-            Assert.Equals(0, int.Parse("0000000000000000000000000000000000000000000000000000000000"));
-            Assert.Equals(1, int.Parse("0000000000000000000000000000000000000000000000000000000001"));
-            Assert.Equals(2147483647, int.Parse("2147483647"));
-            Assert.Equals(2147483647, int.Parse("02147483647"));
-            Assert.Equals(2147483647, int.Parse("00000000000000000000000000000000000000000000000002147483647"));
-            Assert.Equals(123, int.Parse("123\0\0"));
+            Assert.AreEquals(0, int.Parse("0"));
+            Assert.AreEquals(0, int.Parse("0000000000000000000000000000000000000000000000000000000000"));
+            Assert.AreEquals(1, int.Parse("0000000000000000000000000000000000000000000000000000000001"));
+            Assert.AreEquals(2147483647, int.Parse("2147483647"));
+            Assert.AreEquals(2147483647, int.Parse("02147483647"));
+            Assert.AreEquals(2147483647, int.Parse("00000000000000000000000000000000000000000000000002147483647"));
+            Assert.AreEquals(123, int.Parse("123\0\0"));
 
-            Assert.Equals(123, int.Parse("123"));
+            Assert.AreEquals(123, int.Parse("123"));
         }
     }
 }

--- a/Tests/CoreLib/CoreLib/StringTests.cs
+++ b/Tests/CoreLib/CoreLib/StringTests.cs
@@ -1,13 +1,13 @@
 ﻿using System;
-using System.Runtime;
 
 namespace CoreLib
 {
     public class StringTests
     {
-        public static void NewStringTests()
+        public static unsafe void NewStringTests()
         {
-            string newString = RuntimeImports.NewString(EETypePtr.EETypePtrOf<String>(), 25);
+            var chars = new char[25];
+            string newString = new String(chars);
             Assert.Equals(25, newString.Length);
         }
     }

--- a/Tests/CoreLib/CoreLib/StringTests.cs
+++ b/Tests/CoreLib/CoreLib/StringTests.cs
@@ -8,7 +8,7 @@ namespace CoreLib
         {
             var chars = new char[25];
             string newString = new String(chars);
-            Assert.Equals(25, newString.Length);
+            Assert.AreEquals(25, newString.Length);
         }
     }
 }

--- a/Tests/CoreLib/CoreLib/UnsafeTests.cs
+++ b/Tests/CoreLib/CoreLib/UnsafeTests.cs
@@ -29,7 +29,7 @@ namespace CoreLib
         public unsafe static void InitBlockTests()
         {
             // TODO: Fix this when bug with stackalloc of size 0 fixed
-            // InitBlockStack(0, 1);
+            InitBlockStack(0, 1);
             InitBlockStack(1, 1);
             InitBlockStack(10, 0);           
             InitBlockStack(10, 2);
@@ -78,13 +78,10 @@ namespace CoreLib
             ref int r = ref Unsafe.As<byte, int>(ref testBytes.B0);
             Assert.Equals(0x42424242, r);
 
-            /*
-             * TODO: This needs ldelema to be implemented
             byte[] b = new byte[4] { 0x42, 0x42, 0x42, 0x42 };
-            ref int r = ref Unsafe.As<byte, int>(ref b[0]);
+            ref int r2 = ref Unsafe.As<byte, int>(ref b[0]);
 
-            Assert.Equals(0x42424242, r);
-            */
+            Assert.Equals(0x42424242, r2);
         }
     }
 

--- a/Tests/CoreLib/CoreLib/UnsafeTests.cs
+++ b/Tests/CoreLib/CoreLib/UnsafeTests.cs
@@ -6,14 +6,14 @@ namespace CoreLib
     {
         public static void SizeOfTests()
         {
-            Assert.Equals(1, Unsafe.SizeOf<sbyte>());
-            Assert.Equals(1, Unsafe.SizeOf<byte>());
-            Assert.Equals(2, Unsafe.SizeOf<short>());
-            Assert.Equals(2, Unsafe.SizeOf<ushort>());
-            Assert.Equals(4, Unsafe.SizeOf<int>());
-            Assert.Equals(4, Unsafe.SizeOf<uint>());
-            Assert.Equals(4, Unsafe.SizeOf<Byte4>());
-            Assert.Equals(8, Unsafe.SizeOf<Byte4Short2>());
+            Assert.AreEquals(1, Unsafe.SizeOf<sbyte>());
+            Assert.AreEquals(1, Unsafe.SizeOf<byte>());
+            Assert.AreEquals(2, Unsafe.SizeOf<short>());
+            Assert.AreEquals(2, Unsafe.SizeOf<ushort>());
+            Assert.AreEquals(4, Unsafe.SizeOf<int>());
+            Assert.AreEquals(4, Unsafe.SizeOf<uint>());
+            Assert.AreEquals(4, Unsafe.SizeOf<Byte4>());
+            Assert.AreEquals(8, Unsafe.SizeOf<Byte4Short2>());
         }
 
         private static unsafe void InitBlockStack(int numBytes, byte value)
@@ -22,13 +22,12 @@ namespace CoreLib
             Unsafe.InitBlock(stackPtr, value, (uint)numBytes);
             for (int i = 0; i < numBytes; i++) 
             {
-                Assert.Equals(value, stackPtr[i]);
+                Assert.AreEquals(value, stackPtr[i]);
             }
         }
 
         public unsafe static void InitBlockTests()
         {
-            // TODO: Fix this when bug with stackalloc of size 0 fixed
             InitBlockStack(0, 1);
             InitBlockStack(1, 1);
             InitBlockStack(10, 0);           
@@ -53,8 +52,8 @@ namespace CoreLib
             for (int i = 0; i < numBytes; i++)
             {
                 byte value = (byte)(i & 255);
-                Assert.Equals(value, destination[i]);
-                Assert.Equals(source[i], destination[i]);
+                Assert.AreEquals(value, destination[i]);
+                Assert.AreEquals(source[i], destination[i]);
             }
         }
 
@@ -76,12 +75,12 @@ namespace CoreLib
             testBytes.B3 = 0x42;
 
             ref int r = ref Unsafe.As<byte, int>(ref testBytes.B0);
-            Assert.Equals(0x42424242, r);
+            Assert.AreEquals(0x42424242, r);
 
             byte[] b = new byte[4] { 0x42, 0x42, 0x42, 0x42 };
             ref int r2 = ref Unsafe.As<byte, int>(ref b[0]);
 
-            Assert.Equals(0x42424242, r2);
+            Assert.AreEquals(0x42424242, r2);
         }
     }
 


### PR DESCRIPTION
Fix bug with call code gen not passing last parameter correctly via registers to internalcall methods
Add tests to validate managed heap allocation.
Make a few things internal to avoid exposing EEType