### PR TITLE
Mark constant as contained when storing to local variable. Allows code gen to embed the constant into the instructions avoiding use of stack to hold constant.

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/StoreLocalVariableCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/StoreLocalVariableCodeGenerator.cs
@@ -1,5 +1,6 @@
 ﻿using ILCompiler.Compiler.EvaluationStack;
 using System.Diagnostics;
+using static ILCompiler.Compiler.Emit.Registers;
 
 namespace ILCompiler.Compiler.CodeGenerators
 {
@@ -9,7 +10,11 @@ namespace ILCompiler.Compiler.CodeGenerators
         {
             var variable = context.LocalVariableTable[entry.LocalNumber];
 
-            if (variable.Type.IsSmall())
+            if (entry.Op1.Contained)
+            {
+                GenerateStoreConstantToLocal(context, variable, entry.Op1);
+            }
+            else if (variable.Type.IsSmall())
             {
                 // Copy from stack to IX truncating to required size
                 var bytesToCopy = variable.Type.IsByte() ? 1 : 2;
@@ -21,6 +26,46 @@ namespace ILCompiler.Compiler.CodeGenerators
                 // Storing a local variable/argument
                 Debug.Assert(variable.ExactSize % 2 == 0);
                 CopyHelper.CopyFromStackToIX(context.InstructionsBuilder, variable.ExactSize, -variable.StackOffset, restoreIX: true);
+            }
+        }
+
+        /// <summary>
+        /// Generate code to store a constant, taking into account the size of the local variable being stored to, and also
+        /// dealing with the offset of the local variable lying beyond the immediately addressable range via IX
+        /// 
+        /// </summary>
+        /// <param name="context">used for emitting instructions</param>
+        /// <param name="variable">local variable to store to</param>
+        /// <param name="constant">constant, can be Int32Constant or NativeIntConstant</param>
+        private static void GenerateStoreConstantToLocal(CodeGeneratorContext context, LocalVariableDescriptor variable, StackEntry constant)
+        {
+            byte[] intBytes = BitConverter.GetBytes(constant.GetIntConstant());
+
+            var ixOffset = -variable.StackOffset;
+            int changeToIX = 0;
+
+            // offset has to be -128 to + 127
+            if (ixOffset < -128)
+            {
+                // Move IX so new offset will be 0
+                var delta = -ixOffset;
+                context.InstructionsBuilder.Ld(DE, (short)-delta);
+                context.InstructionsBuilder.Add(IX, DE);
+                changeToIX -= delta;
+
+                ixOffset += delta;
+            }
+
+            int bytesToStore = variable.Type.IsByte() ? 1 : variable.ExactSize;
+            for (int i = 0; i < bytesToStore; i++) 
+            {
+                context.InstructionsBuilder.Ld(__[IX + (short)(ixOffset + i)], intBytes[i]);
+            }
+
+            if (changeToIX != 0)
+            {
+                context.InstructionsBuilder.Ld(DE, (short)(-changeToIX));
+                context.InstructionsBuilder.Add(IX, DE);
             }
         }
     }

--- a/ILCompiler/Compiler/EvaluationStack/StackEntryExtensions.cs
+++ b/ILCompiler/Compiler/EvaluationStack/StackEntryExtensions.cs
@@ -4,7 +4,16 @@ namespace ILCompiler.Compiler.EvaluationStack
 {
     public static class StackEntryExtensions
     {
-        public static bool IsIntCnsOrI(this StackEntry entry) => entry is Int32ConstantEntry || entry is NativeIntConstantEntry;
+        public static bool IsIntCnsOrI(this StackEntry entry)
+        {
+            if (entry is Int32ConstantEntry) return true;
+
+            // Ignore NativeIntConstants using a symbolname e.g. T1.
+            if (entry is NativeIntConstantEntry nativeEntry && nativeEntry.SymbolName == String.Empty) return true;
+
+            return false;
+
+        }
 
         public static int GetIntConstant(this StackEntry entry)
         {

--- a/ILCompiler/Compiler/Lowerings/ServiceCollectionExtensions.cs
+++ b/ILCompiler/Compiler/Lowerings/ServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ namespace ILCompiler.Compiler.Lowerings
         {
             services.AddSingleton<ILowering<BinaryOperator>, BinaryOperatorLowering>();
             services.AddSingleton<ILowering<JumpTrueEntry>, JumpTrueLowering>();
+            services.AddSingleton<ILowering<StoreLocalVariableEntry>, StoreLocalVariableLowering>();
             return services;
         }
     }

--- a/ILCompiler/Compiler/Lowerings/StoreLocalVariableLowering.cs
+++ b/ILCompiler/Compiler/Lowerings/StoreLocalVariableLowering.cs
@@ -1,0 +1,19 @@
+﻿using ILCompiler.Compiler.EvaluationStack;
+
+namespace ILCompiler.Compiler.Lowerings
+{
+    internal class StoreLocalVariableLowering : ILowering<StoreLocalVariableEntry>
+    {
+        public StackEntry? Lower(StoreLocalVariableEntry entry)
+        {
+            if (entry.Op1.IsIntCnsOrI())
+            {
+                // When storing constant mark as contained as we can embed the constant
+                // into the instructions to store to the local variable directly
+                entry.Op1.Contained = true;
+            }
+
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Allows code gen to embed the constant into the instructions avoiding use of stack to hold constant.