### PR TITLE
Fix type of ldlen to match ecma 335 spec as native unsigned int

### DIFF
--- a/ILCompiler/Compiler/Importer/LoadLengthImporter.cs
+++ b/ILCompiler/Compiler/Importer/LoadLengthImporter.cs
@@ -13,7 +13,7 @@ namespace ILCompiler.Compiler.Importer
             var addr = importer.PopExpression();
             var arraySizeOffset = new NativeIntConstantEntry(2);
             addr = new BinaryOperator(Operation.Add, isComparison: false, addr, arraySizeOffset, VarType.Ptr);
-            var node = new IndirectEntry(addr, VarType.UShort, 2);
+            var node = new IndirectEntry(addr, VarType.Ptr, 2);
             importer.PushExpression(node);
             return true;
         }


### PR DESCRIPTION
ldlen pushes the length as a native unsigned int - type of overall node imported here was UShort but should be Ptr