### PR TITLE
Add initial codegen support for interface dispatch.

### DIFF
--- a/ILCompiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -196,12 +196,12 @@ namespace ILCompiler.Compiler.DependencyAnalysis
                     if (implMethod != null)
                     {
                         int emittedInterfaceSlot = interfaceMethodSlot;
-                        int emittedImplSlot = VirtualMethodSlotHelper.GetVirtualMethodSlot(_nodeFactory, implMethod, resolvedType);
+                        int emittedImplSlot = VirtualMethodSlotHelper.GetVirtualMethodSlot(_nodeFactory, implMethod);
 
                         instructionsBuilder.Comment($"Interface {interfaceType.FullName}, {method.FullName}, {implMethod.FullName}");
                         instructionsBuilder.Db((byte)interfaceIndex, "Interface index");
                         instructionsBuilder.Db((byte)emittedInterfaceSlot, "Interface slot");
-                        instructionsBuilder.Dw((ushort)emittedImplSlot, "Implementation slot");
+                        instructionsBuilder.Dw((byte)emittedImplSlot, "Implementation slot");
 
                         _interfaceSlotCount++;
                     }

--- a/ILCompiler/Compiler/VirtualMethodSlotHelper.cs
+++ b/ILCompiler/Compiler/VirtualMethodSlotHelper.cs
@@ -5,7 +5,7 @@ namespace ILCompiler.Compiler
 {
     public static class VirtualMethodSlotHelper
     {
-        public static int GetVirtualMethodSlot(NodeFactory factory, MethodDef method, TypeDef implType)
+        public static int GetVirtualMethodSlot(NodeFactory factory, MethodDef method)
         {
             var owningType = method.DeclaringType;
             int baseSlots = GetNumberOfBaseSlots(factory, owningType);


### PR DESCRIPTION
- calculates interface slot but needs to call the generic resolver
- Use single byte for implementation slot
- Remove unnecessary parameter in GetVirtualMethodSlot