### PR TITLE
Optimise copy code using indexed addressing with IX to use HL instead.

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/CopyHelper.cs
+++ b/ILCompiler/Compiler/CodeGenerators/CopyHelper.cs
@@ -6,43 +6,26 @@ namespace ILCompiler.Compiler.CodeGenerators
 {
     internal static class CopyHelper
     {
-        public static void CopyStackToSmall(Emitter emitter, int bytesToCopy, int ixOffset)
+        /*
+         * Assumes address to copy to is in HL
+         */
+        public static void CopyStackToSmall(Emitter emitter, int bytesToCopy, int offset)
         {
-            // pop lsw
-            emitter.Pop(HL);
+            if (offset != 0)
+            {
+                emitter.Ld(DE, (short)offset);
+                emitter.Add(HL, DE);
+            }
 
-            // pop msw and ignore it as for small data types we
-            // truncate the value
             emitter.Pop(DE);
+            emitter.Pop(BC);    // Ignore msw
 
-            short changeToIX = 0;
-            if (ixOffset + bytesToCopy - 1 > 127)
-            {
-                // Make IX larger so offset doesn't fall outside of bounds
-                changeToIX = 128;
-            }
-            if (ixOffset < -128)
-            {
-                changeToIX = -128;
-                // Make IX smaller so offset doesn't fall outside of bounds
-            }
-            if (changeToIX != 0)
-            {
-                emitter.Ld(DE, changeToIX);
-                emitter.Add(IX, DE);
-                ixOffset -= changeToIX;
-            }
+            emitter.Ld(__[HL], E);
+            emitter.Inc(HL);
 
             if (bytesToCopy == 2)
             {
-                emitter.Ld(__[IX + (short)(ixOffset + 1)], H);
-            }
-            emitter.Ld(__[IX + (short)(ixOffset + 0)], L);
-
-            if (changeToIX != 0)
-            {
-                emitter.Ld(DE, (short)-changeToIX);
-                emitter.Add(IX, DE);
+                emitter.Ld(__[HL], D);
             }
         }
 
@@ -121,74 +104,37 @@ namespace ILCompiler.Compiler.CodeGenerators
             }
         }
 
-        public static void CopyFromStackToIX(Emitter emitter, int size, int ixOffset = 0, bool restoreIX = false)
+        /*
+         *  Assumes address to copy to is in HL
+         */
+        public static void CopyFromStackToHL(Emitter emitter, int size, int offset = 0)
         {
-            // TODO: When does it make sense to use LDIR instead??
-            // e.g. if size > 255 then we'll have to emit code to alter IX so using ldir is probably better
-            // suspect it may be much better for size > x where x is substantially less than 255 as the generated code will be quite large.
-            // For small x should we ditch using ix completely and just use HL & DE e.g. LD (HL), D??
-
-            int changeToIX = 0;
+            if (offset != 0)
+            {
+                emitter.Ld(DE, (short)offset);
+                emitter.Add(HL, DE);
+            }
 
             var totalBytesToCopy = size;
-            int originalIxOffset = ixOffset;
-
             do
             {
                 var bytesToCopy = totalBytesToCopy > 2 ? 2 : totalBytesToCopy;
+                totalBytesToCopy -= 2;
 
-                // offset has to be -128 to + 127
-                if (ixOffset + bytesToCopy > 128)
-                {
-                    // Need to move IX along to keep stackOffset within -128 to +127 range
-                    short newIxChange = 0;
-                    do
-                    {
-                        newIxChange += 127;
-                        ixOffset -= 127;
-                        size -= 127;
-                    }
-                    while (ixOffset + bytesToCopy > 128);
+                emitter.Pop(DE);
 
-                    changeToIX += newIxChange;
-
-                    emitter.Ld(DE, newIxChange);
-                    emitter.Add(IX, DE);
-                }
-
-                while (ixOffset < -128)
-                {
-                    short newIxChange = 0;
-                    do
-                    {
-                        newIxChange -= 128;
-                        ixOffset += 128;
-                        size += 128;
-                    }
-                    while (ixOffset < -128);
-
-                    changeToIX += newIxChange;
-
-                    emitter.Ld(DE, newIxChange);
-                    emitter.Add(IX, DE);
-                }
-
-                emitter.Pop(HL);
+                emitter.Ld(__[HL], E);
+                emitter.Inc(HL);
                 if (bytesToCopy == 2)
                 {
-                    emitter.Ld(__[IX + (short)(ixOffset + 1)], H);
+                    emitter.Ld(__[HL], D);
+                    if (totalBytesToCopy > 0)
+                    {
+                        emitter.Inc(HL);
+                    }
                 }
-                emitter.Ld(__[IX + (short)(ixOffset + 0)], L);
 
-                ixOffset += 2;
-                totalBytesToCopy -= 2;
-            } while (ixOffset < size + originalIxOffset);
-
-            if (changeToIX != 0 && restoreIX)
-            {
-                emitter.Ld(DE, (short)(-changeToIX));
-                emitter.Add(IX, DE);
-            }
+            } while (totalBytesToCopy > 0);
         }
 
         public static void CopyFromIXToStack(Emitter emitter, int size, int ixOffset = 0, bool restoreIX = false)

--- a/ILCompiler/Compiler/CodeGenerators/ReturnCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/ReturnCodeGenerator.cs
@@ -30,7 +30,7 @@ namespace ILCompiler.Compiler.CodeGenerators
 
                     // Copy struct to the return buffer
                     var returnTypeExactSize = entry.ReturnTypeExactSize ?? 0;
-                    CopyHelper.CopyFromStackToIX(context.Emitter, returnTypeExactSize);
+                    CopyHelper.CopyFromStackToHL(context.Emitter, returnTypeExactSize);
 
                     context.Emitter.Push(BC); // restore IX
                     context.Emitter.Pop(IX);

--- a/ILCompiler/Compiler/CodeGenerators/StoreIndCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/StoreIndCodeGenerator.cs
@@ -10,11 +10,7 @@ namespace ILCompiler.Compiler.CodeGenerators
             var exactSize = entry.ExactSize ?? 0;
             if (exactSize > 0)
             {
-                context.Emitter.Push(IX);
-                context.Emitter.Pop(BC);
-
-                context.Emitter.Pop(IX);  
-
+                context.Emitter.Pop(HL);        // Address to store to
                 short offset = (short)entry.FieldOffset;
 
                 if (entry.Type.IsSmall())
@@ -23,11 +19,8 @@ namespace ILCompiler.Compiler.CodeGenerators
                 }
                 else
                 {
-                    CopyHelper.CopyFromStackToIX(context.Emitter, exactSize, offset);
+                    CopyHelper.CopyFromStackToHL(context.Emitter, exactSize, offset);
                 }
-
-                context.Emitter.Push(BC);
-                context.Emitter.Pop(IX);
             }
         }
     }

--- a/ILCompiler/Compiler/CodeGenerators/StoreLocalVariableCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/StoreLocalVariableCodeGenerator.cs
@@ -1,5 +1,6 @@
 ﻿using ILCompiler.Compiler.EvaluationStack;
 using System.Diagnostics;
+using static ILCompiler.Compiler.Emit.Registers;
 
 namespace ILCompiler.Compiler.CodeGenerators
 {
@@ -14,13 +15,22 @@ namespace ILCompiler.Compiler.CodeGenerators
                 // Copy from stack to IX truncating to required size
                 var bytesToCopy = variable.Type.IsByte() ? 1 : 2;
 
-                CopyHelper.CopyStackToSmall(context.Emitter, bytesToCopy, -variable.StackOffset);
+                // Address to copy to needs to be in HL
+                context.Emitter.Push(IX);
+                context.Emitter.Pop(HL);
+
+                CopyHelper.CopyStackToSmall(context.Emitter, bytesToCopy, (short)-variable.StackOffset);
             }
             else
             {
                 // Storing a local variable/argument
                 Debug.Assert(variable.ExactSize % 2 == 0);
-                CopyHelper.CopyFromStackToIX(context.Emitter, variable.ExactSize, -variable.StackOffset, restoreIX: true);
+
+                // Address to copy to needs to be in HL
+                context.Emitter.Push(IX);
+                context.Emitter.Pop(HL);
+
+                CopyHelper.CopyFromStackToHL(context.Emitter, variable.ExactSize, (short)-variable.StackOffset);
             }
         }
     }


### PR DESCRIPTION
Using Index registers can be expensive so where possible try and replace with use of non indexed registers.
Note that have to offset reduction in t-cycles here with potential need to move IX into normal register.

This change mainly impacts on storing from stack to memory, store indirect.

Compare following to store a 4 byte from stack e.g. store int indirectly, which comes to 160 t-cycles

```
PUSH IX
POP BC
POP IX
POP HL
LD (IX+1), H
LD (IX+0), L
POP HL
LD (IX+3), H
LD (IX+2), L
PUSH BC
POP IX

```
with following equivalent code not using IX at all with total cost of 76 t-cycles:

```
POP HL
POP DE
LD (HL), E
INC HL
LD (HL), D
INC HL
POP DE
LD (HL), E
INC HL
LD (HL), D

```
Even adding a `PUSH IX, POP HL`, at the start would add 25 extra cycles bringing cost to 101 which is still 59 cycles better!