### PR TITLE
Use Console.SetCursorPosition only

### DIFF
--- a/Samples/Chess/Chess.cs
+++ b/Samples/Chess/Chess.cs
@@ -53,7 +53,7 @@ namespace Chess
 
         public static void Print(Board board)
         {
-            Console.SetConsoleCursorPosition(0, 0);
+            Console.SetCursorPosition(0, 0);
             Console.WriteLine("   A B C D E F G H");
             Console.WriteLine(" .----------------.");
             for (int rank = 7; rank >= 0; rank--)

--- a/Samples/Mines/Game.cs
+++ b/Samples/Mines/Game.cs
@@ -79,7 +79,7 @@ namespace Mines
         {
             RevealMines();
 
-            Console.SetConsoleCursorPosition((sbyte)(_columns - 4), 0);
+            Console.SetCursorPosition(_columns - 4, 0);
             Console.Write(_revealMines ? Lost : Won);
 
             Thread.Sleep(500);
@@ -118,7 +118,7 @@ namespace Mines
 
         private static void DisplayCell(char cell, int x, int y)
         {
-            Console.SetConsoleCursorPosition((sbyte)(x * 2), (sbyte)y);
+            Console.SetCursorPosition(x * 2, y);
             Console.Write(cell);
         }
 
@@ -136,7 +136,7 @@ namespace Mines
                 Console.WriteLine("+");
             }
 
-            Console.SetConsoleCursorPosition((sbyte)(_columns - 4), 0);
+            Console.SetCursorPosition(_columns - 4, 0);
             Console.Write(Playing);
         }
 
@@ -162,9 +162,9 @@ namespace Mines
 
             _flagged += square.Flagged ? 1 : -1;
 
-            Console.SetConsoleCursorPosition(0, 0);
+            Console.SetCursorPosition(0, 0);
             Console.Write("   ");
-            Console.SetConsoleCursorPosition(0, 0);
+            Console.SetCursorPosition(0, 0);
             Console.Write(_mines - _flagged);
         }
 

--- a/Samples/Snake/Game.cs
+++ b/Samples/Snake/Game.cs
@@ -59,7 +59,7 @@ namespace Snake
 
             SetBoardItem(board, s.HeadX, s.HeadY, true);
 
-            Console.SetConsoleCursorPosition(0, 15);
+            Console.SetCursorPosition(0, 15);
             Console.Write("Score: 0");
 
             while (true)
@@ -95,7 +95,7 @@ namespace Snake
                 if (s.HitTest(foodX, foodY))
                 {
                     _score++;
-                    Console.SetConsoleCursorPosition(7, 15);
+                    Console.SetCursorPosition(7, 15);
                     Console.Write(_score);
 
                     if (s.Extend())
@@ -158,7 +158,7 @@ namespace Snake
                     break;
                 }
 
-                Console.SetConsoleCursorPosition(29, 7);
+                Console.SetCursorPosition(29, 7);
                 Console.Write(result == Result.Win ? "You win" : "You lose");
 
                 Thread.Sleep(3000);

--- a/System.Private.CoreLib/Pal/Console.CPM.cs
+++ b/System.Private.CoreLib/Pal/Console.CPM.cs
@@ -10,10 +10,6 @@ namespace System
             return null;
         }
 
-        public static void SetConsoleCursorPosition(sbyte x, sbyte y)
-        { 
-        }
-
         public static void SetCursorPosition(int x, int y)
         {
         }

--- a/System.Private.CoreLib/Pal/Console.Trs80.cs
+++ b/System.Private.CoreLib/Pal/Console.Trs80.cs
@@ -14,7 +14,7 @@ namespace System
         }
 
         [DllImport(Libraries.Runtime, EntryPoint = "SetXY")]
-        public static unsafe extern void SetConsoleCursorPosition(sbyte x, sbyte y);
+        private static unsafe extern void SetConsoleCursorPosition(sbyte x, sbyte y);
 
         public static unsafe void SetCursorPosition(int x, int y)
         {

--- a/System.Private.CoreLib/Pal/Console.ZXSpectrum.cs
+++ b/System.Private.CoreLib/Pal/Console.ZXSpectrum.cs
@@ -14,7 +14,7 @@ namespace System
         }
 
         [DllImport(Libraries.Runtime, EntryPoint = "SetXY")]
-        public static unsafe extern void SetConsoleCursorPosition(sbyte x, sbyte y);
+        private static unsafe extern void SetConsoleCursorPosition(sbyte x, sbyte y);
 
         public static unsafe void SetCursorPosition(int x, int y) 
         {


### PR DESCRIPTION
Samples have been using Console.SetConsoleCursorPosition which is not part of standard .NET api. This PR corrects the samples to use SetCursorPosition instead and makes the SetConsoleCursorPosition methods private