### PR TITLE
Only use non indexed addressing copying in store indirect code gen

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/ReturnCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/ReturnCodeGenerator.cs
@@ -30,7 +30,7 @@ namespace ILCompiler.Compiler.CodeGenerators
 
                     // Copy struct to the return buffer
                     var returnTypeExactSize = entry.ReturnTypeExactSize ?? 0;
-                    CopyHelper.CopyFromStackToHL(context.Emitter, returnTypeExactSize);
+                    CopyHelper.CopyFromStackToIX(context.Emitter, returnTypeExactSize);
 
                     context.Emitter.Push(BC); // restore IX
                     context.Emitter.Pop(IX);

--- a/ILCompiler/Compiler/CodeGenerators/StoreIndCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/StoreIndCodeGenerator.cs
@@ -15,7 +15,7 @@ namespace ILCompiler.Compiler.CodeGenerators
 
                 if (entry.Type.IsSmall())
                 {
-                    CopyHelper.CopyStackToSmall(context.Emitter, exactSize, offset);
+                    CopyHelper.CopyStackToHLSmall(context.Emitter, exactSize, offset);
                 }
                 else
                 {

--- a/ILCompiler/Compiler/CodeGenerators/StoreLocalVariableCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/StoreLocalVariableCodeGenerator.cs
@@ -1,6 +1,5 @@
 ﻿using ILCompiler.Compiler.EvaluationStack;
 using System.Diagnostics;
-using static ILCompiler.Compiler.Emit.Registers;
 
 namespace ILCompiler.Compiler.CodeGenerators
 {
@@ -15,22 +14,13 @@ namespace ILCompiler.Compiler.CodeGenerators
                 // Copy from stack to IX truncating to required size
                 var bytesToCopy = variable.Type.IsByte() ? 1 : 2;
 
-                // Address to copy to needs to be in HL
-                context.Emitter.Push(IX);
-                context.Emitter.Pop(HL);
-
-                CopyHelper.CopyStackToSmall(context.Emitter, bytesToCopy, (short)-variable.StackOffset);
+                CopyHelper.CopyStackToSmall(context.Emitter, bytesToCopy, -variable.StackOffset);
             }
             else
             {
                 // Storing a local variable/argument
                 Debug.Assert(variable.ExactSize % 2 == 0);
-
-                // Address to copy to needs to be in HL
-                context.Emitter.Push(IX);
-                context.Emitter.Pop(HL);
-
-                CopyHelper.CopyFromStackToHL(context.Emitter, variable.ExactSize, (short)-variable.StackOffset);
+                CopyHelper.CopyFromStackToIX(context.Emitter, variable.ExactSize, -variable.StackOffset, restoreIX: true);
             }
         }
     }


### PR DESCRIPTION
Backout changes to copying not using indexed addressing mode for store local variables and return code

However, original changes do still improve StoreIndirect performance