### PR TITLE
Turn exceptions on permanently

### DIFF
--- a/ILCompiler/Compiler/CodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerator.cs
@@ -50,7 +50,7 @@ namespace ILCompiler.Compiler
                 methodName = _nameMangler.GetMangledMethodName(_context.Method);
             }
 
-            if (_configuration.ExceptionSupport && Compilation.AnyExceptionHandlers)
+            if (Compilation.AnyExceptionHandlers)
             {
                 GenerateMethodUnwindInfo();
             }
@@ -230,12 +230,9 @@ namespace ILCompiler.Compiler
                 }
             }
 
-            if (_context.ParamsCount > 0 || (_context.LocalsCount + tempCount) > 0 || _context.Configuration.ExceptionSupport)
-            {
-                instructionsBuilder.Push(IX);
-                instructionsBuilder.Ld(IX, 0);
-                instructionsBuilder.Add(IX, SP);
-            }
+            instructionsBuilder.Push(IX);
+            instructionsBuilder.Ld(IX, 0);
+            instructionsBuilder.Add(IX, SP);
 
             if (_context.LocalsCount + tempCount > 0)
             {

--- a/ILCompiler/Compiler/CodeGenerators/BoundsCheckCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/BoundsCheckCodeGenerator.cs
@@ -21,18 +21,11 @@ namespace ILCompiler.Compiler.CodeGenerators
             context.InstructionsBuilder.Sbc(HL, DE);    // Calculate Array Length - Index
 
             
-            if (!context.Configuration.ExceptionSupport)
-            {
-                context.InstructionsBuilder.Call(Condition.C, "RangeCheckFail");
-            }
-            else
-            {
-                // Emit conditional call to ThrowHelpers.ThrowIndexOutOfRangeException
-                var throwHelperMethod = context.CorLibModuleProvider.GetHelperEntryPoint("ThrowHelpers", "ThrowIndexOutOfRangeException");
-                var mangledThrowHelperMethod = context.NameMangler.GetMangledMethodName(throwHelperMethod);
+            // Emit conditional call to ThrowHelpers.ThrowIndexOutOfRangeException
+            var throwHelperMethod = context.CorLibModuleProvider.GetHelperEntryPoint("ThrowHelpers", "ThrowIndexOutOfRangeException");
+            var mangledThrowHelperMethod = context.NameMangler.GetMangledMethodName(throwHelperMethod);
 
-                context.InstructionsBuilder.Call(Condition.C, mangledThrowHelperMethod);
-            }
+            context.InstructionsBuilder.Call(Condition.C, mangledThrowHelperMethod);
         }
     }
 }

--- a/ILCompiler/Compiler/CodeGenerators/NullCheckCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/NullCheckCodeGenerator.cs
@@ -8,16 +8,16 @@ namespace ILCompiler.Compiler.CodeGenerators
     {
         public void GenerateCode(NullCheckEntry entry, CodeGeneratorContext context)
         {
-            if (context.Configuration.ExceptionSupport && !context.Configuration.SkipNullReferenceCheck)
+            if (!context.Configuration.SkipNullReferenceCheck)
             {
                 var throwHelperMethod = context.CorLibModuleProvider.GetHelperEntryPoint("ThrowHelpers", "ThrowNullReferenceException");
                 var mangledThrowHelperMethod = context.NameMangler.GetMangledMethodName(throwHelperMethod);
 
                 context.InstructionsBuilder.Pop(HL);
-                context.InstructionsBuilder.Push(HL);
                 context.InstructionsBuilder.Ld(A, H);
                 context.InstructionsBuilder.Or(L);
                 context.InstructionsBuilder.Call(Emit.Condition.Z, mangledThrowHelperMethod);
+                context.InstructionsBuilder.Push(HL);
             }
         }
     }

--- a/ILCompiler/Compiler/Z80AssemblyWriter.cs
+++ b/ILCompiler/Compiler/Z80AssemblyWriter.cs
@@ -117,10 +117,6 @@ namespace ILCompiler.Compiler
             {
                 WriteReturnCodeMessage(instructionsBuilder);
             }
-            if (!_configuration.ExceptionSupport)
-            {
-                WriteIndexOutOfRangeMessage(instructionsBuilder);
-            }
 
             instructionsBuilder.Label("START");
 
@@ -146,14 +142,6 @@ namespace ILCompiler.Compiler
             instructionsBuilder.Db(12);
             instructionsBuilder.Db(0); // Length of message
             instructionsBuilder.Db("R e t u r n   C o d e : ");
-        }
-
-        private static void WriteIndexOutOfRangeMessage(InstructionsBuilder instructionsBuilder)
-        {
-            instructionsBuilder.Label("INDEX_OUT_OF_RANGE_MSG");
-            instructionsBuilder.Db(18);
-            instructionsBuilder.Db(0); // Length of message
-            instructionsBuilder.Db("I n d e x   O u t   O f   R a n g e ");
         }
 
         private void WriteReturnCodeHandler(InstructionsBuilder instructionsBuilder)

--- a/ILCompiler/Configuration.cs
+++ b/ILCompiler/Configuration.cs
@@ -19,6 +19,5 @@ namespace ILCompiler
         public bool NoListFile { get; set; } = true;
         public bool SkipArrayBoundsCheck { get; set; } = false;
         public bool SkipNullReferenceCheck { get; set; } = false;
-        public bool ExceptionSupport { get; set; } = false;
     }
 }

--- a/ILCompiler/ConfigurationBinder.cs
+++ b/ILCompiler/ConfigurationBinder.cs
@@ -30,7 +30,6 @@ namespace ILCompiler
                 NoListFile = bindingContext.ParseResult.GetValueForOption(_configurationOptions.NoListFile),
                 SkipArrayBoundsCheck = bindingContext.ParseResult.GetValueForOption(_configurationOptions.SkipArrayBoundsCheck),
                 SkipNullReferenceCheck = bindingContext.ParseResult.GetValueForOption(_configurationOptions.SkipNullReferenceCheck),
-                ExceptionSupport = bindingContext.ParseResult.GetValueForOption(_configurationOptions.ExceptionSupport),
             };
         }
     }

--- a/ILCompiler/ConfigurationOptions.cs
+++ b/ILCompiler/ConfigurationOptions.cs
@@ -20,7 +20,6 @@ namespace ILCompiler
         public readonly Option<bool> NoListFile = new(new[] { "-nl", "--noListFile" }, "No list file");
         public readonly Option<bool> SkipArrayBoundsCheck = new(new[] { "-nb", "--noBoundsCheck" }, "No Array Bounds Check");
         public readonly Option<bool> SkipNullReferenceCheck = new(new[] { "-nn", "--noNullCheck" }, "No Null Reference Check");
-        public readonly Option<bool> ExceptionSupport = new(new[] { "-ex", "--exceptions" }, "Exceptions support");
 
         public void AddToCommand(Command command)
         {
@@ -36,7 +35,6 @@ namespace ILCompiler
             command.AddOption(NoListFile);
             command.AddOption(SkipArrayBoundsCheck);
             command.AddOption(SkipNullReferenceCheck);
-            command.AddOption(ExceptionSupport);
         }
     }
 }

--- a/ILCompiler/Interfaces/IConfiguration.cs
+++ b/ILCompiler/Interfaces/IConfiguration.cs
@@ -18,6 +18,5 @@ namespace ILCompiler.Interfaces
         public bool NoListFile { get; set; }
         public bool SkipArrayBoundsCheck { get; set; }
         public bool SkipNullReferenceCheck { get; set; }
-        public bool ExceptionSupport { get; set; }
     }
 }

--- a/ILCompiler/Program.cs
+++ b/ILCompiler/Program.cs
@@ -87,7 +87,6 @@ namespace ILCompiler
                     configuration.AssemblerArguments = parsedConfiguration.AssemblerArguments;
                     configuration.AssemblerOutput = parsedConfiguration.AssemblerOutput;
                     configuration.NoListFile = parsedConfiguration.NoListFile;
-                    configuration.ExceptionSupport = parsedConfiguration.ExceptionSupport;
                 },
                 inputFileArgument, outputFileOption, configurationBinder
             );

--- a/Tests/Methodical/MethodicalTestsRunner/MethodicalTestsRunner.cs
+++ b/Tests/Methodical/MethodicalTestsRunner/MethodicalTestsRunner.cs
@@ -28,13 +28,13 @@ namespace MethodicalTests
                 var cimFile = Path.ChangeExtension(testname, CimExtension);
 
                 // Run the test
-                ILCompilerRunner.Create(SolutionPath).CompileILAndAssemble(cimFile, createLibrary : false, optionalArguments : "--exceptions");
+                ILCompilerRunner.Create(SolutionPath).CompileILAndAssemble(cimFile, createLibrary : false);
                 Z80TestRunner.Create(SolutionPath).RunTest(cimFile);
             }
             else
             {
                 // No need to assemble any il as roslyn will have created assembled il
-                ILCompilerRunner.Create(SolutionPath).CompileILAndAssemble(testname, optionalArguments : "--exceptions");
+                ILCompilerRunner.Create(SolutionPath).CompileILAndAssemble(testname);
                 Z80TestRunner.Create(SolutionPath).RunTest(testname);
             }
 


### PR DESCRIPTION
Remove exception config
Fix bug in NullCheck codegen which was leaving object ref on stack when check failed
Use ix stack frame even when no parameters as exception handling cant cope without having an ix stack frame

Contributes to #424 