### PR TITLE
Spectrum auto scrolling

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/IntrinsicCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/IntrinsicCodeGenerator.cs
@@ -1,4 +1,5 @@
 ﻿using ILCompiler.Compiler.EvaluationStack;
+using Microsoft.Extensions.Configuration;
 using static ILCompiler.Compiler.Emit.Registers;
 
 namespace ILCompiler.Compiler.CodeGenerators
@@ -38,6 +39,8 @@ namespace ILCompiler.Compiler.CodeGenerators
                         context.Emitter.Pop(HL);    // chars are stored on stack as int32 so remove MSW
                         context.Emitter.Ld(A, L); // Load low byte of argument 1 into A
                         context.Emitter.Rst(0x0010); // ROM routine to display character at current cursor position
+                        context.Emitter.Ld(A, 255);
+                        context.Emitter.Ld(__[23692], A);
                     }
                     break;
 

--- a/ILCompiler/Compiler/Emit/Emitter.cs
+++ b/ILCompiler/Compiler/Emit/Emitter.cs
@@ -60,7 +60,7 @@ namespace ILCompiler.Compiler.Emit
         public void Push(Register16 register) => EmitInstruction(Instruction.Create(Opcode.Push, register));
         public void Ret() => EmitInstruction(Instruction.Create(Opcode.Ret));
         public void Rr(Register8 target) => EmitInstruction(Instruction.Create(Opcode.Rr, target));
-        public void Rst(ushort target) => EmitInstruction(Instruction.Create(Opcode.Call, target));
+        public void Rst(ushort target) => EmitInstruction(Instruction.Create(Opcode.Rst, target));
         public void Sbc(Register16 target, Register16 source) => EmitInstruction(Instruction.Create(Opcode.Sbc, target, source));
         public void Sbc(Register8 target, Register8 source) => EmitInstruction(Instruction.Create(Opcode.Sbc, target, source));
         public void Srl(Register8 target) => EmitInstruction(Instruction.Create(Opcode.Srl, target));

--- a/ILCompiler/Runtime/NewString.asm
+++ b/ILCompiler/Runtime/NewString.asm
@@ -2,7 +2,7 @@
 ;
 ; Uses: HL, BC, DE
 ;
-; On entry: HL, DE = element code, EETypePtr on stack
+; On entry: HL = element count, EETypePtr on stack
 ; On exit: HL = pointer to allocated object
 
 NewString:

--- a/ILCompiler/Runtime/ZXSpectrum/printchr.asm
+++ b/ILCompiler/Runtime/ZXSpectrum/printchr.asm
@@ -1,7 +1,10 @@
+SCR_CT	EQU 23692	; Scroll Count
+
 PRINTCHR:
-	PUSH DE
-	PUSH HL
 	RST 0x10
-	POP HL
-	POP DE
+
+	; Reset Scroll count to prevent scroll? message
+	LD A, 255
+	LD (SCR_CT), A
+
 	RET


### PR DESCRIPTION
ZX Spectrum displays "scroll?" message and waits for user input when bottom of screen is reached.
To avoid this we have to constantly update the scroll count memory location when writing characters to the console.
