### PR TITLE
Add interface map

### DIFF
--- a/ILCompiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -1,0 +1,35 @@
+﻿using dnlib.DotNet;
+using ILCompiler.Compiler.DependencyAnalysisFramework;
+using ILCompiler.Compiler.Emit;
+using ILCompiler.Interfaces;
+
+namespace ILCompiler.Compiler.DependencyAnalysis
+{
+    public class EETypeNode : DependencyNode
+    {
+        public ITypeDefOrRef Type { get; private set; }
+
+        public override string Name => Type.FullName;
+
+        protected readonly INameMangler _nameMangler;
+
+        public EETypeNode(ITypeDefOrRef type, INameMangler nameMangler)
+        {
+            Type = type;
+            _nameMangler = nameMangler;
+        }
+
+        public string MangledTypeName => _nameMangler.GetMangledTypeName(Type);
+
+        public override IList<Instruction> GetInstructions(string inputFilePath)
+        {
+            var instructionsBuilder = new InstructionsBuilder();
+            instructionsBuilder.Comment($"{Type.FullName}");
+
+            // Need to mangle full field name here
+            instructionsBuilder.Label(MangledTypeName);
+
+            return instructionsBuilder.Instructions;
+        }
+    }
+}

--- a/ILCompiler/Compiler/DependencyAnalysis/ILScanner.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/ILScanner.cs
@@ -204,6 +204,11 @@ namespace ILCompiler.Compiler.DependencyAnalysis
                         method = dependentMethod;
                     }
 
+                    if (methodDef.DeclaringType.IsInterface)
+                    {
+                        _dependencies.Add(_nodeFactory.NecessaryTypeSymbol(methodDef.DeclaringType));
+                    }
+
                     bool directCall = IsDirectCall(methodDef, instruction.OpCode.Code);
                     if (directCall)
                     {

--- a/ILCompiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -13,6 +13,7 @@ namespace ILCompiler.Compiler.DependencyAnalysis
         private readonly IDictionary<string, VirtualMethodUseNode> _virtualMethodNodesByFullName = new Dictionary<string, VirtualMethodUseNode>();
         private readonly IDictionary<string, ConstructedEETypeNode> _constructedEETypeNodesByFullName = new Dictionary<string, ConstructedEETypeNode>();
         private readonly IDictionary<TypeDef, VTableSliceNode> _vTableNodes = new Dictionary<TypeDef, VTableSliceNode>();
+        private readonly IDictionary<ITypeDefOrRef, EETypeNode> _necessaryTypeSymbolNodes = new Dictionary<ITypeDefOrRef, EETypeNode>();
 
         private readonly PreinitializationManager _preinitializationManager;
         private readonly INameMangler _nameMangler;
@@ -34,6 +35,17 @@ namespace ILCompiler.Compiler.DependencyAnalysis
             }
 
             return constructedEETypeNode;
+        }
+
+        public EETypeNode NecessaryTypeSymbol(ITypeDefOrRef type)
+        {
+            if (!_necessaryTypeSymbolNodes.TryGetValue(type, out var necessaryTypeSymbolNode))
+            {
+                necessaryTypeSymbolNode = new EETypeNode(type, _nameMangler);
+                _necessaryTypeSymbolNodes[type] = necessaryTypeSymbolNode;
+            }
+
+            return necessaryTypeSymbolNode;
         }
 
         public StaticsNode StaticsNode(FieldDef field)


### PR DESCRIPTION
Add interface map to constructed EEType
Introduce new lightweight EEType represented just by a symbol with no instructions - used for interface types in the interface map
Finish code gen for interface calls to call new InterfaceCall routine (yet to be written).