### PR TITLE
Implement null reference checks for callvirt

### DIFF
--- a/ILCompiler/Common/TypeSystem/IL/HelperExtensions.cs
+++ b/ILCompiler/Common/TypeSystem/IL/HelperExtensions.cs
@@ -1,0 +1,16 @@
+﻿using dnlib.DotNet;
+using ILCompiler.Compiler;
+
+namespace ILCompiler.Common.TypeSystem.IL
+{
+    internal static class HelperExtensions
+    {
+        private const string HelperTypesNamespace = "Internal.Runtime.CompilerHelpers";
+
+        public static MethodDef GetHelperEntryPoint(this CorLibModuleProvider corLibModuleProvider, string typeName, string methodName)
+        {
+            var compilerHelpers = corLibModuleProvider.FindThrow($"{HelperTypesNamespace}.{typeName}");
+            return compilerHelpers.FindMethod(methodName);
+        }
+    }
+}

--- a/ILCompiler/Compiler/CodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerator.cs
@@ -33,7 +33,7 @@ namespace ILCompiler.Compiler
 
         public IList<Instruction> Generate(IList<BasicBlock> blocks, LocalVariableTable locals, Z80MethodCodeNode methodCodeNode)
         {
-            _context = new CodeGeneratorContext(locals, methodCodeNode, _configuration, _nameMangler, _nodeFactory);
+            _context = new CodeGeneratorContext(locals, methodCodeNode, _configuration, _nameMangler, _nodeFactory, _corLibModuleProvider);
 
             AssignFrameOffsets();
 

--- a/ILCompiler/Compiler/CodeGenerators/CodeGeneratorContext.cs
+++ b/ILCompiler/Compiler/CodeGenerators/CodeGeneratorContext.cs
@@ -19,14 +19,16 @@ namespace ILCompiler.Compiler.CodeGenerators
         private readonly Z80MethodCodeNode _method;
 
         public readonly IConfiguration Configuration;
+        public readonly CorLibModuleProvider CorLibModuleProvider;
 
-        public CodeGeneratorContext(LocalVariableTable localVariableTable, Z80MethodCodeNode method, IConfiguration configuration, INameMangler nameMangler, NodeFactory nodeFactory)
+        public CodeGeneratorContext(LocalVariableTable localVariableTable, Z80MethodCodeNode method, IConfiguration configuration, INameMangler nameMangler, NodeFactory nodeFactory, CorLibModuleProvider corLibModuleProvider)
         {
             LocalVariableTable = localVariableTable;
             _method = method;
             Configuration = configuration;
             NameMangler = nameMangler;
             NodeFactory = nodeFactory;
+            CorLibModuleProvider = corLibModuleProvider;
         }
     }
 }

--- a/ILCompiler/Compiler/CodeGenerators/NullCheckCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/NullCheckCodeGenerator.cs
@@ -1,0 +1,24 @@
+﻿using ILCompiler.Common.TypeSystem.IL;
+using ILCompiler.Compiler.EvaluationStack;
+using static ILCompiler.Compiler.Emit.Registers;
+
+namespace ILCompiler.Compiler.CodeGenerators
+{
+    internal class NullCheckCodeGenerator : ICodeGenerator<NullCheckEntry>
+    {
+        public void GenerateCode(NullCheckEntry entry, CodeGeneratorContext context)
+        {
+            if (context.Configuration.ExceptionSupport)
+            {
+                var throwHelperMethod = context.CorLibModuleProvider.GetHelperEntryPoint("ThrowHelpers", "ThrowNullReferenceException");
+                var mangledThrowHelperMethod = context.NameMangler.GetMangledMethodName(throwHelperMethod);
+
+                context.InstructionsBuilder.Pop(HL);
+                context.InstructionsBuilder.Push(HL);
+                context.InstructionsBuilder.Ld(A, H);
+                context.InstructionsBuilder.Or(L);
+                context.InstructionsBuilder.Jp(Emit.Condition.Z, mangledThrowHelperMethod);
+            }
+        }
+    }
+}

--- a/ILCompiler/Compiler/CodeGenerators/ServiceCollectionExtensions.cs
+++ b/ILCompiler/Compiler/CodeGenerators/ServiceCollectionExtensions.cs
@@ -30,6 +30,7 @@ namespace ILCompiler.Compiler.CodeGenerators
             services.AddSingleton<ICodeGenerator<PutArgTypeEntry>, PutArgTypeCodeGenerator>();
             services.AddSingleton<ICodeGenerator<StaticFieldEntry>,  StaticFieldCodeGenerator>();
             services.AddSingleton<ICodeGenerator<BoundsCheck>, BoundsCheckCodeGenerator>();
+            services.AddSingleton<ICodeGenerator<NullCheckEntry>, NullCheckCodeGenerator>();
             return services;
         }
     }

--- a/ILCompiler/Compiler/DependencyAnalysis/ILScanner.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/ILScanner.cs
@@ -68,6 +68,23 @@ namespace ILCompiler.Compiler.DependencyAnalysis
                             case Code.Throw:
                                 ImportThrow();
                                 break;
+
+                            case Code.Ldelema:
+                                ImportAddressOfElem(currentInstruction);
+                                break;
+
+                            case Code.Ldelem:
+                                ImportLoadElement();
+                                break;
+
+                            case Code.Stelem:
+                            case Code.Stelem_I:
+                            case Code.Stelem_I1:
+                            case Code.Stelem_I2:
+                            case Code.Stelem_I4:
+                            case Code.Stelem_Ref:
+                                ImportStoreElement();
+                                break;
                         }
                         currentOffset += currentInstruction.GetSize();
                         currentIndex++;
@@ -96,6 +113,26 @@ namespace ILCompiler.Compiler.DependencyAnalysis
             var methodNode = _nodeFactory.MethodNode(runtimeHelperMethod);
 
             _dependencies.Add(methodNode);
+        }
+
+        private void ImportAddressOfElem(Instruction instuction)
+        {
+            _dependencies.Add(GetHelperEntryPoint("ThrowHelpers", "ThrowIndexOutOfRangeException"));
+        }
+
+        private void ImportLoadElement()
+        {
+            _dependencies.Add(GetHelperEntryPoint("ThrowHelpers", "ThrowIndexOutOfRangeException"));
+        }
+
+        private void ImportStoreElement()
+        {
+            _dependencies.Add(GetHelperEntryPoint("ThrowHelpers", "ThrowIndexOutOfRangeException"));
+        }
+
+        private void AddThrowNullReferenceThrowHelperDependency()
+        {
+            _dependencies.Add(GetHelperEntryPoint("ThrowHelpers", "ThrowNullReferenceException"));
         }
 
         private void ImportStoreField(Instruction instuction, bool isStatic)
@@ -172,6 +209,11 @@ namespace ILCompiler.Compiler.DependencyAnalysis
 
         private void ImportCall(Instruction instruction)
         {
+            if (instruction.OpCode.Code == Code.Callvirt)
+            {
+                AddThrowNullReferenceThrowHelperDependency();
+            }
+
             if (instruction.OpCode.Code == Code.Newobj)
             {
                 CreateConstructedEETypeNodeDependencies(instruction);
@@ -305,6 +347,12 @@ namespace ILCompiler.Compiler.DependencyAnalysis
 
                 _dependencies.Add(_nodeFactory.ConstructedEETypeNode(objType.ToTypeDefOrRef(), allocSize));
             }
+        }
+
+        private Z80MethodCodeNode GetHelperEntryPoint(string typeName, string methodName)
+        {
+            var helperMethod = _corLibModuleProvider.GetHelperEntryPoint(typeName, methodName);
+            return _nodeFactory.MethodNode(helperMethod);
         }
     }
 }

--- a/ILCompiler/Compiler/DependencyAnalysis/ILScanner.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/ILScanner.cs
@@ -70,7 +70,7 @@ namespace ILCompiler.Compiler.DependencyAnalysis
                                 break;
 
                             case Code.Ldelema:
-                                ImportAddressOfElem(currentInstruction);
+                                ImportAddressOfElem();
                                 break;
 
                             case Code.Ldelem:
@@ -115,7 +115,7 @@ namespace ILCompiler.Compiler.DependencyAnalysis
             _dependencies.Add(methodNode);
         }
 
-        private void ImportAddressOfElem(Instruction instuction)
+        private void ImportAddressOfElem()
         {
             _dependencies.Add(GetHelperEntryPoint("ThrowHelpers", "ThrowIndexOutOfRangeException"));
         }

--- a/ILCompiler/Compiler/EvaluationStack/GenericStackEntryAdapter.cs
+++ b/ILCompiler/Compiler/EvaluationStack/GenericStackEntryAdapter.cs
@@ -35,5 +35,6 @@
         public void Visit(PhiNode entry) => _genericStackEntryVisitor.Visit<PhiNode>(entry);
         public void Visit(PhiArg entry) => _genericStackEntryVisitor.Visit<PhiArg>(entry);
         public void Visit(BoundsCheck entry) => _genericStackEntryVisitor.Visit<BoundsCheck>(entry);
+        public void Visit(NullCheckEntry entry) => _genericStackEntryVisitor.Visit<NullCheckEntry>(entry);
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/IStackEntryVisitor.cs
+++ b/ILCompiler/Compiler/EvaluationStack/IStackEntryVisitor.cs
@@ -34,5 +34,6 @@
         public void Visit(PhiNode entry);
         public void Visit(PhiArg entry);
         public void Visit(BoundsCheck entry);
+        public void Visit(NullCheckEntry entry);
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/NullCheckEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/NullCheckEntry.cs
@@ -1,0 +1,22 @@
+﻿namespace ILCompiler.Compiler.EvaluationStack
+{
+    public class NullCheckEntry : StackEntry
+    {
+        public StackEntry Op1 { get; }
+
+        public NullCheckEntry(StackEntry op1) : base(op1.Type, op1.Type.GetTypeSize() /*op1.ExactSize */)
+        {
+            Op1 = op1;
+        }
+
+        public override StackEntry Duplicate()
+        {
+            return new NullCheckEntry(Op1.Duplicate());
+        }
+
+        public override void Accept(IStackEntryVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
+    }
+}

--- a/ILCompiler/Compiler/Flowgraph.cs
+++ b/ILCompiler/Compiler/Flowgraph.cs
@@ -154,6 +154,12 @@ namespace ILCompiler.Compiler
             SetNext(entry);
         }
 
+        public void Visit(NullCheckEntry entry)
+        {
+            entry.Op1.Accept(this);
+            SetNext(entry);
+        }
+
         public void Visit(SwitchEntry entry)
         {
             entry.Op1.Accept(this);

--- a/ILCompiler/Compiler/Importer/CallImporter.cs
+++ b/ILCompiler/Compiler/Importer/CallImporter.cs
@@ -86,6 +86,12 @@ namespace ILCompiler.Compiler.Importer
             }
             arguments.Reverse();
 
+            if (instruction.OpCode == OpCodes.Callvirt)
+            {
+                // Turn first argument into throw null ref check
+                arguments[0] = new NullCheckEntry(arguments[0]);
+            }
+
             if (methodToCall.DeclaringType.IsInterface)
             {
                 // Need to add this pointer as extra param which will be consumed by InterfaceCall routine

--- a/ILCompiler/Compiler/LIRDumper.cs
+++ b/ILCompiler/Compiler/LIRDumper.cs
@@ -161,6 +161,11 @@ namespace ILCompiler.Compiler
             _sb.AppendLine($"       cast {entry.Type}");
         }
 
+        public void Visit(NullCheckEntry entry)
+        {
+            _sb.AppendLine($"       nullcheck {entry.Op1.TreeID}");
+        }
+
         public void Visit(UnaryOperator entry)
         {
             _sb.AppendLine($"       ┌──▌  t{entry.Op1.TreeID}");

--- a/ILCompiler/Compiler/Morpher.cs
+++ b/ILCompiler/Compiler/Morpher.cs
@@ -120,6 +120,10 @@ namespace ILCompiler.Compiler
                 case PutArgTypeEntry putArgTypeEntry:
                     tree = new PutArgTypeEntry(putArgTypeEntry.ArgType, MorphTree(putArgTypeEntry.Op1));
                     break;
+
+                case NullCheckEntry nullCheckEntry:
+                    tree = new NullCheckEntry(MorphTree(nullCheckEntry.Op1));
+                    break;
             }
             return tree;
         }

--- a/ILCompiler/Compiler/TreeDumper.cs
+++ b/ILCompiler/Compiler/TreeDumper.cs
@@ -171,6 +171,14 @@ namespace ILCompiler.Compiler
             _indent--;
         }
 
+        public void Visit(NullCheckEntry entry)
+        {
+            Print($"NULLCHECK");
+            _indent++;
+            entry.Op1.Accept(this);
+            _indent--;
+        }
+
         public void Visit(PutArgTypeEntry entry)
         {
             Print($"PUTARG_TYPE {entry.ArgType}");

--- a/System.Private.CoreLib/System/IndexOutOfRangeException.cs
+++ b/System.Private.CoreLib/System/IndexOutOfRangeException.cs
@@ -1,0 +1,8 @@
+﻿namespace System
+{
+    public sealed class IndexOutOfRangeException : Exception
+    {
+        public IndexOutOfRangeException() : base("Index was outside the bounds of the array.")
+        { }
+    }
+}

--- a/System.Private.CoreLib/System/NullReferenceException.cs
+++ b/System.Private.CoreLib/System/NullReferenceException.cs
@@ -1,6 +1,6 @@
 ﻿namespace System
 {
-    public class NullReferenceException : Exception
+    public sealed class NullReferenceException : Exception
     {
         public NullReferenceException() : base("Object reference not set to an instance of an object.")
         { }

--- a/System.Private.CoreLib/System/ThrowHelpers.cs
+++ b/System.Private.CoreLib/System/ThrowHelpers.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Internal.Runtime.CompilerHelpers
+{
+    internal static class ThrowHelpers
+    {
+        private static void ThrowIndexOutOfRangeException()
+        {
+            throw new IndexOutOfRangeException();
+        }
+
+        private static void ThrowNullReferenceException()
+        {
+            throw new NullReferenceException();
+        }
+    }
+}


### PR DESCRIPTION
Add new NullCheck IR node.
Codegen will call ThrowHelpers
Also modify bounds check to use ThrowHelpers if exception support is enabled.

Resolves #403 