### PR TITLE
Combine calculation of local variable address with indirect offset

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/IndirectCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/IndirectCodeGenerator.cs
@@ -9,16 +9,24 @@ namespace ILCompiler.Compiler.CodeGenerators
         {
             if (entry.Type.IsInt() || entry.Type == VarType.Struct || entry.Type == VarType.Ptr || entry.Type == VarType.Ref)
             {
-                var size = entry.ExactSize ?? 4; // TODO: is 4 the right default size?
+                int offset = (int)entry.Offset;
+                if (entry.Op1.Contained && entry.Op1 is LocalVariableAddressEntry lvaAddress)
+                {
+                    var localVariable = context.LocalVariableTable[lvaAddress.LocalNumber];
+                    offset = -localVariable.StackOffset + offset;
 
+                    context.InstructionsBuilder.Push(IX);
+                }
                 context.InstructionsBuilder.Pop(HL);
+
+                var size = entry.ExactSize ?? 4; // TODO: is 4 the right default size?
                 if (entry.Type.IsSmall())
                 {
-                    CopyHelper.CopySmallFromHLToStack(context.InstructionsBuilder, size, (short)entry.Offset, !entry.Type.IsUnsigned());
+                    CopyHelper.CopySmallFromHLToStack(context.InstructionsBuilder, size, offset, !entry.Type.IsUnsigned());
                 }
                 else
                 {
-                    CopyHelper.CopyFromHLToStack(context.InstructionsBuilder, size, (short)entry.Offset);
+                    CopyHelper.CopyFromHLToStack(context.InstructionsBuilder, size, offset);
                 }
             }
             else

--- a/ILCompiler/Compiler/Lowerings/IndirectLowering.cs
+++ b/ILCompiler/Compiler/Lowerings/IndirectLowering.cs
@@ -1,0 +1,19 @@
+﻿using ILCompiler.Compiler.EvaluationStack;
+
+namespace ILCompiler.Compiler.Lowerings
+{
+    internal class IndirectLowering : ILowering<IndirectEntry>
+    {
+        public StackEntry? Lower(IndirectEntry entry)
+        {
+            if (entry.Op1 is LocalVariableAddressEntry lvaAddress)
+            {
+                // Mark as contained so calculation of local variable address
+                // can be combined with indirect offset and size
+                lvaAddress.Contained = true;
+            }
+
+            return null;
+        }
+    }
+}

--- a/ILCompiler/Compiler/Lowerings/ServiceCollectionExtensions.cs
+++ b/ILCompiler/Compiler/Lowerings/ServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ namespace ILCompiler.Compiler.Lowerings
             services.AddSingleton<ILowering<BinaryOperator>, BinaryOperatorLowering>();
             services.AddSingleton<ILowering<JumpTrueEntry>, JumpTrueLowering>();
             services.AddSingleton<ILowering<StoreLocalVariableEntry>, StoreLocalVariableLowering>();
+            services.AddSingleton<ILowering<IndirectEntry>, IndirectLowering>();
             return services;
         }
     }


### PR DESCRIPTION
Mark localvariableaddress entry as contained to allow code gen for indirect to combine the calculation of the local variable address and the indirect offset.
This avoids two additions to HL from DE

Final bits for #446 