### PR TITLE
Optimise brtrue/brfalse codegen

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/JumpTrueCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/JumpTrueCodeGenerator.cs
@@ -44,7 +44,6 @@ namespace ILCompiler.Compiler.CodeGenerators
 
             var condition = binOp.Operation == Operation.Eq ? Condition.Z : Condition.NZ;
             context.InstructionsBuilder.Jp(condition, entry.TargetLabel);
-            return;
         }
     }
 }

--- a/ILCompiler/Compiler/CodeGenerators/JumpTrueCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/JumpTrueCodeGenerator.cs
@@ -8,12 +8,43 @@ namespace ILCompiler.Compiler.CodeGenerators
     {
         public void GenerateCode(JumpTrueEntry entry, CodeGeneratorContext context)
         {
+            var binOp = (BinaryOperator)entry.Condition;
+
+            if (binOp.Op1.Contained)
+            {
+                GenerateJumpCompareCode(entry, context, binOp);
+                return;
+            }
+
+
             // Pop i4 from stack and jump if non zero
             context.InstructionsBuilder.Pop(HL);      // LSW
             context.InstructionsBuilder.Ld(A, 0);
             context.InstructionsBuilder.Add(A, L);
             context.InstructionsBuilder.Pop(HL);      // MSW
             context.InstructionsBuilder.Jp(Condition.NZ, entry.TargetLabel);
+        }
+
+        private static void GenerateJumpCompareCode(JumpTrueEntry entry, CodeGeneratorContext context, BinaryOperator binOp)
+        {
+            // Compare to 0 and jump
+            if (entry.Condition.Type.GenActualTypeIsI())
+            {
+                context.InstructionsBuilder.Pop(HL);
+                context.InstructionsBuilder.Ld(A, H);
+                context.InstructionsBuilder.Or(L);
+            }
+            else
+            {
+                context.InstructionsBuilder.Pop(HL);
+                context.InstructionsBuilder.Pop(BC);
+                context.InstructionsBuilder.And(A);
+                context.InstructionsBuilder.Sbc(HL, BC);
+            }
+
+            var condition = binOp.Operation == Operation.Eq ? Condition.Z : Condition.NZ;
+            context.InstructionsBuilder.Jp(condition, entry.TargetLabel);
+            return;
         }
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/ConstantEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/ConstantEntry.cs
@@ -8,7 +8,7 @@
 
         public static ConstantEntry CreateZeroConstantEntry(VarType type)
         {
-            if (type == VarType.Ref || type == VarType.Ptr)
+            if (type.GenActualTypeIsI())
             {
                 return new NativeIntConstantEntry(0);
             }

--- a/ILCompiler/Compiler/Lowerings/JumpTrueLowering.cs
+++ b/ILCompiler/Compiler/Lowerings/JumpTrueLowering.cs
@@ -1,0 +1,27 @@
+﻿using ILCompiler.Compiler.EvaluationStack;
+
+namespace ILCompiler.Compiler.Lowerings
+{
+    internal class JumpTrueLowering : ILowering<JumpTrueEntry>
+    {
+        public StackEntry? Lower(JumpTrueEntry entry)
+        {
+            var condition = entry.Condition;
+
+            if (condition is BinaryOperator binOp && binOp.IsComparison)
+            {
+                if (binOp.Op1.IsIntegralConstant(0) && (binOp.Operation == Operation.Eq || binOp.Operation == Operation.Ne_Un))
+                {
+                    binOp.Op1.Contained = true;
+
+                    // Remove condition from LIR 
+                    // op2 -> op1 -> compare -> jumptrue
+                    // op2 -> op1 -> jumptrue
+                    binOp.Op1.Next = binOp.Next;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/ILCompiler/Compiler/Lowerings/JumpTrueLowering.cs
+++ b/ILCompiler/Compiler/Lowerings/JumpTrueLowering.cs
@@ -8,17 +8,15 @@ namespace ILCompiler.Compiler.Lowerings
         {
             var condition = entry.Condition;
 
-            if (condition is BinaryOperator binOp && binOp.IsComparison)
+            if (condition is BinaryOperator binOp && binOp.IsComparison &&
+                binOp.Op1.IsIntegralConstant(0) && (binOp.Operation == Operation.Eq || binOp.Operation == Operation.Ne_Un))
             {
-                if (binOp.Op1.IsIntegralConstant(0) && (binOp.Operation == Operation.Eq || binOp.Operation == Operation.Ne_Un))
-                {
                     binOp.Op1.Contained = true;
 
                     // Remove condition from LIR 
                     // op2 -> op1 -> compare -> jumptrue
                     // op2 -> op1 -> jumptrue
                     binOp.Op1.Next = binOp.Next;
-                }
             }
 
             return null;

--- a/ILCompiler/Compiler/Lowerings/ServiceCollectionExtensions.cs
+++ b/ILCompiler/Compiler/Lowerings/ServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ namespace ILCompiler.Compiler.Lowerings
         public static IServiceCollection AddLowerings(this IServiceCollection services)
         {
             services.AddSingleton<ILowering<BinaryOperator>, BinaryOperatorLowering>();
+            services.AddSingleton<ILowering<JumpTrueEntry>, JumpTrueLowering>();
             return services;
         }
     }

--- a/ILCompiler/Compiler/TypeList.cs
+++ b/ILCompiler/Compiler/TypeList.cs
@@ -58,6 +58,11 @@
             return type >= VarType.Byte && type <= VarType.UInt;
         }
 
+        public static bool GenActualTypeIsI(this VarType type)
+        {
+            return type == VarType.Ptr || type == VarType.Ref || type == VarType.ByRef;
+        }
+
         public static int GetTypeSize(this VarType type)
         {
             switch (type)


### PR DESCRIPTION
Lower jumptrue where condition is binary operator with 0 as left operand and operator is eq or neq by flagging 0 as contained and removing compare node from LIR. Code gen for lowered form can then generate optimal code for eq/neq comparison to 0 for I and Int types.