### PR TITLE
Extend dependency analyzer to support static conditional dependencies

### DIFF
--- a/ILCompiler/Compiler/DependencyAnalysis/ConditionalDependency.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/ConditionalDependency.cs
@@ -1,0 +1,8 @@
+﻿namespace ILCompiler.Compiler.DependencyAnalysis
+{
+    public record ConditionalDependency
+    {
+        public required IDependencyNode ThenNode { get; init; }
+        public required IDependencyNode IfNode { get; init; }
+    }
+}

--- a/ILCompiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -34,7 +34,6 @@ namespace ILCompiler.Compiler.DependencyAnalysis
             else
             {
                 var baseType = Type.GetBaseType();
-
                 if (baseType != null)
                 {
                     var resolvedBaseType = baseType.ResolveTypeDefThrow();
@@ -53,5 +52,7 @@ namespace ILCompiler.Compiler.DependencyAnalysis
 
             return Dependencies;
         }
+
+        public override IList<ConditionalDependency> GetConditionalStaticDependencies(DependencyNodeContext context) => new List<ConditionalDependency>();
     }
 }

--- a/ILCompiler/Compiler/DependencyAnalysis/DependencyNode.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/DependencyNode.cs
@@ -6,6 +6,8 @@
 
         public abstract IList<IDependencyNode> GetStaticDependencies(DependencyNodeContext context);
 
+        public abstract IList<ConditionalDependency> GetConditionalStaticDependencies(DependencyNodeContext context);
+
         public abstract IList<IDependencyNode> Dependencies { get; set; }
 
         public abstract string Name { get; }

--- a/ILCompiler/Compiler/DependencyAnalysis/IDependencyNode.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/IDependencyNode.cs
@@ -6,6 +6,8 @@
 
         public IList<IDependencyNode> GetStaticDependencies(DependencyNodeContext context);
 
+        public IList<ConditionalDependency> GetConditionalStaticDependencies(DependencyNodeContext context);
+
         public IList<IDependencyNode> Dependencies { get; set; }
 
         public string Name { get; }

--- a/ILCompiler/Compiler/DependencyAnalysis/StaticsNode.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/StaticsNode.cs
@@ -17,5 +17,6 @@ namespace ILCompiler.Compiler.DependencyAnalysis
         public override IList<IDependencyNode> Dependencies { get; set; }
 
         public override IList<IDependencyNode> GetStaticDependencies(DependencyNodeContext context) => Dependencies;
+        public override IList<ConditionalDependency> GetConditionalStaticDependencies(DependencyNodeContext context) => new List<ConditionalDependency>();
     }
 }

--- a/ILCompiler/Compiler/DependencyAnalysis/Z80MethodCodeNode.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/Z80MethodCodeNode.cs
@@ -29,5 +29,7 @@ namespace ILCompiler.Compiler.DependencyAnalysis
             
             return Dependencies;
         }
+
+        public override IList<ConditionalDependency> GetConditionalStaticDependencies(DependencyNodeContext context) => new List<ConditionalDependency>();
     }
 }


### PR DESCRIPTION
These will be used in implementing virtual methods - instead of generating full vtable for all types the plan is to use the dependency analyzer to only generate vtable slots for virtual methods that are actually used.