### PR TITLE
Add exception support configuration option

### DIFF
--- a/ILCompiler/Compiler/CodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerator.cs
@@ -241,7 +241,7 @@ namespace ILCompiler.Compiler
                 }
             }
 
-            if (_context.ParamsCount > 0 || (_context.LocalsCount + tempCount) > 0)
+            if (_context.ParamsCount > 0 || (_context.LocalsCount + tempCount) > 0 || _context.Configuration.ExceptionSupport)
             {
                 instructionsBuilder.Push(IX);
                 instructionsBuilder.Ld(IX, 0);

--- a/ILCompiler/Compiler/CodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerator.cs
@@ -78,6 +78,10 @@ namespace ILCompiler.Compiler
 
                 methodInstructions.AddRange(_context.InstructionsBuilder.Instructions);
             }
+            // Emit end of method label
+            _context.InstructionsBuilder.Reset();
+            _context.InstructionsBuilder.Label($"{mangledMethodName}_END");
+            methodInstructions.AddRange(_context.InstructionsBuilder.Instructions);
 
             Optimize(methodInstructions);
 

--- a/ILCompiler/Compiler/CodeGenerators/ReturnCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/ReturnCodeGenerator.cs
@@ -63,7 +63,7 @@ namespace ILCompiler.Compiler.CodeGenerators
                 }
             }
 
-            if (context.ParamsCount > 0 || (context.LocalsCount + tempCount) > 0)
+            if (context.ParamsCount > 0 || (context.LocalsCount + tempCount) > 0 || context.Configuration.ExceptionSupport)
             {
                 if (context.LocalsCount + tempCount > 0)
                 {

--- a/ILCompiler/Configuration.cs
+++ b/ILCompiler/Configuration.cs
@@ -18,5 +18,6 @@ namespace ILCompiler
         public string AssemblerOutput { get; set; } = string.Empty;
         public bool NoListFile { get; set; } = true;
         public bool SkipArrayBoundsCheck { get; set; } = false;
+        public bool ExceptionSupport { get; set; } = false;
     }
 }

--- a/ILCompiler/ConfigurationBinder.cs
+++ b/ILCompiler/ConfigurationBinder.cs
@@ -29,6 +29,7 @@ namespace ILCompiler
                 AssemblerOutput = bindingContext.ParseResult.GetValueForOption(_configurationOptions.AssemblerOutput) ?? "",
                 NoListFile = bindingContext.ParseResult.GetValueForOption(_configurationOptions.NoListFile),
                 SkipArrayBoundsCheck = bindingContext.ParseResult.GetValueForOption(_configurationOptions.SkipArrayBoundsCheck),
+                ExceptionSupport = bindingContext.ParseResult.GetValueForOption(_configurationOptions.ExceptionSupport),
             };
         }
     }

--- a/ILCompiler/ConfigurationOptions.cs
+++ b/ILCompiler/ConfigurationOptions.cs
@@ -19,6 +19,7 @@ namespace ILCompiler
         public readonly Option<string> AssemblerOutput = new(new[] { "-ao", "--assemblerOutput" }, "Assembler output type");
         public readonly Option<bool> NoListFile = new(new[] { "-nl", "--noListFile" }, "No list file");
         public readonly Option<bool> SkipArrayBoundsCheck = new(new[] { "-nb", "--noBoundsCheck" }, "No Array Bounds Check");
+        public readonly Option<bool> ExceptionSupport = new(new[] { "-ex", "--exceptions" }, "Exceptions support");
 
         public void AddToCommand(Command command)
         {
@@ -33,6 +34,7 @@ namespace ILCompiler
             command.AddOption(AssemblerOutput);
             command.AddOption(NoListFile);
             command.AddOption(SkipArrayBoundsCheck);
+            command.AddOption(ExceptionSupport);
         }
     }
 }

--- a/ILCompiler/Interfaces/IConfiguration.cs
+++ b/ILCompiler/Interfaces/IConfiguration.cs
@@ -17,5 +17,6 @@ namespace ILCompiler.Interfaces
         public string AssemblerOutput { get; set; }
         public bool NoListFile { get; set; }
         public bool SkipArrayBoundsCheck { get; set; }
+        public bool ExceptionSupport { get; set; }
     }
 }

--- a/ILCompiler/Program.cs
+++ b/ILCompiler/Program.cs
@@ -87,6 +87,7 @@ namespace ILCompiler
                     configuration.AssemblerArguments = parsedConfiguration.AssemblerArguments;
                     configuration.AssemblerOutput = parsedConfiguration.AssemblerOutput;
                     configuration.NoListFile = parsedConfiguration.NoListFile;
+                    configuration.ExceptionSupport = parsedConfiguration.ExceptionSupport;
                 },
                 inputFileArgument, outputFileOption, configurationBinder
             );


### PR DESCRIPTION
This option when enabled will force stack frame to be setup in IX for all methods. This is required for stack walking which is key to exception support.
Also emit label for end of methods.

Next step for #424 