### PR TITLE
Generate VTable

### DIFF
--- a/ILCompiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -5,8 +5,6 @@ namespace ILCompiler.Compiler.DependencyAnalysis
 {
     public class ConstructedEETypeNode : DependencyNode
     {
-        public override IList<IDependencyNode> Dependencies { get; set; }
-
         public ITypeDefOrRef Type { get; private set; }
         public int BaseSize { get; private set; }
 
@@ -18,7 +16,6 @@ namespace ILCompiler.Compiler.DependencyAnalysis
         {
             Type = type;
             BaseSize = baseSize;
-            Dependencies = new List<IDependencyNode>();
         }
 
         public override IList<IDependencyNode> GetStaticDependencies(DependencyNodeContext context)
@@ -49,9 +46,8 @@ namespace ILCompiler.Compiler.DependencyAnalysis
                     }
                 }
             }
-            Dependencies = dependencies;
 
-            return Dependencies;
+            return dependencies;
         }
 
         public override IList<ConditionalDependency> GetConditionalStaticDependencies(DependencyNodeContext context)

--- a/ILCompiler/Compiler/DependencyAnalysis/DependencyAnalyzer.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/DependencyAnalyzer.cs
@@ -21,9 +21,9 @@ namespace ILCompiler.Compiler.DependencyAnalysis
             }
         }
 
-        public DependencyAnalyzer(ILogger<DependencyAnalyzer> logger, CorLibModuleProvider corLibModuleProvider, PreinitializationManager preinitializationManager)
+        public DependencyAnalyzer(ILogger<DependencyAnalyzer> logger, CorLibModuleProvider corLibModuleProvider, PreinitializationManager preinitializationManager, NodeFactory nodeFactory)
         {
-            _nodeFactory = new NodeFactory();
+            _nodeFactory = nodeFactory;
             _nodeContext = new DependencyNodeContext
             {
                 Logger = logger,
@@ -90,6 +90,7 @@ namespace ILCompiler.Compiler.DependencyAnalysis
                     conditionalDependencyList.Add(dependency);
                 }
             }
+            node.Dependencies = dependencies;
         }
 
         private void AddToMarkStack(IDependencyNode node) 
@@ -98,6 +99,8 @@ namespace ILCompiler.Compiler.DependencyAnalysis
             {
                 node.Mark = true;
                 _markedNodes.Add(node);
+
+                node.OnMarked(_nodeFactory);
 
                 _markStack.Push(node);
             }

--- a/ILCompiler/Compiler/DependencyAnalysis/DependencyNode.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/DependencyNode.cs
@@ -3,12 +3,15 @@
     public abstract class DependencyNode : IDependencyNode
     {
         public bool Mark { get; set; }
+        public virtual void OnMarked(NodeFactory factory)
+        {
+        }
 
-        public abstract IList<IDependencyNode> GetStaticDependencies(DependencyNodeContext context);
+        public virtual IList<IDependencyNode> GetStaticDependencies(DependencyNodeContext context) => new List<IDependencyNode>();
 
-        public abstract IList<ConditionalDependency> GetConditionalStaticDependencies(DependencyNodeContext context);
+        public virtual IList<ConditionalDependency> GetConditionalStaticDependencies(DependencyNodeContext context) => new List<ConditionalDependency>();
 
-        public abstract IList<IDependencyNode> Dependencies { get; set; }
+        public IList<IDependencyNode> Dependencies { get; set; } = new List<IDependencyNode>();
 
         public abstract string Name { get; }
     }

--- a/ILCompiler/Compiler/DependencyAnalysis/IDependencyNode.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/IDependencyNode.cs
@@ -3,6 +3,7 @@
     public interface IDependencyNode
     {
         public bool Mark { get; set; }
+        public void OnMarked(NodeFactory factory);
 
         public IList<IDependencyNode> GetStaticDependencies(DependencyNodeContext context);
 

--- a/ILCompiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -9,6 +9,7 @@ namespace ILCompiler.Compiler.DependencyAnalysis
         private readonly IDictionary<string, Z80MethodCodeNode> _methodNodesByFullName = new Dictionary<string, Z80MethodCodeNode>();
         private readonly IDictionary<string, VirtualMethodUseNode> _virtualMethodNodesByFullName = new Dictionary<string, VirtualMethodUseNode>();
         private readonly IDictionary<string, ConstructedEETypeNode> _constructedEETypeNodesByFullName = new Dictionary<string, ConstructedEETypeNode>();
+        private readonly IDictionary<TypeDef, VTableSliceNode> _vTableNodes = new Dictionary<TypeDef, VTableSliceNode>();
 
         public ConstructedEETypeNode ConstructedEETypeNode(ITypeDefOrRef type, int size)
         {
@@ -81,6 +82,17 @@ namespace ILCompiler.Compiler.DependencyAnalysis
             }
 
             return methodNode;
+        }
+
+        public VTableSliceNode VTable(TypeDef type)
+        {
+            if (!_vTableNodes.TryGetValue(type, out var vTableSliceNode))
+            {
+                vTableSliceNode = new VTableSliceNode(type);
+                _vTableNodes[type] = vTableSliceNode;
+            }
+
+            return vTableSliceNode;
         }
     }
 }

--- a/ILCompiler/Compiler/DependencyAnalysis/StaticsNode.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/StaticsNode.cs
@@ -11,12 +11,6 @@ namespace ILCompiler.Compiler.DependencyAnalysis
         public StaticsNode(FieldDef field)
         {
             Field = field;
-            Dependencies = new List<IDependencyNode>();
         }
-
-        public override IList<IDependencyNode> Dependencies { get; set; }
-
-        public override IList<IDependencyNode> GetStaticDependencies(DependencyNodeContext context) => Dependencies;
-        public override IList<ConditionalDependency> GetConditionalStaticDependencies(DependencyNodeContext context) => new List<ConditionalDependency>();
     }
 }

--- a/ILCompiler/Compiler/DependencyAnalysis/VTableSliceNode.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/VTableSliceNode.cs
@@ -1,5 +1,6 @@
 ﻿using dnlib.DotNet;
 using ILCompiler.Common.TypeSystem.Common;
+using System.Linq;
 
 namespace ILCompiler.Compiler.DependencyAnalysis
 {
@@ -27,13 +28,9 @@ namespace ILCompiler.Compiler.DependencyAnalysis
         public IReadOnlyList<MethodDef> GetSlots()
         {
             IList<MethodDef> slots = new List<MethodDef>();
-
-            foreach (var method in _type.Methods)
+            foreach (var method in _type.Methods.Where(method => _usedMethods.Contains(method.FullName)))
             {
-                if (_usedMethods.Contains(method.FullName))
-                {
-                    slots.Add(method);
-                }
+                slots.Add(method);
             }
 
             return slots.ToArray();

--- a/ILCompiler/Compiler/DependencyAnalysis/VTableSliceNode.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/VTableSliceNode.cs
@@ -1,0 +1,42 @@
+﻿using dnlib.DotNet;
+using ILCompiler.Common.TypeSystem.Common;
+
+namespace ILCompiler.Compiler.DependencyAnalysis
+{
+    public class VTableSliceNode : DependencyNode
+    {
+        private readonly TypeDef _type;
+        public VTableSliceNode(TypeDef type)
+        {
+            _type = type;
+        }
+
+        public override string Name => _type.FullName + " VTable";
+
+        private readonly ISet<string> _usedMethods = new HashSet<string>();
+
+        public void AddEntry(MethodDesc method)
+        {
+            _usedMethods.Add(method.FullName);
+        }
+
+        /// <summary>
+        /// Sort the used virtual methods in metadata order to get the slots
+        /// </summary>
+        /// <returns></returns>
+        public IReadOnlyList<MethodDef> GetSlots()
+        {
+            IList<MethodDef> slots = new List<MethodDef>();
+
+            foreach (var method in _type.Methods)
+            {
+                if (_usedMethods.Contains(method.FullName))
+                {
+                    slots.Add(method);
+                }
+            }
+
+            return slots.ToArray();
+        }
+    }
+}

--- a/ILCompiler/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
@@ -5,18 +5,19 @@ namespace ILCompiler.Compiler.DependencyAnalysis
     public class VirtualMethodUseNode : DependencyNode
     {
         public MethodDesc Method { get; }
-        public override IList<IDependencyNode> Dependencies { get; set; }
 
         public override string Name => Method.FullName;
 
         public VirtualMethodUseNode(MethodDesc method)
-        {
+        {       
             Method = method;
-            Dependencies = new List<IDependencyNode>();
         }
 
-        public override IList<IDependencyNode> GetStaticDependencies(DependencyNodeContext context) => Dependencies;
-        public override IList<ConditionalDependency> GetConditionalStaticDependencies(DependencyNodeContext context) => new List<ConditionalDependency>();
-
+        public override void OnMarked(NodeFactory factory)
+        {
+            // The virtual method is being used so record that a slot is required in the VTable
+            var vTableSlice = factory.VTable(Method.DeclaringType);
+            vTableSlice.AddEntry(Method);
+        }
     }
 }

--- a/ILCompiler/Compiler/DependencyAnalysis/Z80MethodCodeNode.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/Z80MethodCodeNode.cs
@@ -12,12 +12,9 @@ namespace ILCompiler.Compiler.DependencyAnalysis
             Method = method;
             ParamsCount = method.Parameters().Count;
             LocalsCount = method.Body?.Variables.Count ?? 0;
-            Dependencies = new List<IDependencyNode>();
         }
 
         public string? MethodCode { get; set; }
-
-        public override IList<IDependencyNode> Dependencies { get; set; }
 
         public int ParamsCount { get; set; }
         public int LocalsCount { get; set; }
@@ -25,11 +22,7 @@ namespace ILCompiler.Compiler.DependencyAnalysis
         public override IList<IDependencyNode> GetStaticDependencies(DependencyNodeContext context)
         {
             var scanner = new ILScanner(Method, context.NodeFactory, context.CorLibModuleProvider, context.PreinitializationManager);
-            Dependencies = scanner.FindDependencies();
-            
-            return Dependencies;
+            return scanner.FindDependencies();
         }
-
-        public override IList<ConditionalDependency> GetConditionalStaticDependencies(DependencyNodeContext context) => new List<ConditionalDependency>();
     }
 }

--- a/ILCompiler/IoC/ServiceProviderFactory.cs
+++ b/ILCompiler/IoC/ServiceProviderFactory.cs
@@ -56,6 +56,8 @@ namespace ILCompiler.IoC
 
             services.AddTransient<IObjectAllocator, ObjectAllocator>();
 
+            services.AddSingleton<NodeFactory>();
+
             services.AddSingleton<NativeDependencyAnalyser>();
 
             services.AddSingleton<Z80Writer>();


### PR DESCRIPTION
Introduce VTableSliceNode to hold used virtual methods to enable generation of VTable during code generation.
Tidy up dependency analyzer classes to remove unnecessary code