### PR TITLE
Use dynamic dispatch when calling virtual methods

### DIFF
--- a/ILCompiler/Compiler/CodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerator.cs
@@ -15,23 +15,25 @@ namespace ILCompiler.Compiler
         private readonly ICodeGeneratorFactory _codeGeneratorFactory;
         private readonly IConfiguration _configuration;
         private readonly CorLibModuleProvider _corLibModuleProvider;
+        private readonly NodeFactory _nodeFactory;
 
         private readonly Dictionary<string, string> _labelsToStringData = new();
 
         private CodeGeneratorContext _context = null!;
 
-        public CodeGenerator(INameMangler nameMangler, ILogger<CodeGenerator> logger, ICodeGeneratorFactory codeGeneratorFactory, IConfiguration configuration, CorLibModuleProvider corLibModuleProvider)
+        public CodeGenerator(INameMangler nameMangler, ILogger<CodeGenerator> logger, ICodeGeneratorFactory codeGeneratorFactory, IConfiguration configuration, CorLibModuleProvider corLibModuleProvider, NodeFactory nodeFactory)
         {
             _nameMangler = nameMangler;
             _logger = logger;
             _codeGeneratorFactory = codeGeneratorFactory;
             _configuration = configuration;
             _corLibModuleProvider = corLibModuleProvider;
+            _nodeFactory = nodeFactory;
         }
 
         public IList<Instruction> Generate(IList<BasicBlock> blocks, LocalVariableTable locals, Z80MethodCodeNode methodCodeNode)
         {
-            _context = new CodeGeneratorContext(locals, methodCodeNode, _configuration, _nameMangler);
+            _context = new CodeGeneratorContext(locals, methodCodeNode, _configuration, _nameMangler, _nodeFactory);
 
             AssignFrameOffsets();
 

--- a/ILCompiler/Compiler/CodeGenerators/CallCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/CallCodeGenerator.cs
@@ -40,7 +40,7 @@ namespace ILCompiler.Compiler.CodeGenerators
 
             if (targetMethod == null)
             {
-                throw new ArgumentNullException("Virtual CallEntry must have non-null Method");
+                throw new InvalidOperationException("Virtual CallEntry must have non-null Method");
             }
 
             int slot = VirtualMethodSlotHelper.GetVirtualMethodSlot(context.NodeFactory, targetMethod, targetMethod.DeclaringType);

--- a/ILCompiler/Compiler/CodeGenerators/CallCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/CallCodeGenerator.cs
@@ -7,6 +7,18 @@ namespace ILCompiler.Compiler.CodeGenerators
     {
         public void GenerateCode(CallEntry entry, CodeGeneratorContext context)
         {
+            if (entry.IsVirtual)
+            {
+                GenerateCodeForVirtualCall(entry, context);
+            }
+            else
+            {
+                GenerateCodeForCall(entry, context);
+            }
+        }
+
+        private static void GenerateCodeForCall(CallEntry entry, CodeGeneratorContext context)
+        {
             if (entry.IsInternalCall && entry.Arguments.Count > 0)
             {
                 // Pass last argument in HL for Ptr type
@@ -20,6 +32,49 @@ namespace ILCompiler.Compiler.CodeGenerators
                 }
             }
             context.Emitter.Call(entry.TargetMethod);
+        }
+
+        private static void GenerateCodeForVirtualCall(CallEntry entry, CodeGeneratorContext context)
+        {
+            var targetMethod = entry.Method;
+
+            if (targetMethod == null)
+            {
+                throw new ArgumentNullException("Virtual CallEntry must have non-null Method");
+            }
+
+            int slot = VirtualMethodSlotHelper.GetVirtualMethodSlot(context.NodeFactory, targetMethod, targetMethod.DeclaringType);
+
+            // EEType header comprises of following:
+            //    2 bytes for Flags
+            //    2 bytes for base size
+            //    2 bytes for related type
+            const int eeTypeHeader = 3 * 2;
+
+            // Get this pointer into HL
+            context.Emitter.Pop(HL);
+            context.Emitter.Push(HL);
+
+            // Get address of EEType into HL from first 2 btytes of object
+            context.Emitter.Ld(E, __[HL]);
+            context.Emitter.Inc(HL);
+            context.Emitter.Ld(D, __[HL]);
+            context.Emitter.Ld(H, D);
+            context.Emitter.Ld(L, E);
+
+            // Find slot in VTable
+            context.Emitter.Ld(DE, (byte)((slot * 2) + eeTypeHeader));
+            context.Emitter.Add(HL, DE);
+
+            // Get content of slot into HL
+            context.Emitter.Ld(E, __[HL]);
+            context.Emitter.Inc(HL);
+            context.Emitter.Ld(D, __[HL]);
+            context.Emitter.Ld(H, D);
+            context.Emitter.Ld(L, E);
+
+            // Call (HL)
+            context.Emitter.Call("JPHL");
         }
     }
 }

--- a/ILCompiler/Compiler/CodeGenerators/CodeGeneratorContext.cs
+++ b/ILCompiler/Compiler/CodeGenerators/CodeGeneratorContext.cs
@@ -14,17 +14,19 @@ namespace ILCompiler.Compiler.CodeGenerators
         public MethodDesc Method => _method.Method;
 
         public INameMangler NameMangler { get; }
+        public NodeFactory NodeFactory { get; }
 
         private readonly Z80MethodCodeNode _method;
 
         public readonly IConfiguration Configuration;
 
-        public CodeGeneratorContext(LocalVariableTable localVariableTable, Z80MethodCodeNode method, IConfiguration configuration, INameMangler nameMangler)
+        public CodeGeneratorContext(LocalVariableTable localVariableTable, Z80MethodCodeNode method, IConfiguration configuration, INameMangler nameMangler, NodeFactory nodeFactory)
         {
             LocalVariableTable = localVariableTable;
             _method = method;
             Configuration = configuration;
             NameMangler = nameMangler;
+            NodeFactory = nodeFactory;
         }
     }
 }

--- a/ILCompiler/Compiler/Emit/Emitter.cs
+++ b/ILCompiler/Compiler/Emit/Emitter.cs
@@ -43,6 +43,14 @@ namespace ILCompiler.Compiler.Emit
         public void Halt() => EmitInstruction(Instruction.Create(Opcode.Halt));
         public void Inc(Register16 register) => EmitInstruction(Instruction.Create(Opcode.Inc, register));
         public void Jp(string target) => EmitInstruction(Instruction.CreateBranch(Opcode.Jp, target));
+        public void Jp(MemoryOperand target)
+        {
+            if (target.Register != Register.HL)
+            {
+                throw new NotSupportedException("Indirect jump only supports HL");
+            }
+            EmitInstruction(Instruction.Create(Opcode.Jp, target));
+        }
         public void Jp(Condition condition, string target) => EmitInstruction(Instruction.CreateBranch(Opcode.Jp, condition, target));
         public void Ld(Register8 target, Register8 source) => EmitInstruction(Instruction.Create(Opcode.Ld, target, source));
         public void Ld(Register16 target, Register16 source) => EmitInstruction(Instruction.Create(Opcode.Ld, target, source));

--- a/ILCompiler/Compiler/Emit/Instruction.cs
+++ b/ILCompiler/Compiler/Emit/Instruction.cs
@@ -74,6 +74,9 @@ namespace ILCompiler.Compiler.Emit
         public static Instruction Create(Opcode opcode, ushort target)
             => new() { Opcode = opcode, Op0 = new() { Immediate = target } };
 
+        public static Instruction Create(Opcode opcode, MemoryOperand target)
+            => new() { Opcode = opcode, Op0 = new() { Memory = target } };
+
         public static Instruction Create(Opcode opcode, MemoryOperand target, Register source) 
             => new() { Opcode = opcode, Op0 = new() { Memory = target }, Op1 = new() { Register = source } };
         public static Instruction Create(Opcode opcode, MemoryOperand target, byte source)

--- a/ILCompiler/Compiler/EvaluationStack/CallEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/CallEntry.cs
@@ -1,4 +1,6 @@
-﻿namespace ILCompiler.Compiler.EvaluationStack
+﻿using dnlib.DotNet;
+
+namespace ILCompiler.Compiler.EvaluationStack
 {
     public class CallEntry : StackEntry
     {
@@ -6,17 +8,22 @@
         public IList<StackEntry> Arguments { get; }
 
         public bool IsInternalCall { get; }
+        public bool IsVirtual { get; }
 
-        public CallEntry(string targetMethod, IList<StackEntry> arguments, VarType returnType, int? returnSize, bool isInternalCall = false) : base(returnType, returnSize)
+        public MethodDef? Method { get; }
+
+        public CallEntry(string targetMethod, IList<StackEntry> arguments, VarType returnType, int? returnSize, bool isInternalCall = false, bool isVirtual = false, MethodDef? method = null) : base(returnType, returnSize)
         {
             TargetMethod = targetMethod;
             Arguments = arguments;
             IsInternalCall = isInternalCall;
+            IsVirtual = isVirtual;
+            Method = method;
         }
 
         public override StackEntry Duplicate()
         {
-            return new CallEntry(TargetMethod, Arguments, Type, ExactSize, IsInternalCall);
+            return new CallEntry(TargetMethod, Arguments, Type, ExactSize, IsInternalCall, IsVirtual, Method);
         }
 
         public override void Accept(IStackEntryVisitor visitor)

--- a/ILCompiler/Compiler/Morpher.cs
+++ b/ILCompiler/Compiler/Morpher.cs
@@ -45,7 +45,7 @@ namespace ILCompiler.Compiler
                     break;
 
                 case CallEntry c:
-                    tree = new CallEntry(c.TargetMethod, MorphList(c.Arguments), c.Type, c.ExactSize, c.IsInternalCall);
+                    tree = new CallEntry(c.TargetMethod, MorphList(c.Arguments), c.Type, c.ExactSize, c.IsInternalCall, c.IsVirtual, c.Method);
                     break;
 
                 case BinaryOperator bo:

--- a/ILCompiler/Compiler/VirtualMethodSlotHelper.cs
+++ b/ILCompiler/Compiler/VirtualMethodSlotHelper.cs
@@ -1,0 +1,44 @@
+﻿using dnlib.DotNet;
+using ILCompiler.Compiler.DependencyAnalysis;
+
+namespace ILCompiler.Compiler
+{
+    public static class VirtualMethodSlotHelper
+    {
+        public static int GetVirtualMethodSlot(NodeFactory factory, MethodDef method, TypeDef implType)
+        {
+            var owningType = method.DeclaringType;
+            int baseSlots = GetNumberOfBaseSlots(factory, owningType);
+
+            IReadOnlyList<MethodDef> virtualSlots = factory.VTable(owningType).GetSlots();
+            int methodSlot = -1;
+            for (int slot = 0; slot < virtualSlots.Count; slot++) 
+            { 
+                if (virtualSlots[slot] == method)
+                {
+                    methodSlot = slot;
+                    break;
+                }
+            }
+
+            return methodSlot == -1 ? -1 : baseSlots + methodSlot;
+        }
+
+        private static int GetNumberOfBaseSlots(NodeFactory factory, TypeDef owningType) 
+        {
+            int baseSlots = 0;
+
+            var baseType = owningType.BaseType;
+            while (baseType != null)
+            {
+                var resolvedBaseType = baseType.ResolveTypeDefThrow();
+                IReadOnlyList<MethodDef> baseVirtualSlots = factory.VTable(resolvedBaseType).GetSlots();
+                baseSlots += baseVirtualSlots.Count;
+
+                baseType = baseType.GetBaseType();
+            }
+
+            return baseSlots;
+        }
+    }
+}

--- a/ILCompiler/Compiler/Z80Writer.cs
+++ b/ILCompiler/Compiler/Z80Writer.cs
@@ -206,11 +206,15 @@ namespace ILCompiler.Compiler
 
         private void OutputEpilog()
         {
+            // Emit stub for simulating Call (HL)
+            var emitter = new Emitter();
+            emitter.CreateLabel("JPHL");
+            emitter.Jp(__[HL]);
+
             OutputRuntimeCode();
 
             _out.WriteLine();
 
-            var emitter = new Emitter();
             emitter.CreateLabel(Heap);
             emitter.End(Entry);
 


### PR DESCRIPTION
Dynamic dispatch via slots in vtables for calling virtual methods.

Last piece for #70 to actually get working virtual methods.
However some tidyup will be needed in later PR including lifting out the z80 code for the dynamic dispatch including the CALL (HL) stub into a shared runtime assembly routine. Also consider creating a separate CallVirtualEntry.