### PR TITLE
Invert y-axis for ZX Spectrum SETRES

### DIFF
--- a/ILCompiler/Runtime/ZXSpectrum/setres.asm
+++ b/ILCompiler/Runtime/ZXSpectrum/setres.asm
@@ -12,7 +12,8 @@ SETRES:
 	POP DE		; Get y-coordinate into DE
 	POP BC		; Ignore msw
 
-	LD A, E		; Save y into A
+	LD A, 175	; Save 175-y into A
+	SUB E
 
 	POP DE		; get x-coordinate into HL
 	POP BC		; Ignore msw

--- a/Samples/NetBot/Program.cs
+++ b/Samples/NetBot/Program.cs
@@ -1,4 +1,5 @@
-﻿using System.Drawing;
+﻿using System;
+using System.Drawing;
 
 [module: System.Runtime.CompilerServices.SkipLocalsInit]
 
@@ -8,6 +9,7 @@ namespace MiniBCL
     {
         public static void Main()
         {
+            Console.Clear();
             DrawDotNetBot();
         }
 


### PR DESCRIPTION
Invert y-axis for ZX Spectrum SETRES to match default coordinate system. 
Clear screen first in netbot sample