### PR TITLE
Add slot counts into EEType

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/CallCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/CallCodeGenerator.cs
@@ -49,7 +49,9 @@ namespace ILCompiler.Compiler.CodeGenerators
             //    2 bytes for Flags
             //    2 bytes for base size
             //    2 bytes for related type
-            const int eeTypeHeader = 3 * 2;
+            //    1 byte for vtable slot count
+            //    1 byte for interface slot count
+            const int eeTypeHeader = 2 + 2 + 2 + 1 + 1;
             context.InstructionsBuilder.Ld(BC, (byte)((slot * 2) + eeTypeHeader));
 
             context.InstructionsBuilder.Call("VirtualCall");

--- a/ILCompiler/Compiler/Emit/Instruction.cs
+++ b/ILCompiler/Compiler/Emit/Instruction.cs
@@ -28,7 +28,7 @@ namespace ILCompiler.Compiler.Emit
 
             FormatOpcode(stringBuilder);
 
-            if (Comment != null)
+            if (!string.IsNullOrEmpty(Comment))
             {
                 stringBuilder.Append(" ;");
                 stringBuilder.Append(Comment);
@@ -78,8 +78,8 @@ namespace ILCompiler.Compiler.Emit
         public static Instruction Create(Opcode opcode, string target)
             => new() { Opcode = opcode, Op0 = new() { Label = target } };
 
-        public static Instruction Create(Opcode opcode, ushort target)
-            => new() { Opcode = opcode, Op0 = new() { Immediate = target } };
+        public static Instruction Create(Opcode opcode, ushort target, string? comment = null)
+            => new() { Opcode = opcode, Op0 = new() { Immediate = target }, Comment = comment };
 
         public static Instruction Create(Opcode opcode, MemoryOperand target)
             => new() { Opcode = opcode, Op0 = new() { Memory = target } };
@@ -112,7 +112,7 @@ namespace ILCompiler.Compiler.Emit
         public static Instruction CreateDeclareByte(Opcode opcode, string data)
             => new() { Opcode = opcode, Op0 = new() { Data = data } };
 
-        public static Instruction CreateDeclareWord(Opcode opcode, string label)
-            => new() { Opcode = opcode, Op0 = new() { Label = label } };
+        public static Instruction CreateDeclareWord(Opcode opcode, string label, string? comment = null)
+            => new() { Opcode = opcode, Op0 = new() { Label = label }, Comment = comment };
     }
 }

--- a/ILCompiler/Compiler/Emit/InstructionsBuilder.cs
+++ b/ILCompiler/Compiler/Emit/InstructionsBuilder.cs
@@ -11,6 +11,20 @@ namespace ILCompiler.Compiler.Emit
             Instructions.Add(instruction);
         }
 
+        public int ReserveByte()
+        {
+            var reservationIndex = Instructions.Count;
+
+            AddInstruction(Instruction.Create(Opcode.Db, (ushort)0));
+
+            return reservationIndex;
+        }
+
+        public void UpdateReservation(int reservationIndex, Instruction instruction)
+        {
+            Instructions[reservationIndex] = instruction;
+        }
+
         public void Reset()
         {
             Instructions.Clear();
@@ -77,9 +91,9 @@ namespace ILCompiler.Compiler.Emit
         // Pseudo instructions
         public void Db(string source) => AddInstruction(Instruction.CreateDeclareByte(Opcode.Db, source));
         public void Db(string label, string source) => AddInstruction(Instruction.CreateDeclareByte(Opcode.Db, source, label));
-        public void Db(byte b) => AddInstruction(Instruction.Create(Opcode.Db, b));
-        public void Dw(string source) => AddInstruction(Instruction.CreateDeclareWord(Opcode.Dw, source));
-        public void Dw(ushort w) => AddInstruction(Instruction.Create(Opcode.Dw, w));
+        public void Db(byte b, string? comment = null) => AddInstruction(Instruction.Create(Opcode.Db, b, comment));
+        public void Dw(string source, string? comment = null) => AddInstruction(Instruction.CreateDeclareWord(Opcode.Dw, source, comment));
+        public void Dw(ushort w, string? comment = null) => AddInstruction(Instruction.Create(Opcode.Dw, w, comment));
         public void Defs(ushort size) => AddInstruction(Instruction.Create(Opcode.Defs, size));
         public void Dc(ushort count, ushort value) => AddInstruction(Instruction.Create(Opcode.Dc, count, value));
         public void Org(ushort target) => AddInstruction(Instruction.Create(Opcode.Org, target));

--- a/ILCompiler/Runtime/NewObject.asm
+++ b/ILCompiler/Runtime/NewObject.asm
@@ -5,8 +5,6 @@
 ; On Entry: BC = EETypePtr, DE = size to allocate
 ; On Exit: HL = pointer to allocated object
 
-OFFSET_BASESIZE		EQU 0
-
 NewObject:	
 
 	; Allocate and check if hit stack


### PR DESCRIPTION
This is required for interface generic resolver which will need to skip over the vtable to find the dispatch maps and know how many dispatch maps there are.

Used a single byte for the slot counts but given nature of Z80 architecture this should be fine.

Next piece of puzzle for #386 