### PR TITLE
Improve code to download assembler

### DIFF
--- a/ILCompiler/Compiler/Assembler/Z80Assembler.cs
+++ b/ILCompiler/Compiler/Assembler/Z80Assembler.cs
@@ -82,15 +82,27 @@ namespace ILCompiler.Compiler.Z80Assembler
 
         private static void DownloadAssembler(string zmacPath)
         {
+            var tempPath = Path.GetTempFileName();
+
             using (var client = new HttpClient())
             {
                 using (var s = client.GetStreamAsync(ZmacUrl))
                 {
-                    using (var fs = new FileStream(zmacPath, FileMode.OpenOrCreate))
+                    using (var fs = new FileStream(tempPath, FileMode.OpenOrCreate))
                     {
                         s.Result.CopyTo(fs);
                     }
                 }
+            }
+
+            try
+            {
+                File.Move(tempPath, zmacPath);
+            }
+            catch
+            {
+                // Ignore errors as another ILCompiler process running at same time may
+                // have downloaded the compiler already
             }
         }
     }

--- a/ILCompiler/Compiler/Assembler/Z80Assembler.cs
+++ b/ILCompiler/Compiler/Assembler/Z80Assembler.cs
@@ -82,7 +82,7 @@ namespace ILCompiler.Compiler.Z80Assembler
 
         private static void DownloadAssembler(string zmacPath)
         {
-            var tempPath = Path.GetTempFileName();
+            var tempPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
             using (var client = new HttpClient())
             {


### PR DESCRIPTION
Github builds have been failing due to multiple ilcompiler processes running simultaneously.
Fix download of assembler to download to temp file and rename to required file name at the end. Ignore any errors in the renaming as another process may have already renamed an assembler file.