### PR TITLE
Use frames counter on ZX spectrum that increments once every 20 ms as basis for GetDateTime

### DIFF
--- a/System.Private.CoreLib/Pal/Environment.ZXSpectrum.cs
+++ b/System.Private.CoreLib/Pal/Environment.ZXSpectrum.cs
@@ -19,8 +19,21 @@ namespace System
         /// </summary>
         public static int TickCount => GetFrameCount() * 20;
 
-        //[DllImport(Libraries.Runtime, EntryPoint = "GETDATETIME")]
-        public static DateTime GetDateTime() { return new DateTime(); }
+        //DllImport(Libraries.Runtime, EntryPoint = "GETDATETIME")]
+        public static DateTime GetDateTime()
+        {
+            var framesCounter = GetFramesCounter();
+            var seconds = (framesCounter / 50) % 60;
+            var minutes = (framesCounter / 3000) % 60;
+            var hours = (framesCounter / 180000) % 60;
+            var days = (framesCounter / 4320000) % 24;
+            return new DateTime(days, hours, minutes, seconds);
+        }
+
+        private static unsafe int GetFramesCounter()
+        {
+            return 65536 * *((byte*)23674) + 256 * *((byte*)23673) + *((byte*)23672);
+        }
 
         public static string NewLine => "\r";
     }

--- a/Tests/ILCompiler.Tests.Common/ILCompiler.Tests.Common.csproj
+++ b/Tests/ILCompiler.Tests.Common/ILCompiler.Tests.Common.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
-    <PackageReference Include="Microsoft.NETCore.ILAsm" Version="7.0.0" />
+    <PackageReference Include="Microsoft.NETCore.ILAsm" Version="6.0.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 	<PackageReference Include="Z80dotNet" Version="1.0.6">


### PR DESCRIPTION
Use 20ms frames counter to work out seconds, minutes, hours, days for GetDateTime.