### PR TITLE
Fix graphics for zx spectrum

### DIFF
--- a/ILCompiler/Runtime/ZXSpectrum/setres.asm
+++ b/ILCompiler/Runtime/ZXSpectrum/setres.asm
@@ -1,3 +1,5 @@
+P_FLAG	EQU	23697
+
 SETRES:
 
 	EXX
@@ -24,6 +26,8 @@ SETRES:
 
 	LD A, L	; SET/RESET
 
+	LD HL, P_FLAG
+	LD (HL), A
 
 	LD B, E
 	LD C, D

--- a/Samples/GfxDemos/Program.cs
+++ b/Samples/GfxDemos/Program.cs
@@ -23,11 +23,11 @@ namespace GfxDemos
         {
             for (int y = 0; y < Graphics.ScreenHeight; y++)
             {
-                Graphics.DrawLine(pen, 0, y, 127, y);
+                Graphics.DrawLine(pen, 0, y, Graphics.ScreenWidth, y);
             }
         }
 
-        public static void Spiral(Pen pen, int startx = 0, int endx = 127, int starty = 0, int endy = 47)
+        public static void Spiral(Pen pen, int startx = 0, int endx = Graphics.ScreenWidth, int starty = 0, int endy = Graphics.ScreenHeight)
         {
             Graphics.DrawLine(pen, startx, starty, endx, starty);
             Graphics.DrawLine(pen, endx, starty, endx, endy);
@@ -48,11 +48,11 @@ namespace GfxDemos
 
             for (int i = 0; i < 10; i++)
             {
-                var x = random.Next(128);
-                var y = random.Next(48);
+                var x = random.Next(Graphics.ScreenWidth);
+                var y = random.Next(Graphics.ScreenHeight);
 
-                var width = random.Next(128) % (128 - x);
-                var height = random.Next(48) % (48 - y);
+                var width = random.Next(Graphics.ScreenWidth) % (Graphics.ScreenWidth - x);
+                var height = random.Next(Graphics.ScreenHeight) % (Graphics.ScreenHeight - y);
 
                 Graphics.DrawEllipse(Pens.White, x, y, width, height);
             }

--- a/System.Private.CoreLib/Pal/Graphics.ZXSpectrum.cs
+++ b/System.Private.CoreLib/Pal/Graphics.ZXSpectrum.cs
@@ -4,8 +4,8 @@ namespace System.Drawing
 {
     public enum Color
     {
-        White = 0x80,
-        Black = 1
+        White = 0,
+        Black = 12,     // Corresponds to INVERSE 1
     }
 
     public partial class Graphics
@@ -14,7 +14,7 @@ namespace System.Drawing
         public static extern void SetPixel(int x, int y, Color color = Color.White);
 
         // TODO: These are not part of standard MS Graphics class
-        public const int ScreenWidth = 249;
-        public const int ScreenHeight = 191;
+        public const int ScreenWidth = 255;
+        public const int ScreenHeight = 175;    // Doesn't include bottom 2 lines
     }
 }


### PR DESCRIPTION
Make gfxdemos sample use screen width and height for platform instead of hardcoded values
Enhance SetRes routine for ZX Spectrum to support two colors via use of INVERSE 1 in P_FLAG
Set ZX Spectrum screen height to 175 as ROM routines don't support drawing in bottom 2 lines.