### PR TITLE
Use RuntimeTypeHandle in AllocTests

### DIFF
--- a/ILCompiler/Compiler/DependencyAnalysis/DependencyAnalyser.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/DependencyAnalyser.cs
@@ -241,19 +241,17 @@ namespace ILCompiler.Compiler.DependencyAnalysis
             {
                 // TODO: Will need to review this when changing NewArray assembly routine to take EEType instead of size
             }
-            else
+            else if (declaringTypeSig.IsValueType)
             {
-                if (declaringTypeSig.FullName != "System.String")
-                {
-                    var objType = declaringTypeSig.ToClassOrValueTypeSig();
-                    if (!objType.IsValueType)
-                    {
-                        // Determine required size on GC heap
-                        var allocSize = objType.GetInstanceByteCount();
+                // No dependency required 
+            }
+            else if (declaringTypeSig.FullName != "System.String")
+            {
+                var objType = declaringTypeSig.ToClassSig();
+                // Determine required size on GC heap
+                var allocSize = objType.GetInstanceByteCount();
 
-                        _dependencies.Add(_nodeFactory.ConstructedEETypeNode(objType.ToTypeDefOrRef(), allocSize));
-                    }
-                }
+                _dependencies.Add(_nodeFactory.ConstructedEETypeNode(objType.ToTypeDefOrRef(), allocSize));
             }
         }
     }

--- a/ILCompiler/Compiler/Importer/NewobjImporter.cs
+++ b/ILCompiler/Compiler/Importer/NewobjImporter.cs
@@ -29,7 +29,7 @@ namespace ILCompiler.Compiler.Importer
                 }
                 else
                 {
-                    var objType = declaringTypeSig.ToClassOrValueTypeSig();
+                    var objType = declaringTypeSig;
                     var objVarType = objType.GetVarType();
                     var objSize = objType.GetInstanceFieldSize();
 
@@ -39,7 +39,8 @@ namespace ILCompiler.Compiler.Importer
                     }
                     else
                     {
-                        ImportNewObjReferenceType(instruction, context, importer, objType, objVarType, objSize);
+                        var classType = objType.ToClassSig();
+                        ImportNewObjReferenceType(instruction, context, importer, classType, objVarType, objSize);
                     }
                 }
             }
@@ -97,7 +98,7 @@ namespace ILCompiler.Compiler.Importer
             // Call the valuetype constructor
             CallImporter.ImportCall(instruction, context, importer, newObjThisPtr);
 
-            var node = new LocalVariableEntry(lclNum, VarType.Struct, objSize);
+            var node = new LocalVariableEntry(lclNum, objVarType, objSize);
             importer.PushExpression(node);
         }
 

--- a/System.Private.CoreLib/System/IntPtr.cs
+++ b/System.Private.CoreLib/System/IntPtr.cs
@@ -11,5 +11,8 @@
 
         public static unsafe explicit operator IntPtr(void* value) => new IntPtr(value);
         public static unsafe explicit operator void*(IntPtr value) => value._value;
+
+        public static unsafe bool operator ==(IntPtr value1, IntPtr value2) => value1._value == value2._value;
+        public static unsafe bool operator !=(IntPtr value1, IntPtr value2) => value1._value != value2._value;
     }
 }

--- a/System.Private.CoreLib/System/IntPtr.cs
+++ b/System.Private.CoreLib/System/IntPtr.cs
@@ -1,6 +1,6 @@
 ﻿namespace System
 {
-    public struct IntPtr
+    public readonly struct IntPtr
     {
         private readonly unsafe void* _value;
 
@@ -9,10 +9,13 @@
             _value = value;
         }
 
-        public static unsafe explicit operator IntPtr(void* value) => new IntPtr(value);
+        public static unsafe explicit operator IntPtr(void* value) => new(value);
         public static unsafe explicit operator void*(IntPtr value) => value._value;
 
         public static unsafe bool operator ==(IntPtr value1, IntPtr value2) => value1._value == value2._value;
         public static unsafe bool operator !=(IntPtr value1, IntPtr value2) => value1._value != value2._value;
+
+        public override bool Equals(object obj) => (obj is nint other) && Equals(other);
+        public override unsafe int GetHashCode() => (int)_value;
     }
 }

--- a/System.Private.CoreLib/System/Object.cs
+++ b/System.Private.CoreLib/System/Object.cs
@@ -1,5 +1,4 @@
 ﻿using Internal.Runtime;
-using Internal.Runtime.CompilerServices;
 
 namespace System
 {
@@ -12,5 +11,8 @@ namespace System
         {
             return new RuntimeTypeHandle((IntPtr)m_pEEType);
         }
+
+        public virtual bool Equals(object o) => false;
+        public virtual int GetHashCode() => 0;
     }
 }

--- a/System.Private.CoreLib/System/Object.cs
+++ b/System.Private.CoreLib/System/Object.cs
@@ -1,9 +1,16 @@
 ﻿using Internal.Runtime;
+using Internal.Runtime.CompilerServices;
 
 namespace System
 {
     public unsafe class Object
     {
         internal EEType* m_pEEType;
+
+        // Equivalent to GetType().TypeHandle
+        public RuntimeTypeHandle GetEEType()
+        {
+            return new RuntimeTypeHandle((IntPtr)m_pEEType);
+        }
     }
 }

--- a/System.Private.CoreLib/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/System.Private.CoreLib/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -7,6 +7,5 @@
         // TODO: This should be removed when better support for reflection has been
         // added via Type class.
         public unsafe static bool HasCctor<T>() => EETypePtr.EETypePtrOf<T>().HasCctor;
-
     }
 }

--- a/System.Private.CoreLib/System/RuntimeType.cs
+++ b/System.Private.CoreLib/System/RuntimeType.cs
@@ -1,6 +1,0 @@
-﻿namespace System
-{
-    public class RuntimeType
-    {
-    }
-}

--- a/System.Private.CoreLib/System/RuntimeTypeHandle.cs
+++ b/System.Private.CoreLib/System/RuntimeTypeHandle.cs
@@ -2,11 +2,23 @@
 {
     public struct RuntimeTypeHandle
     {
-        private EETypePtr _EEType;
+        private IntPtr _EEType;
+
+        internal RuntimeTypeHandle(IntPtr pEEType)
+        {
+            _EEType = pEEType;
+        }
 
         internal static unsafe IntPtr GetValueInternal(RuntimeTypeHandle handle)
         {
-            return (IntPtr)handle._EEType.ToPointer();
+            return handle._EEType;
+        }
+
+        public bool Equals(RuntimeTypeHandle handle)
+        {
+            if (_EEType == handle._EEType)
+                return true;
+            return false;
         }
     }
 }

--- a/System.Private.CoreLib/System/RuntimeTypeHandle.cs
+++ b/System.Private.CoreLib/System/RuntimeTypeHandle.cs
@@ -1,24 +1,16 @@
 ﻿namespace System
 {
-    public struct RuntimeTypeHandle
+    public readonly struct RuntimeTypeHandle
     {
-        private IntPtr _EEType;
+        private readonly IntPtr _EEType;
 
         internal RuntimeTypeHandle(IntPtr pEEType)
         {
             _EEType = pEEType;
         }
 
-        internal static unsafe IntPtr GetValueInternal(RuntimeTypeHandle handle)
-        {
-            return handle._EEType;
-        }
+        internal static unsafe IntPtr GetValueInternal(RuntimeTypeHandle handle) => handle._EEType;
 
-        public bool Equals(RuntimeTypeHandle handle)
-        {
-            if (_EEType == handle._EEType)
-                return true;
-            return false;
-        }
+        public readonly bool Equals(RuntimeTypeHandle handle) => handle._EEType == _EEType;
     }
 }

--- a/Tests/CoreLib/CoreLib/AllocTests.cs
+++ b/Tests/CoreLib/CoreLib/AllocTests.cs
@@ -11,16 +11,6 @@ namespace CoreLib
             private bool field3;
         }
 
-        // Very unsafe method to get EEType of a managed object
-        // This is not GC safe
-        static unsafe ushort GetEEType(object obj)
-        {
-            var objectptr = *(void**)Internal.Runtime.CompilerServices.Unsafe.AsPointer(ref obj);
-            var eetypeptr = *((ushort*)objectptr);
-
-            return eetypeptr;
-        }
-
         private static void AllocStringSizeTest(char[] chars)
         {
             // This is not GC safe
@@ -83,16 +73,16 @@ namespace CoreLib
             var str2 = new String(new char[3]);
 
             // Check EEType is same for both string objects
-            Assert.AreEquals(GetEEType(str1), GetEEType(str2));
+            Assert.AreEquals(str1.GetEEType(), str2.GetEEType());
 
             var class1 = new TestClass();
             var class2 = new TestClass();
 
             // Check EEType is same for both instances of TestClass
-            Assert.AreEquals(GetEEType(class1), GetEEType(class2));
+            Assert.AreEquals(class1.GetEEType(), class2.GetEEType());
 
             // Check EEType is different for String and TestClass instances
-            Assert.AreNotEquals(GetEEType(str1), GetEEType(class1));
+            Assert.AreNotEquals(str1.GetEEType(), class1.GetEEType());
         }
     }
 }

--- a/Tests/CoreLib/CoreLib/Assert.cs
+++ b/Tests/CoreLib/CoreLib/Assert.cs
@@ -20,9 +20,17 @@ namespace CoreLib
             }
         }
 
-        public static void AreNotEquals(int expected, int actual)
+        public static void AreEquals(RuntimeTypeHandle expected, RuntimeTypeHandle actual)
         {
-            if (expected == actual)
+            if (!expected.Equals(actual))
+            {
+                Environment.Exit(1);
+            }
+        }
+
+        public static void AreNotEquals(RuntimeTypeHandle expected, RuntimeTypeHandle actual)
+        {
+            if (expected.Equals(actual))
             {
                 Environment.Exit(1);
             }


### PR DESCRIPTION
Extend RuntimeTypeHandle to support exact equals Use Use this in AllocTests by adding a GetEEType to Object
Fix bugs in importing New with primitive valuetype such as IntPtr
Fix bug in dependency analysis of New with primitive valuetype such as IntPtr