### PR TITLE
Improve InterfaceCall assembly code

### DIFF
--- a/ILCompiler/Compiler/NativeDependencyAnalyser.cs
+++ b/ILCompiler/Compiler/NativeDependencyAnalyser.cs
@@ -67,7 +67,7 @@ namespace ILCompiler.Compiler
         private static ISet<string> GetCalls(TextReader reader)
         {
             var calls = new HashSet<string>();
-            var callRegex = new Regex(@"^\s*(call)\s*(.*\s*,\s*)?(?<target>\w+)", RegexOptions.IgnoreCase);
+            var callRegex = new Regex(@"^\s*(call|jp)\s*(.*\s*,\s*)?(?<target>\w+)", RegexOptions.IgnoreCase);
 
             var line = reader.ReadLine();
             while (line != null)

--- a/ILCompiler/Runtime/VirtualCall.asm
+++ b/ILCompiler/Runtime/VirtualCall.asm
@@ -17,6 +17,7 @@ VirtualCall:
 	LD H, D
 	LD L, E
 
+VirtualCall_Internal:
 	ADD HL, BC	; Add VTable slot offset to EEType Ptr
 
 	LD E, (HL)	; Get entry in VTable slot into HL


### PR DESCRIPTION
Simplify and eliminate redundant code
Reuse code from virtual call
Track jumps as well as calls when trimming unused assembly routines