### PR TITLE
Resolve interface method to default implementation

### DIFF
--- a/ILCompiler/Common/TypeSystem/Common/DefaultInterfaceMethodResolution.cs
+++ b/ILCompiler/Common/TypeSystem/Common/DefaultInterfaceMethodResolution.cs
@@ -1,0 +1,10 @@
+﻿namespace ILCompiler.Common.TypeSystem.Common
+{
+    public enum DefaultInterfaceMethodResolution
+    {
+        None,
+        DefaultImplementation,
+        Reabstraction,
+        Diamond,
+    }
+}

--- a/ILCompiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -240,10 +240,17 @@ namespace ILCompiler.Compiler.DependencyAnalysis
                         // No need to emit a dispatch map in this case as the runtime interface dispatch code will
                         // walk the inheritance chain
 
-                        // TODO: Will need to check here for
-                        //  * default implementation
-                        //  * Reabstraction
-                        //  * Diamond
+                        var result = VirtualMethodAlgorithm.ResolveInterfaceMethodToDefaultImplementationOnType(method, resolvedType, out implMethod);
+
+                        if (result != DefaultInterfaceMethodResolution.None)
+                        {
+                            // TODO: Will need to check here for
+                            //  * default implementation
+                            //  * Reabstraction
+                            //  * Diamond
+
+                            throw new NotImplementedException();
+                        }
                     }
                 }
             }

--- a/System.Private.CoreLib/System/Runtime/CompilerServices/RuntimeFeature.cs
+++ b/System.Private.CoreLib/System/Runtime/CompilerServices/RuntimeFeature.cs
@@ -1,0 +1,12 @@
+﻿namespace System.Runtime.CompilerServices
+{
+    public static class RuntimeFeature
+    {
+        public const string DefaultImplementationsOfInterfaces = nameof(DefaultImplementationsOfInterfaces);
+
+        public static bool IsSupported(string feature)
+        {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Resolve interface method to default implementation in order to generate better error message as default interface implementation not currently supported