### PR TITLE
Fix build error

### DIFF
--- a/System.Private.CoreLib/Pal/Console.ZXSpectrum.cs
+++ b/System.Private.CoreLib/Pal/Console.ZXSpectrum.cs
@@ -6,11 +6,11 @@ namespace System
     public static partial class Console
     {
         [DllImport(Libraries.Runtime, EntryPoint = "READLINE")]
-        private static unsafe extern String InternalReadLine(EETypePtr stringEEType);
+        private static unsafe extern String InternalReadLine(EEType* stringEEType);
 
         public static unsafe string ReadLine()
         {
-            return InternalReadLine(EETypePtr.EETypePtrOf<String>());
+            return InternalReadLine(EEType.Of<String>());
         }
 
         [DllImport(Libraries.Runtime, EntryPoint = "SetXY")]


### PR DESCRIPTION
Forgot about use of EETypePtr in ZXSpectrum version of Console class.