### PR TITLE
Improve codegen for bounds check

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/BoundsCheckCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/BoundsCheckCodeGenerator.cs
@@ -19,18 +19,7 @@ namespace ILCompiler.Compiler.CodeGenerators
             context.InstructionsBuilder.And(A);         // Clear carry flag
             context.InstructionsBuilder.Sbc(HL, DE);    // Calculate Array Length - Index
 
-            var endLabel = context.NameMangler.GetUniqueName();
-
-            context.InstructionsBuilder.Jp(Condition.NC, endLabel);
-
-            // Code to display Index Out of Range message and fail fast
-
-            context.InstructionsBuilder.Ld(HL, "INDEX_OUT_OF_RANGE_MSG - 2");
-            context.InstructionsBuilder.Call("PRINT");
-            context.InstructionsBuilder.Jp("EXIT");
-
-            // Index was valid
-            context.InstructionsBuilder.Label(endLabel);
+            context.InstructionsBuilder.Call(Condition.C, "RangeCheckFail");            
         }
     }
 }

--- a/ILCompiler/Compiler/Emit/InstructionsBuilder.cs
+++ b/ILCompiler/Compiler/Emit/InstructionsBuilder.cs
@@ -52,6 +52,7 @@ namespace ILCompiler.Compiler.Emit
         public void And(Register8 target) => AddInstruction(Instruction.Create(Opcode.And, target));
         public void Call(string target) => AddInstruction(Instruction.CreateBranch(Opcode.Call, target));
         public void Call(ushort target) => AddInstruction(Instruction.CreateBranch(Opcode.Call, target));
+        public void Call(Condition condition, string target) => AddInstruction(Instruction.CreateBranch(Opcode.Call, condition, target));
         public void Dec(Register16 register) => AddInstruction(Instruction.Create(Opcode.Dec, register));
         public void Dec(Register8 register) => AddInstruction(Instruction.Create(Opcode.Dec, register));
 

--- a/ILCompiler/ILCompiler.csproj
+++ b/ILCompiler/ILCompiler.csproj
@@ -70,6 +70,7 @@
     <None Remove="Runtime\NewObject.asm" />
     <None Remove="Runtime\NewString.asm" />
     <None Remove="Runtime\print.asm" />
+    <None Remove="Runtime\RangeCheckFail.asm" />
     <None Remove="Runtime\stoi.asm" />
     <None Remove="Runtime\TRS80\beep.asm" />
     <None Remove="Runtime\TRS80\cls.asm" />
@@ -111,6 +112,7 @@
     <EmbeddedResource Include="Runtime\Memcpy.asm" />
     <EmbeddedResource Include="Runtime\Memset.asm" />
     <EmbeddedResource Include="Runtime\InterfaceCall.asm" />
+    <EmbeddedResource Include="Runtime\RangeCheckFail.asm" />
     <EmbeddedResource Include="Runtime\VirtualCall.asm" />
     <EmbeddedResource Include="Runtime\NewString.asm" />
     <EmbeddedResource Include="Runtime\print.asm" />

--- a/ILCompiler/Runtime/RangeCheckFail.asm
+++ b/ILCompiler/Runtime/RangeCheckFail.asm
@@ -1,0 +1,8 @@
+; This routine displays the out of range message and then exitsk
+;
+; Uses: HL
+
+RangeCheckFail:
+	LD HL, INDEX_OUT_OF_RANGE_MSG - 2
+	CALL PRINT
+	JP EXIT


### PR DESCRIPTION
Factor out code for displaying index out of range message into runtime routine.
Reduces code emitted for bounds check.
Call is slower if branch taken but bounds check has failed in this case so doesn't matter. It has same number of t-states if branch isn't taken as the Jp previously emitted.