### PR TITLE
Import of call nodes needs to spill existing stack entries to ensure preservation of evaluation order

### DIFF
--- a/ILCompiler/Compiler/ILImporter.cs
+++ b/ILCompiler/Compiler/ILImporter.cs
@@ -98,27 +98,19 @@ namespace ILCompiler.Compiler
 
         private void ImportSpillAppendTree(StackEntry entry)
         {
-            // If we have an assignment and the variable being assigned to
-            // has prior loads on the evaluation stack then we need to ensure
-            // these loads are completed before the variable is modified
-            if (entry is StoreLocalVariableEntry)
-            {
-                // TODO: Do we need to check that variable being assigned to is a struct type?
-
-                // Convert loads into assignmented to new temps
-                ImportSpillLocalReferences(entry.As<StoreLocalVariableEntry>().LocalNumber);
-            }
+            // Spill any existing stack entries to temps to preserve evaluation order
+            ImportSpillStackEntries();
             ImportAppendTree(entry);
         }
 
-        private void ImportSpillLocalReferences(int localNumber)
+        private void ImportSpillStackEntries()
         {
             for (int i = 0; i < _stack.Length; i++)
             {
                 // TODO: Check if this evaluation stack entry refers to the local to spill
                 // if not then it can be skipped otherwise ...
 
-                // Create an assignment node from the spilled local var to a new temp
+                // Create an assignment node from the spilled stack entry to a new temp
                 // The return value is a local var node for the new temp
                 var tempLocalVar = ImportSpillStackEntry(_stack[i], null);
 

--- a/ILCompiler/Compiler/Importer/CallImporter.cs
+++ b/ILCompiler/Compiler/Importer/CallImporter.cs
@@ -130,13 +130,13 @@ namespace ILCompiler.Compiler.Importer
 
             if (!methodToCall.HasReturnType)
             {
-                importer.ImportAppendTree(callNode);
+                importer.ImportAppendTree(callNode, true);
             }
             else
             {
                 if (returnType.IsStruct())
                 {
-                    importer.ImportAppendTree(callNode);
+                    importer.ImportAppendTree(callNode, true);
 
                     // Load return buffer to stack
                     var loadTemp = new LocalVariableEntry(returnBufferArgIndex, returnType.GetVarType(), returnType.GetInstanceFieldSize());

--- a/Tests/ILCompiler.IntegrationTests/il_bvt/out_of_order.il
+++ b/Tests/ILCompiler.IntegrationTests/il_bvt/out_of_order.il
@@ -1,0 +1,59 @@
+﻿.assembly extern System.Private.CoreLib as mscorlib
+{
+    .ver 0:0:0:0
+}
+
+.assembly TestAssembly
+{
+	.ver 0:0:0:0
+}
+.class public OutOfOrder
+{
+    .field private static int32 o
+    .field private static int32 t1_order
+    .field private static int32 t2_order
+
+	.method public static void T1() {
+		.maxstack 8
+			ldsfld int32 OutOfOrder::o
+			dup
+			ldc.i4.1
+			add
+			stsfld int32 OutOfOrder::o
+			stsfld int32 OutOfOrder::t1_order
+			ret
+	}
+
+	.method public static char[] T2() {
+		.maxstack 8
+			ldsfld int32 OutOfOrder::o
+			dup
+			ldc.i4.1
+			add
+			stsfld int32 OutOfOrder::o
+			stsfld int32 OutOfOrder::t2_order
+			ldc.i4.5
+			newarr [mscorlib]System.Char
+			ret
+	}
+
+.method public static int32 Main() {
+.entrypoint
+.maxstack  5
+.locals ()
+	call char[] OutOfOrder::T2()
+	call void OutOfOrder::T1()
+	newobj instance void [mscorlib]System.String::.ctor(char[])
+	pop
+	ldsfld int32 OutOfOrder::t1_order
+	ldsfld int32 OutOfOrder::t2_order
+	cgt
+	brfalse FAIL
+PASS:
+	ldc.i4 0x0000
+	ret
+FAIL:
+	ldc.i4 0x0001
+	ret
+}
+}


### PR DESCRIPTION
Changed import of call instructions to spill existing stack entries when:
* method called has void return type
* method called has struct return type, return value is effectively void as return struct is passed by return buffer.

Added IL based test to check evaluation order is preserved with calls