### PR TITLE
When no exception handlers just failfast

### DIFF
--- a/ILCompiler/Common/TypeSystem/Common/MethodDesc.cs
+++ b/ILCompiler/Common/TypeSystem/Common/MethodDesc.cs
@@ -52,6 +52,8 @@ namespace ILCompiler.Common.TypeSystem.Common
 
         public CilBody Body { get; set; }
 
+        public bool HasExceptionHandlers => Body.ExceptionHandlers.Count > 0;
+
         public bool HasCustomAttribute(string attributeNamespace, string attributeName) => _methodDef.HasCustomAttribute(attributeNamespace, attributeName);
 
         public CustomAttribute FindCustomAttribute(string attributeName) => _methodDef.CustomAttributes.Find(attributeName);

--- a/ILCompiler/Compiler/CodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerator.cs
@@ -52,21 +52,7 @@ namespace ILCompiler.Compiler
 
             if (_configuration.ExceptionSupport && Compilation.AnyExceptionHandlers)
             {
-                // Think of this as the unwind information
-                // Could expand from single byte for number of parameters
-                // For example to handle frameless methods.
-
-                // Emit byte before method as number of bytes parameters take up on stack - basically unwind info for exception handling
-                var totalParametersSize = 0;
-                foreach (var local in _context.LocalVariableTable)
-                {
-                    if (local.IsParameter)
-                    {
-                        totalParametersSize += local.ExactSize;
-                    }
-                }
-                Debug.Assert(totalParametersSize <= Byte.MaxValue);
-                _context.InstructionsBuilder.Db((byte)totalParametersSize, "Total Parameter Size");
+                GenerateMethodUnwindInfo();
             }
 
             _context.InstructionsBuilder.Label(methodName);
@@ -116,6 +102,25 @@ namespace ILCompiler.Compiler
             methodInstructions.Add(Instruction.CreateComment($"Total bytes of code {totalBytes} for method {methodCodeNode.Method.FullName}"));
 
             return methodInstructions;
+        }
+
+        private void GenerateMethodUnwindInfo()
+        {
+            // Think of this as the unwind information
+            // Could expand from single byte for number of parameters
+            // For example to handle frameless methods.
+
+            // Emit byte before method as number of bytes parameters take up on stack - basically unwind info for exception handling
+            var totalParametersSize = 0;
+            foreach (var local in _context.LocalVariableTable)
+            {
+                if (local.IsParameter)
+                {
+                    totalParametersSize += local.ExactSize;
+                }
+            }
+            Debug.Assert(totalParametersSize <= Byte.MaxValue);
+            _context.InstructionsBuilder.Db((byte)totalParametersSize, "Total Parameter Size");
         }
 
         private void AssignFrameOffsets()

--- a/ILCompiler/Compiler/CodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerator.cs
@@ -50,7 +50,7 @@ namespace ILCompiler.Compiler
                 methodName = _nameMangler.GetMangledMethodName(_context.Method);
             }
 
-            if (_configuration.ExceptionSupport)
+            if (_configuration.ExceptionSupport && Compilation.AnyExceptionHandlers)
             {
                 // Think of this as the unwind information
                 // Could expand from single byte for number of parameters

--- a/ILCompiler/Compiler/Compilation.cs
+++ b/ILCompiler/Compiler/Compilation.cs
@@ -12,6 +12,8 @@ namespace ILCompiler.Compiler
         private readonly DependencyAnalyzer _dependencyAnalyzer;
         private readonly CorLibModuleProvider _corLibModuleProvider;
 
+        public static bool AnyExceptionHandlers { get; set; } = false;
+
         public Compilation(IConfiguration configuration, Z80AssemblyWriter z80Writer, CorLibModuleProvider corLibModuleProvider, DependencyAnalyzer dependencyAnalyzer)
         {
             _configuration = configuration;
@@ -48,6 +50,8 @@ namespace ILCompiler.Compiler
 
             // Core Dependency Analysis and code output routine
             var nodes = _dependencyAnalyzer.ComputeMarkedNodes();
+            AnyExceptionHandlers = nodes.OfType<Z80MethodCodeNode>().Any(n => n.HasExceptionHandlers);
+
             _z80AssemblyWriter.WriteCode(rootNode, nodes, inputFilePath, outputFilePath);
 
             // Write dgml version of dependency graph

--- a/ILCompiler/Compiler/DependencyAnalysis/ILScanner.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/ILScanner.cs
@@ -67,10 +67,6 @@ namespace ILCompiler.Compiler.DependencyAnalysis
                                 ImportCasting();
                                 break;
 
-                            case Code.Throw:
-                                ImportThrow();
-                                break;
-
                             case Code.Ldelema:
                                 ImportAddressOfElem();
                                 break;
@@ -133,10 +129,6 @@ namespace ILCompiler.Compiler.DependencyAnalysis
             var methodNode = _nodeFactory.MethodNode(runtimeHelperMethod);
 
             _dependencies.Add(methodNode);
-        }
-
-        private void ImportThrow()
-        {
         }
 
         private void ImportAddressOfElem()

--- a/ILCompiler/Compiler/DependencyAnalysis/Z80MethodCodeNode.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/Z80MethodCodeNode.cs
@@ -22,6 +22,7 @@ namespace ILCompiler.Compiler.DependencyAnalysis
             _methodCompilerFactory = methodCompilerFactory;
         }
 
+        public bool HasExceptionHandlers => Method?.Body?.HasExceptionHandlers ?? false;
         public IList<Instruction> MethodCode { get; set; } = new List<Instruction>();
 
         public IList<EHClause> EhClauses { get; set; } = new List<EHClause>();

--- a/ILCompiler/Compiler/Importer/ThrowImporter.cs
+++ b/ILCompiler/Compiler/Importer/ThrowImporter.cs
@@ -15,12 +15,23 @@ namespace ILCompiler.Compiler.Importer
 
             // Create call to helper method passing exception object
             var args = new List<StackEntry>() { op1 };
-            var node = new CallEntry("ThrowEx", args, VarType.Void, 0);
+            var node = new CallEntry(GetThrowHelper(), args, VarType.Void, 0);
 
             importer.ImportAppendTree(node);
 
             return true;
         }
 
+        public static string GetThrowHelper()
+        {
+            // If no exception handlers then can just use fail fast
+            // and avoid any overhead of searching for exception handler
+            if (!Compilation.AnyExceptionHandlers)
+            {
+                return "FailFast";
+            }
+
+            return "ThrowEx";
+        }
     }
 }

--- a/ILCompiler/ILCompiler.csproj
+++ b/ILCompiler/ILCompiler.csproj
@@ -24,6 +24,7 @@
     <None Remove="Runtime\CPM\printchr.asm" />
     <None Remove="Runtime\EHEnumInit.asm" />
     <None Remove="Runtime\EHEnumNext.asm" />
+    <None Remove="Runtime\FailFast.asm" />
     <None Remove="Runtime\GCGetTotalMemory.asm" />
     <None Remove="Runtime\InterfaceCall.asm" />
     <None Remove="Runtime\itoa.asm" />
@@ -121,6 +122,7 @@
     <EmbeddedResource Include="Runtime\Memcpy.asm" />
     <EmbeddedResource Include="Runtime\Memset.asm" />
     <EmbeddedResource Include="Runtime\InterfaceCall.asm" />
+    <EmbeddedResource Include="Runtime\FailFast.asm" />
     <EmbeddedResource Include="Runtime\ThrowEx.asm" />
     <EmbeddedResource Include="Runtime\RangeCheckFail.asm" />
     <EmbeddedResource Include="Runtime\VirtualCall.asm" />

--- a/ILCompiler/Runtime/FailFast.asm
+++ b/ILCompiler/Runtime/FailFast.asm
@@ -1,0 +1,27 @@
+; This routine takes an exception object and displays the message
+; then exits the program
+;
+; Uses: HL, DE
+;
+; On Entry: On stack: exception object
+
+FailFast:
+	; Remove return address
+	POP DE
+
+	; exception object
+	POP HL
+
+	; Get message object from exception
+	INC HL
+	INC HL
+	LD E, (HL)
+	INC HL
+	LD D, (HL)
+	EX DE, HL
+
+	; print exception message
+	CALL PRINT
+
+	; exit
+	JP EXIT


### PR DESCRIPTION
Optimize exception handling when there are no exception handlers. In this case all exceptions are unhandled exceptions and there is no need to try and search through the exception handlers, so throwing an exception is translated into calling failfast, and emit of eh clauses is unnecessary.

Hoping to make exceptions low enough overhead that they can be enabled by default.