### PR TITLE
Remove CallEntry.IsInternalCall

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/CallCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/CallCodeGenerator.cs
@@ -19,7 +19,7 @@ namespace ILCompiler.Compiler.CodeGenerators
 
         private static void GenerateCodeForCall(CallEntry entry, CodeGeneratorContext context)
         {
-            if (entry.IsInternalCall && entry.Arguments.Count > 0)
+            if (entry.Method != null && entry.Method.IsInternalCall && entry.Arguments.Count > 0)
             {
                 // Pass last argument in HL for Ptr type
                 // and in HL, DE otherwise

--- a/ILCompiler/Compiler/EvaluationStack/CallEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/CallEntry.cs
@@ -6,24 +6,21 @@ namespace ILCompiler.Compiler.EvaluationStack
     {
         public string TargetMethod { get; }
         public IList<StackEntry> Arguments { get; }
-
-        public bool IsInternalCall { get; }
         public bool IsVirtual { get; }
 
         public MethodDef? Method { get; }
 
-        public CallEntry(string targetMethod, IList<StackEntry> arguments, VarType returnType, int? returnSize, bool isInternalCall = false, bool isVirtual = false, MethodDef? method = null) : base(returnType, returnSize)
+        public CallEntry(string targetMethod, IList<StackEntry> arguments, VarType returnType, int? returnSize, bool isVirtual = false, MethodDef? method = null) : base(returnType, returnSize)
         {
             TargetMethod = targetMethod;
             Arguments = arguments;
-            IsInternalCall = isInternalCall;
             IsVirtual = isVirtual;
             Method = method;
         }
 
         public override StackEntry Duplicate()
         {
-            return new CallEntry(TargetMethod, Arguments, Type, ExactSize, IsInternalCall, IsVirtual, Method);
+            return new CallEntry(TargetMethod, Arguments, Type, ExactSize, IsVirtual, Method);
         }
 
         public override void Accept(IStackEntryVisitor visitor)

--- a/ILCompiler/Compiler/Importer/CallImporter.cs
+++ b/ILCompiler/Compiler/Importer/CallImporter.cs
@@ -113,25 +113,11 @@ namespace ILCompiler.Compiler.Importer
                 targetMethod = context.NameMangler.GetMangledMethodName(methodToCall);
             }
 
-            bool directCall = false;
-            if (methodToCall.IsStatic)
-            {
-                directCall = true;
-            }
-            else if (instruction.OpCode.Code != Code.Callvirt)
-            {
-                directCall = true;
-            }
-            else if (!methodToCall.IsVirtual)
-            {
-                directCall = true;
-            }
-
+            bool directCall = !(instruction.OpCode.Code == Code.Callvirt && methodToCall.IsVirtual);
             if (methodToCall.HasGenericParameters && !directCall)
             {
                 throw new NotSupportedException("Non direct calls to generic methods not supported");
             }
-
 
             int returnBufferArgIndex = 0;
             var returnType = GenericTypeInstantiator.Instantiate(methodToCall.ReturnType, method, context.Method);
@@ -146,7 +132,7 @@ namespace ILCompiler.Compiler.Importer
             int? returnTypeSize = methodToCall.HasReturnType ? returnType.GetInstanceFieldSize() : null;
 
             var returnVarType = methodToCall.HasReturnType ? returnType.GetVarType() : VarType.Void;
-            StackEntry callNode = new CallEntry(targetMethod, arguments, returnVarType, returnTypeSize, methodToCall.IsInternalCall, !directCall, methodToCall);
+            StackEntry callNode = new CallEntry(targetMethod, arguments, returnVarType, returnTypeSize, !directCall, methodToCall);
 
             if (methodToCall.IsStatic && !context.PreinitializationManager.IsPreinitialized(methodToCall.DeclaringType))
             {

--- a/ILCompiler/Compiler/Morpher.cs
+++ b/ILCompiler/Compiler/Morpher.cs
@@ -45,7 +45,7 @@ namespace ILCompiler.Compiler
                     break;
 
                 case CallEntry c:
-                    tree = new CallEntry(c.TargetMethod, MorphList(c.Arguments), c.Type, c.ExactSize, c.IsInternalCall, c.IsVirtual, c.Method);
+                    tree = new CallEntry(c.TargetMethod, MorphList(c.Arguments), c.Type, c.ExactSize, c.IsVirtual, c.Method);
                     break;
 
                 case BinaryOperator bo:


### PR DESCRIPTION
Remove CallEntry.IsInternalCall 
Simplify logic to calculate if call is direct or not