### PR TITLE
Virtual Methods in dependency graph

### DIFF
--- a/ILCompiler/Common/TypeSystem/Common/VirtualMethodAlgorithm.cs
+++ b/ILCompiler/Common/TypeSystem/Common/VirtualMethodAlgorithm.cs
@@ -1,0 +1,123 @@
+﻿using dnlib.DotNet;
+
+namespace ILCompiler.Common.TypeSystem.Common
+{
+    /// <summary>
+    /// This static methods in this class implement the standard virtual method algorithm as described in ECMA 335.
+    /// Specifically see these sections
+    ///     II.10.3 Introducing and overriding virtual methods
+    ///     II.10.3.1 Introduction a virtual method
+    /// </summary>
+    public class VirtualMethodAlgorithm
+    {
+        /// <summary>
+        /// Enumerate all virtual methods on the specified type and it's parent types
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        public static IEnumerable<MethodDef> EnumAllVirtualSlots(TypeDef type)
+        {
+            var alreadyEnumerated = new List<MethodDef>();
+            if (!type.IsInterface)
+            {
+                TypeDef? currentType = type;
+                do
+                {
+                    foreach (var method in currentType.Methods)
+                    {
+                        if (method.IsVirtual)
+                        {
+                            var possibleVirtual = FindSlotDefiningMethodForVirtualMethod(method);
+                            if (!alreadyEnumerated.Contains(possibleVirtual))
+                            {
+                                alreadyEnumerated.Add(possibleVirtual);
+                                yield return possibleVirtual;
+                            }
+                        }
+                    }
+                    currentType = currentType.BaseType?.ResolveTypeDefThrow();
+                } while (currentType != null);
+            }
+        }
+
+        /// <summary>
+        /// Resolve a virtual method call on the specified type
+        /// </summary>
+        /// <param name="decl"></param>
+        /// <param name="method"></param>
+        /// <returns></returns>
+        public static MethodDef? FindVirtualFunctionTargetMethodOnObjectType(TypeDef? currentType, MethodDef method)
+        {
+            while (currentType != null)
+            {
+                var nameSigOverride = FindMatchingVirtualMethodOnTypeByNameAndSig(method, currentType);
+                if (nameSigOverride != null)
+                {
+                    return nameSigOverride;
+                }
+
+                // No match so move up the type hierarchy and try again
+                currentType = currentType.BaseType?.ResolveTypeDefThrow();
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Find matching virtual method by name and signature on a type. Finds both exact and equivalent methods.
+        /// Prefers exact match over equivalent match.
+        /// </summary>
+        /// <param name="targetMethod"></param>
+        /// <param name="currentType"></param>
+        /// <returns></returns>
+        public static MethodDef? FindMatchingVirtualMethodOnTypeByNameAndSig(MethodDef targetMethod, TypeDef currentType)
+        {
+            MethodDef? exactMatch = null;
+            MethodDef? equivalentMatch = null;
+
+            foreach (var candidateMethod in currentType.Methods)
+            {
+                if (candidateMethod.Name == targetMethod.Name)
+                {
+                    if (new SigComparer().Equals(candidateMethod.Signature, targetMethod.Signature))
+                    {
+                        equivalentMatch = candidateMethod;
+
+                        if (candidateMethod.Signature == targetMethod.Signature)
+                        {
+                            exactMatch = candidateMethod;
+                        }
+                    }
+                }
+            }
+
+            return exactMatch ?? equivalentMatch;
+        }
+
+        /// <summary>
+        /// Find the base type method that defines the slot for the specified method.
+        /// This is either:
+        ///    * the new slot method most derived that is in the parent hierarchy of the method, or
+        ///    * the least derived method that isn't new slot that matches by name and sig
+        /// </summary>
+        /// <param name="method"></param>
+        /// <returns></returns>
+        public static MethodDef FindSlotDefiningMethodForVirtualMethod(MethodDef method)
+        {
+            var currentType = method.DeclaringType.BaseType;
+
+            while (currentType != null && !method.IsNewSlot)
+            {
+                var foundMethod = FindMatchingVirtualMethodOnTypeByNameAndSig(method, currentType.ResolveTypeDefThrow());
+                if (foundMethod != null)
+                {
+                    return foundMethod;
+                }
+
+                currentType = currentType.GetBaseType();
+            }
+
+            return method;
+        }
+    }
+}

--- a/ILCompiler/Common/TypeSystem/Common/VirtualMethodAlgorithm.cs
+++ b/ILCompiler/Common/TypeSystem/Common/VirtualMethodAlgorithm.cs
@@ -8,7 +8,7 @@ namespace ILCompiler.Common.TypeSystem.Common
     ///     II.10.3 Introducing and overriding virtual methods
     ///     II.10.3.1 Introduction a virtual method
     /// </summary>
-    public class VirtualMethodAlgorithm
+    public static class VirtualMethodAlgorithm
     {
         /// <summary>
         /// Enumerate all virtual methods on the specified type and it's parent types
@@ -77,16 +77,13 @@ namespace ILCompiler.Common.TypeSystem.Common
 
             foreach (var candidateMethod in currentType.Methods)
             {
-                if (candidateMethod.Name == targetMethod.Name)
+                if (candidateMethod.Name == targetMethod.Name && new SigComparer().Equals(candidateMethod.Signature, targetMethod.Signature))
                 {
-                    if (new SigComparer().Equals(candidateMethod.Signature, targetMethod.Signature))
-                    {
-                        equivalentMatch = candidateMethod;
+                    equivalentMatch = candidateMethod;
 
-                        if (candidateMethod.Signature == targetMethod.Signature)
-                        {
-                            exactMatch = candidateMethod;
-                        }
+                    if (candidateMethod.Signature == targetMethod.Signature)
+                    {
+                        exactMatch = candidateMethod;
                     }
                 }
             }

--- a/ILCompiler/Compiler/DependencyAnalysis/ConditionalDependency.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/ConditionalDependency.cs
@@ -3,6 +3,7 @@
     public record ConditionalDependency
     {
         public required IDependencyNode ThenNode { get; init; }
+        public required IDependencyNode ThenParent { get; init; }
         public required IDependencyNode IfNode { get; init; }
     }
 }

--- a/ILCompiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -72,6 +72,7 @@ namespace ILCompiler.Compiler.DependencyAnalysis
                         var conditionalDependency = new ConditionalDependency
                         {
                             IfNode = context.NodeFactory.VirtualMethodUse(method),
+                            ThenParent = this,
                             ThenNode = context.NodeFactory.MethodNode(implementation),
                         };
                         conditionalDependencies.Add(conditionalDependency);

--- a/ILCompiler/Compiler/DependencyAnalysis/DependencyAnalyzer.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/DependencyAnalyzer.cs
@@ -8,7 +8,7 @@ namespace ILCompiler.Compiler.DependencyAnalysis
     {
         private readonly Stack<IDependencyNode> _markStack = new();
         private readonly List<IDependencyNode> _markedNodes = new();
-        private readonly Dictionary<IDependencyNode, IList<IDependencyNode>> _conditionalDependencyStore = new();
+        private readonly Dictionary<IDependencyNode, IList<ConditionalDependency>> _conditionalDependencyStore = new();
 
         private readonly NodeFactory _nodeFactory;
         private readonly DependencyNodeContext _nodeContext;
@@ -57,7 +57,8 @@ namespace ILCompiler.Compiler.DependencyAnalysis
                 {
                     foreach(var conditionalDependency in conditionalDependencyList) 
                     {
-                        AddToMarkStack(conditionalDependency);
+                        conditionalDependency.ThenParent.Dependencies.Add(conditionalDependency.ThenNode);
+                        AddToMarkStack(conditionalDependency.ThenNode);
                     }
                     _conditionalDependencyStore.Remove(currentNode);
                 }
@@ -76,16 +77,17 @@ namespace ILCompiler.Compiler.DependencyAnalysis
             {
                 if (dependency.IfNode.Mark)
                 {
+                    node.Dependencies.Add(dependency.ThenNode);
                     AddToMarkStack(dependency.ThenNode);
                 }
                 else
                 {
                     if (!_conditionalDependencyStore.TryGetValue(dependency.IfNode, out var conditionalDependencyList))
                     {
-                        conditionalDependencyList = new List<IDependencyNode>();
+                        conditionalDependencyList = new List<ConditionalDependency>();
                         _conditionalDependencyStore.Add(dependency.IfNode, conditionalDependencyList);
                     }
-                    conditionalDependencyList.Add(dependency.ThenNode);
+                    conditionalDependencyList.Add(dependency);
                 }
             }
         }

--- a/ILCompiler/Compiler/DependencyAnalysis/ILScanner.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/ILScanner.cs
@@ -210,7 +210,8 @@ namespace ILCompiler.Compiler.DependencyAnalysis
                     }
                     else
                     {
-                        throw new NotImplementedException("Non direct calls not supported");
+                        _dependencies.Add(_nodeFactory.VirtualMethodUse(method));
+                        return;
                     }
                 }
 

--- a/ILCompiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -7,6 +7,7 @@ namespace ILCompiler.Compiler.DependencyAnalysis
     {
         private readonly IDictionary<string, StaticsNode> _staticNodesByFullName = new Dictionary<string, StaticsNode>();
         private readonly IDictionary<string, Z80MethodCodeNode> _methodNodesByFullName = new Dictionary<string, Z80MethodCodeNode>();
+        private readonly IDictionary<string, VirtualMethodUseNode> _virtualMethodNodesByFullName = new Dictionary<string, VirtualMethodUseNode>();
         private readonly IDictionary<string, ConstructedEETypeNode> _constructedEETypeNodesByFullName = new Dictionary<string, ConstructedEETypeNode>();
 
         public ConstructedEETypeNode ConstructedEETypeNode(ITypeDefOrRef type, int size)
@@ -29,6 +30,18 @@ namespace ILCompiler.Compiler.DependencyAnalysis
             }
 
             return staticNode;
+        }
+
+        public VirtualMethodUseNode VirtualMethodUse(IMethod method)
+        {
+            var methodDef = method.ResolveMethodDefThrow();
+            if (!_virtualMethodNodesByFullName.TryGetValue(methodDef.FullName, out var methodNode))
+            {
+                methodNode = new VirtualMethodUseNode(new MethodDesc(methodDef));
+                _virtualMethodNodesByFullName[methodDef.FullName] = methodNode;
+            }
+
+            return methodNode;
         }
 
         public Z80MethodCodeNode MethodNode(MethodSpec calleeMethod, MethodDesc callerMethod)

--- a/ILCompiler/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
@@ -5,7 +5,7 @@ namespace ILCompiler.Compiler.DependencyAnalysis
     public class VirtualMethodUseNode : DependencyNode
     {
         public MethodDesc Method { get; }
-        public override IList<IDependencyNode> Dependencies {  get; set; } = new List<IDependencyNode>();
+        public override IList<IDependencyNode> Dependencies { get; set; }
 
         public override string Name => Method.FullName;
 

--- a/ILCompiler/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
@@ -1,0 +1,22 @@
+﻿using ILCompiler.Common.TypeSystem.Common;
+
+namespace ILCompiler.Compiler.DependencyAnalysis
+{
+    public class VirtualMethodUseNode : DependencyNode
+    {
+        public MethodDesc Method { get; }
+        public override IList<IDependencyNode> Dependencies {  get; set; } = new List<IDependencyNode>();
+
+        public override string Name => Method.FullName;
+
+        public VirtualMethodUseNode(MethodDesc method)
+        {
+            Method = method;
+            Dependencies = new List<IDependencyNode>();
+        }
+
+        public override IList<IDependencyNode> GetStaticDependencies(DependencyNodeContext context) => Dependencies;
+        public override IList<ConditionalDependency> GetConditionalStaticDependencies(DependencyNodeContext context) => new List<ConditionalDependency>();
+
+    }
+}


### PR DESCRIPTION
Add virtual method use to the dependency graph.
Use these dependencies as trigger for conditional dependencies on the actual virtual methods themselves.

Note virtual method calls are not doing dispatch yet so won't work but at least the right code should now be being included in the code generated.