### PR TITLE
Fix brtrue brfalse import to deal with ptr types correctly

### DIFF
--- a/ILCompiler/Compiler/Importer/BranchImporter.cs
+++ b/ILCompiler/Compiler/Importer/BranchImporter.cs
@@ -84,7 +84,7 @@ namespace ILCompiler.Compiler.Importer
                 }
                 else
                 {
-                    if (op2.Type == VarType.Ref)
+                    if (op2.Type == VarType.Ref || op2.Type == VarType.Ptr)
                     {
                         op1 = new NativeIntConstantEntry(0);
                     }

--- a/Tests/ILCompiler.IntegrationTests/il_bvt/brfalse.il
+++ b/Tests/ILCompiler.IntegrationTests/il_bvt/brfalse.il
@@ -9,7 +9,19 @@
 .entrypoint
 .locals ()
 	ldc.i4 0x0
+	brfalse next1
+	br fail
+
+next1:
+	ldnull
+	brfalse next2
+	br fail
+
+next2:
+	ldc.i4.0
+	conv.i
 	brfalse pass
+
 fail:
 	ldc.i4 0x0001
 	ret

--- a/Tests/ILCompiler.IntegrationTests/il_bvt/brtrue.il
+++ b/Tests/ILCompiler.IntegrationTests/il_bvt/brtrue.il
@@ -11,9 +11,23 @@
 	ldc.i4 0x1
 	brtrue next0
 	br fail
+
 next0:
 	ldc.i4 0x2
 	brtrue pass
+
+	ldnull
+	brtrue fail
+
+	ldc.i4 0x1
+	conv.i
+	brtrue next1
+	br fail
+
+next1:
+	ldc.i4 0x2
+	brtrue pass
+
 fail:
 	ldc.i4 0x0001
 	ret


### PR DESCRIPTION
Fixes #290. Improves tests for brtrue and brfalse to cover ref and ptr types properly.
