### PR TITLE
Fix codegen for NonGC strings to include correct EEType pointer

### DIFF
--- a/ILCompiler/Compiler/Compilation.cs
+++ b/ILCompiler/Compiler/Compilation.cs
@@ -3,6 +3,7 @@ using ILCompiler.Compiler.DependencyAnalysis;
 using ILCompiler.Interfaces;
 using ILCompiler.IoC;
 using Microsoft.Extensions.Logging;
+using System.Runtime.CompilerServices;
 
 namespace ILCompiler.Compiler
 {
@@ -13,14 +14,16 @@ namespace ILCompiler.Compiler
         private readonly Factory<IMethodCompiler> _methodCompilerFactory;
         private readonly Z80Writer _z80Writer;
         private readonly TypeDependencyAnalyser _typeDependencyAnalyser;
+        private readonly CorLibModuleProvider _corLibModuleProvider;
 
-        public Compilation(IConfiguration configuration, ILogger<Compilation> logger, Factory<IMethodCompiler> methodCompilerFactory, Z80Writer z80Writer, TypeDependencyAnalyser typeDependencyAnalyser)
+        public Compilation(IConfiguration configuration, ILogger<Compilation> logger, Factory<IMethodCompiler> methodCompilerFactory, Z80Writer z80Writer, TypeDependencyAnalyser typeDependencyAnalyser, CorLibModuleProvider corLibModuleProvider)
         {
             _configuration = configuration;
             _logger = logger;
             _methodCompilerFactory = methodCompilerFactory;
             _z80Writer = z80Writer;
             _typeDependencyAnalyser = typeDependencyAnalyser;
+            _corLibModuleProvider = corLibModuleProvider;
         }
 
         public void Compile(string inputFilePath, string outputFilePath)
@@ -44,6 +47,8 @@ namespace ILCompiler.Compiler
                 CorLibAssemblyRef = corlibModule.Assembly.ToAssemblyRef()
             };
             ModuleDefMD module = ModuleDefMD.Load(inputFilePath, options);
+
+            _corLibModuleProvider.CorLibModule = corlibModule;
 
             var rootNode = _typeDependencyAnalyser.AnalyseDependencies(module.EntryPoint);
 

--- a/ILCompiler/Compiler/CorLibModuleProvider.cs
+++ b/ILCompiler/Compiler/CorLibModuleProvider.cs
@@ -24,6 +24,6 @@ namespace ILCompiler.Compiler
         public CorLibTypeResolutionException() { }
         public CorLibTypeResolutionException(string message) : base(message) { }
         public CorLibTypeResolutionException(string message, Exception innerException) : base(message, innerException) { }
-        public CorLibTypeResolutionException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+        protected CorLibTypeResolutionException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }

--- a/ILCompiler/Compiler/CorLibModuleProvider.cs
+++ b/ILCompiler/Compiler/CorLibModuleProvider.cs
@@ -1,0 +1,19 @@
+﻿using dnlib.DotNet;
+
+namespace ILCompiler.Compiler
+{
+    public class CorLibModuleProvider
+    {
+        public ModuleDefMD? CorLibModule { get; set; }
+        public TypeDef FindThrow(string name)
+        {
+            var typeDef = CorLibModule?.Find(name, false);
+            if (typeDef is not null)
+            {
+                return typeDef;
+            }
+
+            throw new NullReferenceException("System.String type cannot be found in corlib module");
+        }
+    }
+}

--- a/ILCompiler/Compiler/CorLibModuleProvider.cs
+++ b/ILCompiler/Compiler/CorLibModuleProvider.cs
@@ -1,4 +1,5 @@
 ﻿using dnlib.DotNet;
+using System.Runtime.Serialization;
 
 namespace ILCompiler.Compiler
 {
@@ -13,7 +14,16 @@ namespace ILCompiler.Compiler
                 return typeDef;
             }
 
-            throw new NullReferenceException("System.String type cannot be found in corlib module");
+            throw new CorLibTypeResolutionException("System.String type cannot be found in corlib module");
         }
+    }
+
+    [Serializable]
+    public class CorLibTypeResolutionException : Exception
+    {
+        public CorLibTypeResolutionException() { }
+        public CorLibTypeResolutionException(string message) : base(message) { }
+        public CorLibTypeResolutionException(string message, Exception innerException) : base(message, innerException) { }
+        public CorLibTypeResolutionException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }

--- a/ILCompiler/Compiler/DependencyAnalysis/TypeDependencyAnalyser.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/TypeDependencyAnalyser.cs
@@ -7,11 +7,13 @@ namespace ILCompiler.Compiler.DependencyAnalysis
     {
         private readonly ILogger<TypeDependencyAnalyser> _logger;
         private readonly NodeFactory _nodeFactory;
+        private readonly CorLibModuleProvider _corLibModuleProvider;
 
-        public TypeDependencyAnalyser(ILogger<TypeDependencyAnalyser> logger)
+        public TypeDependencyAnalyser(ILogger<TypeDependencyAnalyser> logger, CorLibModuleProvider corLibModuleProvider)
         {
             _logger = logger;
             _nodeFactory = new NodeFactory();
+            _corLibModuleProvider = corLibModuleProvider;
         }
 
         private void AnalyzeDependenciesForMethodCodeNode(Z80MethodCodeNode codeNode)
@@ -19,7 +21,7 @@ namespace ILCompiler.Compiler.DependencyAnalysis
             _logger.LogDebug("Analysing dependencies for {methodFullName}", codeNode.Method.FullName);
             codeNode.Analysed = true;
 
-            var dependencyAnalyser = new DependencyAnalyser(codeNode.Method, _nodeFactory);
+            var dependencyAnalyser = new DependencyAnalyser(codeNode.Method, _nodeFactory, _corLibModuleProvider);
             var dependencies = dependencyAnalyser.FindDependencies();
 
             foreach (var dependentMethod in dependencies)

--- a/ILCompiler/Compiler/Emit/Emitter.cs
+++ b/ILCompiler/Compiler/Emit/Emitter.cs
@@ -69,6 +69,7 @@ namespace ILCompiler.Compiler.Emit
         public void Db(string source) => EmitInstruction(Instruction.CreateDeclareByte(Opcode.Db, source));
         public void Db(string label, string source) => EmitInstruction(Instruction.CreateDeclareByte(Opcode.Db, source, label));
         public void Db(byte b) => EmitInstruction(Instruction.Create(Opcode.Db, b));
+        public void Dw(string source) => EmitInstruction(Instruction.CreateDeclareWord(Opcode.Dw, source));
         public void Defs(ushort size) => EmitInstruction(Instruction.Create(Opcode.Defs, size));
         public void Dc(ushort count, ushort value) => EmitInstruction(Instruction.Create(Opcode.Dc, count, value));
         public void Org(ushort target) => EmitInstruction(Instruction.Create(Opcode.Org, target));

--- a/ILCompiler/Compiler/Emit/Instruction.cs
+++ b/ILCompiler/Compiler/Emit/Instruction.cs
@@ -98,5 +98,8 @@ namespace ILCompiler.Compiler.Emit
             => new() { Label = label, Opcode = opcode, Op0 = new() { Data = data } };
         public static Instruction CreateDeclareByte(Opcode opcode, string data)
             => new() { Opcode = opcode, Op0 = new() { Data = data } };
+
+        public static Instruction CreateDeclareWord(Opcode opcode, string label)
+            => new() { Opcode = opcode, Op0 = new() { Label = label } };
     }
 }

--- a/ILCompiler/Compiler/Emit/Opcode.cs
+++ b/ILCompiler/Compiler/Emit/Opcode.cs
@@ -10,6 +10,7 @@
         Db,
         Defs,
         Dc,
+        Dw,
 
         Adc,
         Add,

--- a/ILCompiler/IoC/ServiceProviderFactory.cs
+++ b/ILCompiler/IoC/ServiceProviderFactory.cs
@@ -61,6 +61,8 @@ namespace ILCompiler.IoC
 
             services.AddSingleton<RTILProvider>();
 
+            services.AddSingleton<CorLibModuleProvider>();
+
             _serviceProvider = services.BuildServiceProvider();
 
             return ServiceProvider;


### PR DESCRIPTION
For NonGC/Frozen strings the EEType needs to be set to the EEType pointe for System.String
Dependency analysis will include constructed dependency on System.String if ldstr used as EEType required in NonGC strings