### PR TITLE
Improve Add/Sub codegen

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/Int32ConstantCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/Int32ConstantCodeGenerator.cs
@@ -11,9 +11,9 @@ namespace ILCompiler.Compiler.CodeGenerators
             var low = BitConverter.ToInt16(BitConverter.GetBytes(value), 0);
             var high = BitConverter.ToInt16(BitConverter.GetBytes(value), 2);
 
-            context.InstructionsBuilder.Ld(HL, high);     //MSW
-            context.InstructionsBuilder.Push(HL);
+            context.InstructionsBuilder.Ld(DE, high);     //MSW
             context.InstructionsBuilder.Ld(HL, low);      //LSW
+            context.InstructionsBuilder.Push(DE);
             context.InstructionsBuilder.Push(HL);
         }
     }


### PR DESCRIPTION
Use Inc/Dec for 16 bit add/sub of 1
Refactorings to locate push/pops for 32 bits next to each other to allow code optmizer to eliminate pairings of push/pops

Fixes most of #404 without needing to use containment for memory ops