### PR TITLE
Lift out dynamic dispatch code from CallCodeGenerator into new VirtualCall assembly file

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/CallCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/CallCodeGenerator.cs
@@ -50,31 +50,9 @@ namespace ILCompiler.Compiler.CodeGenerators
             //    2 bytes for base size
             //    2 bytes for related type
             const int eeTypeHeader = 3 * 2;
+            context.Emitter.Ld(BC, (byte)((slot * 2) + eeTypeHeader));
 
-            // Get this pointer into HL
-            context.Emitter.Pop(HL);
-            context.Emitter.Push(HL);
-
-            // Get address of EEType into HL from first 2 btytes of object
-            context.Emitter.Ld(E, __[HL]);
-            context.Emitter.Inc(HL);
-            context.Emitter.Ld(D, __[HL]);
-            context.Emitter.Ld(H, D);
-            context.Emitter.Ld(L, E);
-
-            // Find slot in VTable
-            context.Emitter.Ld(DE, (byte)((slot * 2) + eeTypeHeader));
-            context.Emitter.Add(HL, DE);
-
-            // Get content of slot into HL
-            context.Emitter.Ld(E, __[HL]);
-            context.Emitter.Inc(HL);
-            context.Emitter.Ld(D, __[HL]);
-            context.Emitter.Ld(H, D);
-            context.Emitter.Ld(L, E);
-
-            // Call (HL)
-            context.Emitter.Call("JPHL");
+            context.Emitter.Call("VirtualCall");
         }
     }
 }

--- a/ILCompiler/Compiler/Z80Writer.cs
+++ b/ILCompiler/Compiler/Z80Writer.cs
@@ -206,15 +206,11 @@ namespace ILCompiler.Compiler
 
         private void OutputEpilog()
         {
-            // Emit stub for simulating Call (HL)
-            var emitter = new Emitter();
-            emitter.CreateLabel("JPHL");
-            emitter.Jp(__[HL]);
-
             OutputRuntimeCode();
 
             _out.WriteLine();
 
+            var emitter = new Emitter();
             emitter.CreateLabel(Heap);
             emitter.End(Entry);
 

--- a/ILCompiler/ILCompiler.csproj
+++ b/ILCompiler/ILCompiler.csproj
@@ -81,6 +81,7 @@
     <None Remove="Runtime\TRS80\ticks.asm" />
 	<None Remove="Runtime\TRS80\setres.asm" />
 	<None Remove="Runtime\TRS80\setxy.asm" />
+	<None Remove="Runtime\VirtualCall.asm" />
 	<None Remove="Runtime\ZXSpectrum\beep.asm" />
 	<None Remove="Runtime\ZXSpectrum\cls.asm" />
 	<None Remove="Runtime\ZXSpectrum\delay.asm" />
@@ -108,6 +109,7 @@
     <EmbeddedResource Include="Runtime\GCGetTotalMemory.asm" />
     <EmbeddedResource Include="Runtime\Memcpy.asm" />
     <EmbeddedResource Include="Runtime\Memset.asm" />
+    <EmbeddedResource Include="Runtime\VirtualCall.asm" />
     <EmbeddedResource Include="Runtime\NewString.asm" />
     <EmbeddedResource Include="Runtime\print.asm" />
     <EmbeddedResource Include="Runtime\NewArray.asm" />

--- a/ILCompiler/Runtime/VirtualCall.asm
+++ b/ILCompiler/Runtime/VirtualCall.asm
@@ -1,0 +1,28 @@
+; This routine performs a virtual call by dynamic dispatch through the VTable
+;
+; Uses: HL, DE, BC
+;
+; On Entry: BC = VTable offset
+
+VirtualCall:	
+	POP DE		; Return address
+	POP HL		; This pointer
+
+	PUSH HL		; Restore stack
+	PUSH DE
+
+	LD E, (HL)	; Get EEType Ptr into HL
+	INC HL
+	LD D, (HL)
+	LD H, D
+	LD L, E
+
+	ADD HL, BC	; Add VTable slot offset to EEType Ptr
+
+	LD E, (HL)	; Get entry in VTable slot into HL
+	INC HL
+	LD D, (HL)
+	LD H, D
+	LD L, E
+
+	JP (HL)		; Dynamic dispatch


### PR DESCRIPTION
Refactor CallCodeGenerator to use assembly routine doing the heavy lifting of dynamic dispatch. Reduces overhead in terms of instructions per virtual call site to one extra compared to normal non-virtual call. e.g.

```
LD BC, n   ; n is offset to slot in EEType
CALL VirtualCall

```
Versus

`CALL NonVirtualMethod
`
Obviously there is the added overhead of instructions in the VirtualCall.asm but this is a one time cost compared to a per virtual call cost.