### PR TITLE
Upgrade to Java 17 in workflows

### DIFF
--- a/.github/workflows/MainBuild.yml
+++ b/.github/workflows/MainBuild.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'zulu' # Alternative distribution options are available.
 
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'zulu' # Alternative distribution options are available.
 
       - uses: actions/checkout@v3


### PR DESCRIPTION
Upgrade Java version to 17 to avoid warnings like:

<img width="698" alt="image" src="https://github.com/drcjt/CSharp-80/assets/5084481/762723c9-8ed4-422e-9af0-6e40121e0d35">
