### PR TITLE
Reinstate locals init codegen

### DIFF
--- a/ILCompiler/Compiler/CodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerator.cs
@@ -249,30 +249,28 @@ namespace ILCompiler.Compiler
                 
                 if (_context.Method.Body.InitLocals)
                 {
-                    /*
                     // TODO: This should loop through the locals and only init those flagged as must init
                     // but this requires SSA and use/def analysis which we don't have yet.
                     // So for now just init all the locals
 
-                    emitter.Ld(Bc, (short)localsSize);
+                    emitter.Ld(BC, (short)localsSize);
 
-                    emitter.Push(Ix);
-                    emitter.Pop(Hl);
+                    emitter.Push(IX);
+                    emitter.Pop(HL);
 
                     var initLoopLabel = _context.NameMangler.GetUniqueName();
                     emitter.CreateLabel(initLoopLabel);
 
-                    emitter.Dec(Hl);  // Stack grows downwards so need to move to next byte first
+                    emitter.Dec(HL);  // Stack grows downwards so need to move to next byte first
 
-                    emitter.Ld(__[Hl], 0);
+                    emitter.Ld(__[HL], 0);
 
-                    emitter.Dec(Bc);
+                    emitter.Dec(BC);
 
                     emitter.Ld(A, B);
                     emitter.Or(C);
 
                     emitter.Jp(Condition.NZ, initLoopLabel);
-                    */
                 }
             }
         }

--- a/Samples/CalcPi/CalculatePi.cs
+++ b/Samples/CalcPi/CalculatePi.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 
+[module: System.Runtime.CompilerServices.SkipLocalsInit]
+
 namespace CalculatePi
 {
     public static class CalculatePi

--- a/Samples/Checksum/Program.cs
+++ b/Samples/Checksum/Program.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 
+[module: System.Runtime.CompilerServices.SkipLocalsInit]
+
 namespace MiniBCL
 {
     public static class Program

--- a/Samples/Chess/Chess.cs
+++ b/Samples/Chess/Chess.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Threading;
 
+[module: System.Runtime.CompilerServices.SkipLocalsInit]
+
 namespace Chess
 {
     public static class Chess

--- a/Samples/Fib/Program.cs
+++ b/Samples/Fib/Program.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 
+[module: System.Runtime.CompilerServices.SkipLocalsInit]
+
 namespace MiniBCL
 {
     public static class Program

--- a/Samples/GfxDemos/Program.cs
+++ b/Samples/GfxDemos/Program.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Drawing;
 
+[module: System.Runtime.CompilerServices.SkipLocalsInit]
+
 namespace GfxDemos
 {
     public static class Program

--- a/Samples/Hanoi/Program.cs
+++ b/Samples/Hanoi/Program.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 
+[module: System.Runtime.CompilerServices.SkipLocalsInit]
+
 namespace Hanoi
 {
     public static class Program

--- a/Samples/Life/Life.cs
+++ b/Samples/Life/Life.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 
+[module: System.Runtime.CompilerServices.SkipLocalsInit]
+
 namespace Life
 {
     public static class Life

--- a/Samples/Mandel/Mandel.cs
+++ b/Samples/Mandel/Mandel.cs
@@ -1,6 +1,8 @@
 ﻿using dnlib.DotNet.Resources;
 using System;
 
+[module: System.Runtime.CompilerServices.SkipLocalsInit]
+
 namespace Mandelbrot
 {
     public static class Program

--- a/Samples/NetBot/Program.cs
+++ b/Samples/NetBot/Program.cs
@@ -1,5 +1,7 @@
 ﻿using System.Drawing;
 
+[module: System.Runtime.CompilerServices.SkipLocalsInit]
+
 namespace MiniBCL
 {
     public static class Program

--- a/Samples/Paint/Program.cs
+++ b/Samples/Paint/Program.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Drawing;
 
+[module: System.Runtime.CompilerServices.SkipLocalsInit]
+
 namespace Paint
 {
     public static class Program

--- a/Samples/Primes/Program.cs
+++ b/Samples/Primes/Program.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 
+[module: System.Runtime.CompilerServices.SkipLocalsInit]
+
 namespace Primes
 {
     public static class Program

--- a/Samples/Wumpus/Program.cs
+++ b/Samples/Wumpus/Program.cs
@@ -1,5 +1,6 @@
-﻿using System;
-using Wumpus;
+﻿using Wumpus;
+
+[module: System.Runtime.CompilerServices.SkipLocalsInit]
 
 namespace MiniBCL
 {


### PR DESCRIPTION
Reinstate the code to init locals even though this is not particularly optimal as can easily be avoided by use of SkipLocalsInit
Add SkipLocalsInit to various samples to maintain existing level of performance in the samples