### PR TITLE
Fix bug in newobj importer and dependency analysis

### DIFF
--- a/ILCompiler/Compiler/DependencyAnalysis/DependencyAnalyser.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/DependencyAnalyser.cs
@@ -207,17 +207,22 @@ namespace ILCompiler.Compiler.DependencyAnalysis
             }
             else
             {
-                var methodToCall = methodDefOrRef.ResolveMethodDefThrow();
-                var declType = methodToCall.DeclaringType;
-
-                var objType = declType.ToTypeSig();
-
-                if (!declType.IsValueType)
+                if (declaringTypeSig.FullName == "System.String")
                 {
-                    // Determine required size on GC heap
-                    var allocSize = objType.GetInstanceByteCount();
+                    // No need to add dependency here as newobj importer will
+                    // detect dynamic dependency automatically
+                }
+                else
+                {
 
-                    _dependencies.Add(_nodeFactory.ConstructedEETypeNode(declType, allocSize));
+                    var objType = declaringTypeSig.ToClassOrValueTypeSig();
+                    if (!objType.IsValueType)
+                    {
+                        // Determine required size on GC heap
+                        var allocSize = objType.GetInstanceByteCount();
+
+                        _dependencies.Add(_nodeFactory.ConstructedEETypeNode(objType.ToTypeDefOrRef(), allocSize));
+                    }
                 }
             }
         }

--- a/Tests/ILCompiler.IntegrationTests/il_bvt/field_tests.il
+++ b/Tests/ILCompiler.IntegrationTests/il_bvt/field_tests.il
@@ -114,6 +114,7 @@
 	   dup
 	   stloc 2
 	   call instance void field_tests::initialize()
+
 	   ldloc 2
 	   ldfld int8 field_tests::i1Field
 	   ldc.i4 0x1
@@ -132,12 +133,10 @@
 	   ceq
 	   brfalse fail
 
-	   /* TODO: Fix this when isinst is implemented
 	   ldloc 2
 	   ldfld class field_tests field_tests::ptrField
 	   isinst field_tests
 	   brfalse fail
-	   */
 
 	   ldsfld int8 field_tests::i1SField
 	   ldc.i4 0x1
@@ -154,11 +153,9 @@
 	   ceq
 	   brfalse fail
 
-	   /* TODO: Fix this when isinst is implemented
 	   ldsfld class field_tests field_tests::ptrSField
 	   isinst field_tests
 	   brfalse fail
-	   */
 
 	pass:
 		ldc.i4 0x0000


### PR DESCRIPTION
If class being created has no explicit constructor newobj importer would incorrectly use object as ee type instead of the real classes ee type.

This showed up in the field_tests when uncommenting the commented out tests that needed isinst