### PR TITLE
Correct IP used in EH

### DIFF
--- a/ILCompiler/Runtime/SFINext.asm
+++ b/ILCompiler/Runtime/SFINext.asm
@@ -135,6 +135,11 @@ SFINEXT:
 	LD (HL), D
 	INC HL
 
+	; Call instruction is 3 before return address
+	DEC BC
+	DEC BC
+	DEC BC
+
 	LD (HL), C	; save new instruction pointer into stack frame iterator
 	INC HL
 	LD (HL), B

--- a/ILCompiler/Runtime/ThrowEx.asm
+++ b/ILCompiler/Runtime/ThrowEx.asm
@@ -18,8 +18,10 @@ ThrowEx:
 	; First is ExInfo._exception object
 	;PUSH BC
 
-	; Initialise ExInfo._frameIter.InstructionPointer
-	DEC DE	; Return address is after call instruction so need to decrement by 1
+	; Initialise ExInfo._frameIter.InstructionPointer to be return address - 3 as call instruction is 3 bytes long
+	DEC DE
+	DEC DE
+	DEC DE
 	PUSH DE
 
 	; Initialise ExInfo._frameIter.FramePointer

--- a/Tests/Methodical/Exceptions/SimpleExceptionTests.cs
+++ b/Tests/Methodical/Exceptions/SimpleExceptionTests.cs
@@ -164,6 +164,28 @@ namespace Exceptions
             return result;
         }
 
+        public static int TryCatch_ThrowBeforeTry_IsNotCaughtByInnerTry()
+        {
+            int result = 2;
+            try
+            {
+                Throw();
+                try
+                {
+                }
+                catch
+                {
+                    result = 1;
+                }
+            }
+            catch
+            {
+                result = 0;
+            }
+
+            return result;
+        }
+
         public static int RunTests()
         {
             int result = Try_NoThrow(); if (result != 0) return result;
@@ -174,6 +196,7 @@ namespace Exceptions
             result = TryCatch_WithSpecificExceptionTypes(); if (result != 0) return result;
             result = TryCatchOfNRE_WhenNREThrown_IsCaught(); if (result != 0) return result;
             result = TryCatch_WithThrowingMethodHavingAParameter_StackIsRestoredCorrectly(); if (result != 0) return result;
+            result = TryCatch_ThrowBeforeTry_IsNotCaughtByInnerTry(); if (result != 0) return result;
 
             return result;
         }


### PR DESCRIPTION
Correct IP used in EH. During stack frame iteration it was pointing at return address rather than the call instruction
Similarly when throwing an exception it was return address - 1 but should have been return address - 3

Fix for #424