### PR TITLE
Better code gen for Indirect

### DIFF
--- a/ILCompiler/Compiler/CodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerator.cs
@@ -286,9 +286,7 @@ namespace ILCompiler.Compiler
             if (_context.LocalsCount + tempCount > 0)
             {
                 // Reserve space on stack for locals
-                instructionsBuilder.Ld(HL, (short)-localsSize);
-                instructionsBuilder.Add(HL, SP);
-                instructionsBuilder.Ld(SP, HL);
+                CodeGeneratorHelper.AddSPFromHL(instructionsBuilder, (short)-localsSize);
 
                 ZeroInitFrame(instructionsBuilder);
             }
@@ -308,8 +306,8 @@ namespace ILCompiler.Compiler
 
                         instructionsBuilder.Push(IX);
                         instructionsBuilder.Pop(HL);
-                        instructionsBuilder.Ld(DE, (short)-offset);
-                        instructionsBuilder.Add(HL, DE);
+
+                        CodeGeneratorHelper.AddHLFromDE(instructionsBuilder, (short)-offset);
 
                         for (var count = 0; count < exactSize; count++)
                         {

--- a/ILCompiler/Compiler/CodeGenerators/CodeGeneratorHelper.cs
+++ b/ILCompiler/Compiler/CodeGenerators/CodeGeneratorHelper.cs
@@ -1,0 +1,72 @@
+﻿using ILCompiler.Compiler.Emit;
+using static ILCompiler.Compiler.Emit.Registers;
+
+namespace ILCompiler.Compiler.CodeGenerators
+{
+    internal static class CodeGeneratorHelper
+    {
+        public static void AddHLFromDE(InstructionsBuilder builder, short value)
+        {
+            if (value != 0)
+            {
+                if (-3 <= value && value <= 3)
+                {
+                    // For values upto +/- 3 we can just use Inc/Dec
+                    // These instructions use 1 byte, 6 t-states                
+                    IncOrDecNTimes(builder, value > 0, Math.Abs(value), HL);
+                }
+                else
+                {
+                    builder.Ld(DE, (short)value);       // 3 bytes, 10 t-states
+                    builder.Add(HL, DE);                // 1 byte, 11 t-states
+                }
+            }
+        }
+
+        public static void AddSPFromHL(InstructionsBuilder builder, short value)
+        {
+            if (value != 0) 
+            {
+                if (-5 <= value && value <= 5)
+                {
+                    if (value % 2 == 0 && value > 0)
+                    {
+                        // Can use pop to alter sp
+                        for (int i = 0; i < value / 2; i++)
+                        {
+                            builder.Pop(AF);
+                        }
+                    }
+                    else
+                    {
+                        // For values upto +/- 3 we can just use Inc/Dec
+                        // These instructions use 1 byte, 6 t-states
+                        IncOrDecNTimes(builder, value > 0, Math.Abs(value), SP);
+                    }
+                }
+                else
+                {
+                    // 5 bytes, 10 + 11 + 6 = 27 t-states
+                    builder.Ld(HL, (short)value);
+                    builder.Add(HL, SP);
+                    builder.Ld(SP, HL);
+                }
+            }
+        }
+
+        public static void IncOrDecNTimes(InstructionsBuilder builder, bool inc, int count, Register16 register)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                if (inc)
+                {
+                    builder.Inc(register);
+                }
+                else
+                {
+                    builder.Dec(register);
+                }
+            }
+        }
+    }
+}

--- a/ILCompiler/Compiler/CodeGenerators/CodeGeneratorHelper.cs
+++ b/ILCompiler/Compiler/CodeGenerators/CodeGeneratorHelper.cs
@@ -17,8 +17,8 @@ namespace ILCompiler.Compiler.CodeGenerators
                 }
                 else
                 {
-                    builder.Ld(DE, (short)value);       // 3 bytes, 10 t-states
-                    builder.Add(HL, DE);                // 1 byte, 11 t-states
+                    builder.Ld(DE, value);       // 3 bytes, 10 t-states
+                    builder.Add(HL, DE);         // 1 byte, 11 t-states
                 }
             }
         }
@@ -47,7 +47,7 @@ namespace ILCompiler.Compiler.CodeGenerators
                 else
                 {
                     // 5 bytes, 10 + 11 + 6 = 27 t-states
-                    builder.Ld(HL, (short)value);
+                    builder.Ld(HL, value);
                     builder.Add(HL, SP);
                     builder.Ld(SP, HL);
                 }

--- a/ILCompiler/Compiler/CodeGenerators/FieldAddressCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/FieldAddressCodeGenerator.cs
@@ -13,8 +13,7 @@ namespace ILCompiler.Compiler.CodeGenerators
             context.InstructionsBuilder.Pop(HL);      // LSW
 
             // Calculate field address
-            context.InstructionsBuilder.Ld(DE, (short)fieldOffset);
-            context.InstructionsBuilder.Add(HL, DE);
+            CodeGeneratorHelper.AddHLFromDE(context.InstructionsBuilder, (short)fieldOffset);
 
             // Push field address onto the stack msw first, lsw second
             context.InstructionsBuilder.Ld(DE, 0);

--- a/ILCompiler/Compiler/CodeGenerators/IndirectCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/IndirectCodeGenerator.cs
@@ -9,31 +9,17 @@ namespace ILCompiler.Compiler.CodeGenerators
         {
             if (entry.Type.IsInt() || entry.Type == VarType.Struct || entry.Type == VarType.Ptr || entry.Type == VarType.Ref)
             {
-                // Save IX to BC
-                context.InstructionsBuilder.Push(IX);
-                context.InstructionsBuilder.Pop(BC);
-
-                // Get indirect address from stack into IX
-                context.InstructionsBuilder.Pop(IX);
-
                 var size = entry.ExactSize ?? 4; // TODO: is 4 the right default size?
 
-                if (entry.Type == VarType.Ptr || entry.Type == VarType.Ref)
+                context.InstructionsBuilder.Pop(HL);
+                if (entry.Type.IsSmall())
                 {
-                    CopyHelper.CopyFromIXToStack(context.InstructionsBuilder, size, (short)entry.Offset, false);
-                }
-                else if (entry.Type.IsSmall())
-                {
-                    CopyHelper.CopySmallToStack(context.InstructionsBuilder, size, (short)entry.Offset, !entry.Type.IsUnsigned());
+                    CopyHelper.CopySmallFromHLToStack(context.InstructionsBuilder, size, (short)entry.Offset, !entry.Type.IsUnsigned());
                 }
                 else
                 {
-                    CopyHelper.CopyFromIXToStack(context.InstructionsBuilder, size, (short)entry.Offset, false);
+                    CopyHelper.CopyFromHLToStack(context.InstructionsBuilder, size, (short)entry.Offset);
                 }
-
-                // Restore IX
-                context.InstructionsBuilder.Push(BC);
-                context.InstructionsBuilder.Pop(IX);
             }
             else
             {

--- a/ILCompiler/Compiler/CodeGenerators/LocalVariableAddressCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/LocalVariableAddressCodeGenerator.cs
@@ -15,8 +15,7 @@ namespace ILCompiler.Compiler.CodeGenerators
             context.InstructionsBuilder.Push(IX);
             context.InstructionsBuilder.Pop(HL);
 
-            context.InstructionsBuilder.Ld(DE, (short)(-offset));
-            context.InstructionsBuilder.Add(HL, DE);
+            CodeGeneratorHelper.AddHLFromDE(context.InstructionsBuilder, (short)(-offset));
 
             // Push address
             context.InstructionsBuilder.Push(HL);

--- a/ILCompiler/Compiler/CodeGenerators/LocalVariableCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/LocalVariableCodeGenerator.cs
@@ -12,7 +12,7 @@ namespace ILCompiler.Compiler.CodeGenerators
 
             if (variable.Type.IsSmall())
             {
-                CopyHelper.CopySmallToStack(context.InstructionsBuilder, variable.Type.IsByte() ? 1 : 2, -variable.StackOffset, !variable.Type.IsUnsigned());
+                CopyHelper.CopySmallFromIXToStack(context.InstructionsBuilder, variable.Type.IsByte() ? 1 : 2, -variable.StackOffset, !variable.Type.IsUnsigned());
             }
             else
             {


### PR DESCRIPTION
Stop using IX for copying data for Indirect.
Improve codegen for ADD HL, nn
Improve codegen for callee removal of parameters

Contributes to #446

Impact on Samples built with release configuration:




| Sample | Size (bytes) With PR | Size (bytes) based on main | Delta bytes |
| -------- | ---------------------- | ------------------------------ | ------------ |
|CalcPi|6505|6980|475|
|Checksum|1583|1594|11|
|Chess|9744|10662|918|
|DoomFire|1688|1743|55|
|Fib|1243|1254|11|
|GfxDemos|9210|9523|313|
|Hanoi|3778|4052|274|
|Hello|248|252|4
|Life|9939|10915|976|
|Mandel|1730|1730|0|
|Matrix|5990|6432|442|
|Mines|12607|13517|910|
|Music|2380|2387|7|
|Netbot|13614|13871|257|
|Paint|2007|2026|19|
|Primes|9250|9405|155|
|Sample|2785|2810|25|
|Snake|7490|8106|616|
|Structs|1103|1116|13|
|Wumpus|15131|17070|1939|