### PR TITLE
Unwind SP correctly by removing any method parameters from stack

### DIFF
--- a/ILCompiler/Compiler/BasicBlock.cs
+++ b/ILCompiler/Compiler/BasicBlock.cs
@@ -55,6 +55,8 @@ namespace ILCompiler.Compiler
         public bool FilterStart { get; set; }
         public bool HandlerStart { get; set; }
 
+        public IList<BasicBlock> TryBlocks { get; set; } = new List<BasicBlock>();
+
         public IList<BasicBlock> Handlers { get; set; } = new List<BasicBlock>();
 
         public BasicBlock(int offset)

--- a/ILCompiler/Compiler/BasicBlockAnalyser.cs
+++ b/ILCompiler/Compiler/BasicBlockAnalyser.cs
@@ -100,7 +100,7 @@ namespace ILCompiler.Compiler
             }
         }
 
-        private IList<BasicBlock> GetTryBlocks(ExceptionHandler exceptionHandler, BasicBlock[] basicBlocks)
+        private static List<BasicBlock> GetTryBlocks(ExceptionHandler exceptionHandler, BasicBlock[] basicBlocks)
         {
             var tryStartOffset = (int)exceptionHandler.TryStart.Offset;
             var tryEndOffset = (int?)exceptionHandler.TryEnd?.Offset ?? basicBlocks.Length;

--- a/ILCompiler/Compiler/BasicBlockAnalyser.cs
+++ b/ILCompiler/Compiler/BasicBlockAnalyser.cs
@@ -78,6 +78,9 @@ namespace ILCompiler.Compiler
 
                 var handlerBeginBlock = CreateBasicBlock(basicBlocks, (int)exceptionHandler.HandlerStart.Offset);
                 var handlerEndBlock = exceptionHandler.HandlerEnd != null ? basicBlocks[exceptionHandler.HandlerEnd.Offset] : null;
+
+                handlerBeginBlock.TryBlocks = GetTryBlocks(exceptionHandler, basicBlocks);
+
                 var tryEndBlock = exceptionHandler.TryEnd != null ? basicBlocks[exceptionHandler.TryEnd.Offset] : null;
 
                 handlerBeginBlock.HandlerStart = true;
@@ -97,6 +100,22 @@ namespace ILCompiler.Compiler
             }
         }
 
+        private IList<BasicBlock> GetTryBlocks(ExceptionHandler exceptionHandler, BasicBlock[] basicBlocks)
+        {
+            var tryStartOffset = (int)exceptionHandler.TryStart.Offset;
+            var tryEndOffset = (int?)exceptionHandler.TryEnd?.Offset ?? basicBlocks.Length;
+
+            var tryBlocks = new List<BasicBlock>();
+            for (int offset = tryStartOffset; offset < tryEndOffset; offset++)
+            {
+                if (basicBlocks[offset] != null)
+                {
+                    tryBlocks.Add(basicBlocks[offset]);
+                }
+            }
+
+            return tryBlocks;
+        }
         private static BasicBlock CreateBasicBlock(BasicBlock[] basicBlocks, int offset)
         {
             var basicBlock = basicBlocks[offset];

--- a/ILCompiler/Compiler/ILImporter.cs
+++ b/ILCompiler/Compiler/ILImporter.cs
@@ -305,7 +305,7 @@ namespace ILCompiler.Compiler
             return importedBasicBlocks;
         }
 
-        private void SetTryBlockSuccessors(IList<BasicBlock> basicBlocks)
+        private static void SetTryBlockSuccessors(IList<BasicBlock> basicBlocks)
         {
             foreach (var block in basicBlocks)
             {

--- a/ILCompiler/Compiler/ILImporter.cs
+++ b/ILCompiler/Compiler/ILImporter.cs
@@ -294,12 +294,29 @@ namespace ILCompiler.Compiler
             for (int i = 0; i < _basicBlocks.Length; i++)
             {
                 if (_basicBlocks[i] != null)
-                {
+                {                    
                     importedBasicBlocks.Add(_basicBlocks[i]);
                 }
             }
-         
+
+            // Add EH begin block as successor to all blocks in trys
+            SetTryBlockSuccessors(importedBasicBlocks);
+
             return importedBasicBlocks;
+        }
+
+        private void SetTryBlockSuccessors(IList<BasicBlock> basicBlocks)
+        {
+            foreach (var block in basicBlocks)
+            {
+                if (block.HandlerStart)
+                {
+                    foreach (var tryBlock in block.TryBlocks)
+                    {
+                        tryBlock.Successors.Add(block);
+                    }
+                }
+            }
         }
 
         private void ImportFallThrough(BasicBlock next)

--- a/ILCompiler/Compiler/SsaBuilder.cs
+++ b/ILCompiler/Compiler/SsaBuilder.cs
@@ -499,7 +499,7 @@ namespace ILCompiler.Compiler
         /// </summary>
         /// <param name="block"></param>
         /// <returns>list of dominance predecessors</returns>
-        private IList<BasicBlock> BlockDominancePredecessors(BasicBlock block)
+        private static IList<BasicBlock> BlockDominancePredecessors(BasicBlock block)
         {
             if (!block.HandlerStart)
             {

--- a/ILCompiler/Compiler/SsaBuilder.cs
+++ b/ILCompiler/Compiler/SsaBuilder.cs
@@ -317,7 +317,8 @@ namespace ILCompiler.Compiler
                 // First we consider the predecessors of block looking for candidate B2's
                 // block is obviously an immediate successor of its immediate predecessors
 
-                var predecessors = block.Predecessors;
+                // If block is first block in exception handler then use all blocks handled by the handler
+                IList<BasicBlock> predecessors = !block.HandlerStart ? block.Predecessors : block.TryBlocks;
 
                 // If there is zero or one predecessors then there is no predecessor,
                 // or else the single predecessor dominates block, so no B2 exists
@@ -446,7 +447,7 @@ namespace ILCompiler.Compiler
 
                     // Find the first processed predecessor
                     BasicBlock? predecessorBlock = null;
-                    foreach (var predecessor in block.Predecessors)
+                    foreach (var predecessor in BlockDominancePredecessors(block))
                     {
                         if (processedBlocks.Contains(predecessor))
                         {
@@ -462,7 +463,7 @@ namespace ILCompiler.Compiler
 
                     // Intersect DOM, if computed for all predecessors
                     var basicBlockDominator = predecessorBlock;
-                    foreach (var predecessor in block.Predecessors)
+                    foreach (var predecessor in BlockDominancePredecessors(block))
                     {
                         if (predecessorBlock != predecessor)
                         {
@@ -487,6 +488,26 @@ namespace ILCompiler.Compiler
                     _logger.LogDebug("Marking block {BlockLabel} as processed", block.Label);
                     processedBlocks.Add(block);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Calculates the predecessor blocks that have fully executed before block was reached.
+        /// Only differs for handler blocks as the try blocks may not have fully executed 
+        /// so we use the predecessors of the first block in the try
+        /// 
+        /// </summary>
+        /// <param name="block"></param>
+        /// <returns>list of dominance predecessors</returns>
+        private IList<BasicBlock> BlockDominancePredecessors(BasicBlock block)
+        {
+            if (!block.HandlerStart)
+            {
+                return block.Predecessors;
+            }
+            else
+            {
+                return block.TryBlocks[0].Predecessors;
             }
         }
 

--- a/Tests/Methodical/Exceptions/SimpleExceptionTests.cs
+++ b/Tests/Methodical/Exceptions/SimpleExceptionTests.cs
@@ -62,6 +62,11 @@ namespace Exceptions
             throw new Exception();
         }
 
+        private static void Throw(int parameter)
+        {
+            throw new Exception();
+        }
+
         private static void ThrowIndirect()
         {
             Throw();
@@ -135,6 +140,30 @@ namespace Exceptions
             return result;
         }
 
+        public unsafe static int TryCatch_WithThrowingMethodHavingAParameter_StackIsRestoredCorrectly()
+        {
+            int result = 1;
+            int count = 0;
+            ushort[] stackAllocedVariables = new ushort[2];
+            while (count < 2)
+            {
+                try
+                {
+                    var stackTest = stackalloc int[1];
+                    stackAllocedVariables[count] = (ushort)stackTest;
+
+                    Throw(count);
+                }
+                catch
+                {
+                }
+                count++;
+            }
+
+            result = stackAllocedVariables[0] - stackAllocedVariables[1] != 4 ? 1 : 0;
+            return result;
+        }
+
         public static int RunTests()
         {
             int result = Try_NoThrow(); if (result != 0) return result;
@@ -144,6 +173,7 @@ namespace Exceptions
             result = TryCatch_WithThrowInNestedSeparateMethod_IsCaught(); if (result != 0) return result;
             result = TryCatch_WithSpecificExceptionTypes(); if (result != 0) return result;
             result = TryCatchOfNRE_WhenNREThrown_IsCaught(); if (result != 0) return result;
+            result = TryCatch_WithThrowingMethodHavingAParameter_StackIsRestoredCorrectly(); if (result != 0) return result;
 
             return result;
         }


### PR DESCRIPTION
Emit "unwind" information for all methods - indicates number of parameters setup by caller requiring clean-up
Use "unwind" information in StackFrameIterator.Next to correctly determine SP when unwinding Add test to validate SP is correctly unwound
Fix SSA to deal with Exception handlers properly

Fixes for #424