### PR TITLE
Minor bug fixes for exception handling

### DIFF
--- a/ILCompiler/Compiler/BasicBlockAnalyser.cs
+++ b/ILCompiler/Compiler/BasicBlockAnalyser.cs
@@ -15,14 +15,14 @@ namespace ILCompiler.Compiler
     public class EHClause
     {
         public BasicBlock TryBegin { get; init; }
-        public BasicBlock TryEnd { get; init; }
+        public BasicBlock? TryEnd { get; init; }
         public BasicBlock HandlerBegin { get; init; }
-        public BasicBlock HandlerEnd { get; init; }
+        public BasicBlock? HandlerEnd { get; init; }
         public BasicBlock? Filter { get; init; }
         public EHClauseKind Kind { get; init; }
         public string CatchTypeMangledName { get; init; }
 
-        public EHClause(BasicBlock tryBegin, BasicBlock tryEnd, BasicBlock handlerBegin, BasicBlock handlerEnd, BasicBlock? filter, EHClauseKind kind, string catchTypeMangledName)
+        public EHClause(BasicBlock tryBegin, BasicBlock? tryEnd, BasicBlock handlerBegin, BasicBlock? handlerEnd, BasicBlock? filter, EHClauseKind kind, string catchTypeMangledName)
         {
             TryBegin = tryBegin;
             TryEnd = tryEnd;
@@ -77,8 +77,8 @@ namespace ILCompiler.Compiler
                 }
 
                 var handlerBeginBlock = CreateBasicBlock(basicBlocks, (int)exceptionHandler.HandlerStart.Offset);
-                var handlerEndBlock = basicBlocks[exceptionHandler.HandlerEnd.Offset];
-                var tryEndBlock = basicBlocks[exceptionHandler.TryEnd.Offset];
+                var handlerEndBlock = exceptionHandler.HandlerEnd != null ? basicBlocks[exceptionHandler.HandlerEnd.Offset] : null;
+                var tryEndBlock = exceptionHandler.TryEnd != null ? basicBlocks[exceptionHandler.TryEnd.Offset] : null;
 
                 handlerBeginBlock.HandlerStart = true;
                 tryBeginBlock.TryStart = true;

--- a/ILCompiler/Compiler/ILImporter.cs
+++ b/ILCompiler/Compiler/ILImporter.cs
@@ -99,7 +99,7 @@ namespace ILCompiler.Compiler
             // Add exception object for catch
             if (basicBlock.HandlerStart)
             {
-                // TODO: need to use a node type that won't generate any code
+                // Use a node type that won't generate any code
                 _stack.Push(new CatchArgumentEntry());
             }
 

--- a/ILCompiler/Compiler/LIRDumper.cs
+++ b/ILCompiler/Compiler/LIRDumper.cs
@@ -213,7 +213,7 @@ namespace ILCompiler.Compiler
 
         public void Visit(CatchArgumentEntry entry)
         {
-            throw new Exception("CatchArgumentEntry not valid in LIR");
+            _sb.AppendLine($"       catchArgument");
         }
 
         public void Visit(PutArgTypeEntry entry)

--- a/ILCompiler/Compiler/Z80AssemblyWriter.cs
+++ b/ILCompiler/Compiler/Z80AssemblyWriter.cs
@@ -241,7 +241,15 @@ namespace ILCompiler.Compiler
                             if (ehClause.Kind == EHClauseKind.Typed)
                             {
                                 ehClausesBuilder.Dw(ehClause.TryBegin.Label, "Protected Region Start");
-                                ehClausesBuilder.Dw(ehClause.TryEnd.Label, "Protected Region End");
+                                if (ehClause.TryEnd != null)
+                                {
+                                    ehClausesBuilder.Dw(ehClause.TryEnd.Label, "Protected Region End");
+                                }
+                                else
+                                {
+                                    var methodName = _nameMangler.GetMangledMethodName(codeNode.Method);
+                                    ehClausesBuilder.Dw($"{methodName}_END", "Protected Region End");
+                                }
                                 ehClausesBuilder.Dw(ehClause.HandlerBegin.Label, "Handler Start");
                                 ehClausesBuilder.Dw(ehClause.CatchTypeMangledName, "Catch Type");
                             }


### PR DESCRIPTION
TryEnd and HandlerEnd can be null if they are the end of the method.
LIRDumper shouldn't throw for CatchArgument

Fixes for #424