### PR TITLE
Fix primes sample due to running off end of array

### DIFF
--- a/Samples/Primes/AdvancedSieve.cs
+++ b/Samples/Primes/AdvancedSieve.cs
@@ -4,22 +4,6 @@ namespace Primes
 {
     internal static class EratosthenesSieve
     {
-        private static int Sqrt(int num)
-        {
-            int ret = 0;
-
-            for (var i = 15; i >= 0; i--)
-            {
-                int temp = ret | (1 << i);
-                if (temp * temp <= num)
-                {
-                    ret = temp;
-                }
-            }
-
-            return ret;
-        }
-
         public static unsafe int GeneratePrimes(int* isPrime, int bound)
         {
             var startTime = Environment.GetDateTime();
@@ -29,7 +13,7 @@ namespace Primes
             while (thisFactor * thisFactor <= bound)
             {
                 var mark = thisFactor + thisFactor;
-                while (mark <= bound)
+                while (mark < bound)
                 {
                     isPrime[mark] = 0;
                     mark += thisFactor;

--- a/Samples/Primes/AtkinSieve.cs
+++ b/Samples/Primes/AtkinSieve.cs
@@ -23,15 +23,15 @@ namespace Primes
                 {
                     var yy = y * y;
                     var n = 4 * xx + yy;
-                    if (n <= limit && (n % 12 == 1 || n % 12 == 5))
+                    if (n < limit && (n % 12 == 1 || n % 12 == 5))
                         primes[n] = Xor(primes[n], 1);
 
                     n = 3 * xx + yy;
-                    if (n <= limit && n % 12 == 7)
+                    if (n < limit && n % 12 == 7)
                         primes[n] = Xor(primes[n], 1);
 
                     n = 3 * xx - yy;
-                    if (x > y && n <= limit && n % 12 == 11)
+                    if (x > y && n < limit && n % 12 == 11)
                         primes[n] = Xor(primes[n], 1);
                 }
             }
@@ -41,7 +41,7 @@ namespace Primes
                 if (primes[n] == 1)
                 {
                     var nn = n * n;
-                    for (var k = nn; k <= limit; k += nn)
+                    for (var k = nn; k < limit; k += nn)
                     {
                         primes[k] = 0;
                     }

--- a/Samples/Primes/Program.cs
+++ b/Samples/Primes/Program.cs
@@ -30,6 +30,7 @@ namespace Primes
             Console.WriteLine("Original Sieve:");
 
             ResetPrimes(primes, length, 0);
+
             var elapsedTime = Sieve.GeneratePrimes(primes, length);
             PrimesWriter.Write(primes, length, elapsedTime);
         }
@@ -66,7 +67,6 @@ namespace Primes
             Console.WriteLine("Sundaram Sieve:");
 
             ResetPrimes(primes, length, 0);
-
             var elapsedTime = SundaramSieve.GeneratePrimes(primes, temp, length);
             PrimesWriter.Write(primes, length, elapsedTime);
         }

--- a/Samples/Primes/Sieve.cs
+++ b/Samples/Primes/Sieve.cs
@@ -22,12 +22,12 @@ namespace Primes
 
             // At this point we still have some numbers that aren't prime marked as prime
             // So we go over them with a sieve, also we can start at 3 for obvious reasons
-            for (int i = 3; i * i <= bound; i += 2)
+            for (int i = 3; i * i < bound; i += 2)
             {
                 if (isPrime[i] == 1)
                 {
                     // Can this be optimized?
-                    for (int j = i; j * i <= bound; j++)
+                    for (int j = i; j * i < bound; j++)
                         isPrime[i * j] = 0;
                 }
             }
@@ -37,6 +37,5 @@ namespace Primes
 
             return elapsedTime;
         }
-
     }
 }

--- a/Samples/Primes/TrialDivision.cs
+++ b/Samples/Primes/TrialDivision.cs
@@ -8,7 +8,7 @@ namespace Primes
         {
             var startTime = Environment.GetDateTime();
 
-            for (var i = 2; i <= limit; i++)
+            for (var i = 2; i < limit; i++)
             {
                 var isPrime = true;
                 var n = Sqrt(i);


### PR DESCRIPTION
Due to use of int* to access array there was no protection for algorithms running of the end of the array.
They were all running off by 1 extra element and since the array was allocated on the stack this was corrupting the next 2 bytes on the stack which happened to be a pointer to the array itself.