### PR TITLE
Update readme to add how to use instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,20 @@
 
 ![Build Status](https://github.com/drcjt/csharp-80/actions/workflows/build.yml/badge.svg)
 
-This repo contains a .NET ahead of time compiler targetting the Z80 8-bit microprocessor. The compiler converts managed .NET applications into assembly language which is subsequently assembled using the [zmac](http://48k.ca/zmac.html) assembler. To learn more about CSharp-80, see the
-[intro document](Documentation/intro-to-csharp-80.md) and read the [blog](https://csharpdot80.wordpress.com/)
+This repo contains a .NET ahead of time compiler targetting the Z80 8-bit microprocessor. The compiler converts managed .NET assemblies into Z80 assembly language 
+which is subsequently assembled using the [zmac](http://48k.ca/zmac.html) assembler. To learn more about CSharp-80, see the
+[intro document](Documentation/intro-to-csharp-80.md). Currently there is support for the Trs-80, ZX Spectrum and CPM platforms.
 
-Try out the samples applications [here](https://drcjt.github.io/CSharp-80/index.html)
+## How to use
+
+Try out the sample applications in an online TRS-80 emulator [here](https://drcjt.github.io/CSharp-80/index.html)
+
+Currently the easiest way to use the compiler is to clone the repo, load the solution in Visual Studio, build, and then alter the code in one of the samples like Hello World.
+Rebuild and then you can see the z80 assembly in the Hello.lst file, look in Samples/Hello/bin/Trs80/Debug/net7.0. Note that by default the solution targets the TRS-80 platform 
+and so you'll also get a Hello.cmd file which is the binary file you can then use with either a real TRS-80 or an emulator.
+
+Note that the csproj files for the samples contain some specific configuration settings to disable the normal .NET SDK libs. The samples reference the System.Private.CoreLib 
+project which is a cut down version of the normal .NET SDK libs.
 
 ## Credits
 * [SeeSharpSnake](https://github.com/MichalStrehovsky/SeeSharpSnake) written by Michal Strehovský


### PR DESCRIPTION
Clarify what the CSharp-80 ILCompiler does.
Add some simple instructions on how to use it.