### PR TITLE
Fix bugs in Readline

### DIFF
--- a/ILCompiler/Runtime/TRS80/readline.asm
+++ b/ILCompiler/Runtime/TRS80/readline.asm
@@ -20,12 +20,12 @@ READLINE:
 	LD H, 0
 	LD L, B
 
-	PUSH BC		; Save string length
+	PUSH HL		; Save string length
 
 	PUSH DE
 	CALL NewString
-
 	POP HL		; HL = allocated string
+
 	POP BC		; BC = string length
 
 	PUSH HL		; Save allocated string
@@ -50,10 +50,7 @@ COPYCHAR:
 	POP HL		; Pointer to heap allocated string
 	POP DE		; Return address
 
-	LD BC, 0
-
-	PUSH BC		; MSW of heap allocated string object - always 0 as we only have 64kb of addressable memory
-	PUSH HL		; LSW of heap allocated string obejct
+	PUSH HL		; address of heap allocated string obejct
 
 	PUSH DE		; Restore return address
 	RET

--- a/ILCompiler/Runtime/ZXSpectrum/readline.asm
+++ b/ILCompiler/Runtime/ZXSpectrum/readline.asm
@@ -52,12 +52,12 @@ READOVER:
 	LD H, 0
 	LD L, B
 
-	PUSH BC		; Save string length
+	PUSH HL		; Save string length
 
 	PUSH DE
 	CALL NewString
-
 	POP HL		; HL = allocated string
+
 	POP BC		; BC = string length
 
 	PUSH HL		; Save allocated string
@@ -84,8 +84,7 @@ COPYCHAR:
 
 	LD BC, 0
 
-	PUSH BC		; MSW of heap allocated string object - always 0 as we only have 64kb of addressable memory
-	PUSH HL		; LSW of heap allocated string obejct
+	PUSH HL		; address of heap allocated string obejct
 
 	PUSH DE		; Restore return address
 	RET


### PR DESCRIPTION
Main issue was resulting string reference was being pushed on stack as 32 bits instead of 16 bits.
Also there was a separate issue of the string length not being saved correctly across call to newstring.

This resolves #300 and #302