### PR TITLE
Generic static fields

### DIFF
--- a/ILCompiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -137,7 +137,7 @@ namespace ILCompiler.Compiler.DependencyAnalysis
             var eeMangledTypeName = _nameMangler.GetMangledTypeName(Type);
 
             var instructionsBuilder = new InstructionsBuilder();
-            instructionsBuilder.Comment($"{Type.FullName}");
+            instructionsBuilder.Comment($"{Type}");
 
             // Need to mangle full field name here
             instructionsBuilder.Label(eeMangledTypeName);

--- a/ILCompiler/Compiler/DependencyAnalysis/ILScanner.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/ILScanner.cs
@@ -24,7 +24,7 @@ namespace ILCompiler.Compiler.DependencyAnalysis
 
         public IList<IDependencyNode> FindDependencies()
         {
-            if (_method is InstantiatedMethod && _methodIL != null)
+            if ((_method is InstantiatedMethod || _method is MethodForInstantiatedType) && _methodIL != null)
             {
                 _methodIL = new InstantiatedMethodIL(_method, _methodIL);
             }

--- a/ILCompiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -53,10 +53,10 @@ namespace ILCompiler.Compiler.DependencyAnalysis
 
         public StaticsNode StaticsNode(FieldDesc field)
         {
-            if (!_staticNodesByFullName.TryGetValue(field.FullName, out var staticNode))
+            if (!_staticNodesByFullName.TryGetValue(field.ToString(), out var staticNode))
             {
                 staticNode = new StaticsNode(field, _preinitializationManager, _nameMangler);
-                _staticNodesByFullName[field.FullName] = staticNode;
+                _staticNodesByFullName[field.ToString()] = staticNode;
             }
 
             return staticNode;

--- a/ILCompiler/Compiler/DependencyAnalysis/StaticsNode.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/StaticsNode.cs
@@ -10,7 +10,7 @@ namespace ILCompiler.Compiler.DependencyAnalysis
     {
         public FieldDesc Field { get; private set; }
 
-        public override string Name => Field.FullName;
+        public override string Name => Field.ToString();
 
         private readonly PreinitializationManager _preinitializationManager;
         private readonly INameMangler _nameMangler;
@@ -45,7 +45,7 @@ namespace ILCompiler.Compiler.DependencyAnalysis
             else
             {
                 var fieldSize = field.FieldType.GetElementSize().AsInt;
-                instructionsBuilder.Comment($"Reserving {fieldSize} bytes for static field {field.FullName}");
+                instructionsBuilder.Comment($"Reserving {fieldSize} bytes for static field {field.ToString()}");
 
                 // Need to mangle full field name here
                 instructionsBuilder.Label(_nameMangler.GetMangledFieldName(field));

--- a/ILCompiler/Compiler/NameMangler.cs
+++ b/ILCompiler/Compiler/NameMangler.cs
@@ -34,7 +34,7 @@ namespace ILCompiler.Compiler
 
         public string GetMangledFieldName(FieldDesc field)
         {
-            return GetMangledFieldName(field.FullName);
+            return GetMangledFieldName(field.ToString());
         }
 
         public string GetMangledTypeName(TypeDesc type)

--- a/ILCompiler/Runtime/NewObject.asm
+++ b/ILCompiler/Runtime/NewObject.asm
@@ -32,7 +32,7 @@ NewObject:
 	; Zero rest of allocated memory
 	LD B, D
 	LD C, E
-	DEC BC	; Skip over first 1 byte of EEType
+	INC BC	; Skip over first 1 byte of EEType
 
 NewObject_ZeroLoop:
 	DEC BC

--- a/ILCompiler/TypeSystem/Common/FieldDesc.cs
+++ b/ILCompiler/TypeSystem/Common/FieldDesc.cs
@@ -44,8 +44,6 @@
 
         public abstract string Name { get;  }
 
-        public abstract string FullName { get; }
-
         public abstract DefType OwningType { get; }
 
         public abstract TypeDesc FieldType { get; }
@@ -69,6 +67,11 @@
         public virtual FieldDesc GetTypicalFieldDefinition()
         {
             return this;
+        }
+
+        public override string ToString()
+        {
+            return $"{OwningType}.{Name}";
         }
     }
 }

--- a/ILCompiler/TypeSystem/Common/FieldForInstantiatedType.cs
+++ b/ILCompiler/TypeSystem/Common/FieldForInstantiatedType.cs
@@ -14,8 +14,6 @@
 
         public override string Name => _fieldDef.Name;
 
-        public override string FullName => _fieldDef.FullName;
-
         public override DefType OwningType => _instantiatedType;
 
         public override TypeDesc FieldType => _fieldDef.FieldType.InstantiateSignature(_instantiatedType.Instantiation, default(Instantiation));

--- a/ILCompiler/TypeSystem/Common/InstantiatedType.cs
+++ b/ILCompiler/TypeSystem/Common/InstantiatedType.cs
@@ -105,5 +105,7 @@ namespace ILCompiler.TypeSystem.Common
         }
 
         public override VarType VarType => _typeDef.VarType;
+
+        public override string Name => _typeDef.Name;
     }
 }

--- a/ILCompiler/TypeSystem/Common/MethodDesc.cs
+++ b/ILCompiler/TypeSystem/Common/MethodDesc.cs
@@ -85,9 +85,7 @@ namespace ILCompiler.TypeSystem.Common
             typeNameFormatter.AppendName(sb, Signature.ReturnType);
             sb.Append(' ');
 
-            sb.Append(OwningType.Namespace);
-            sb.Append('.');
-            sb.Append(OwningType.Name);
+            sb.Append(OwningType);
             sb.Append("::");
             sb.Append(Name);
 

--- a/ILCompiler/TypeSystem/Common/TypeDesc.cs
+++ b/ILCompiler/TypeSystem/Common/TypeDesc.cs
@@ -1,4 +1,5 @@
 ﻿using ILCompiler.Compiler;
+using System.Text;
 
 namespace ILCompiler.TypeSystem.Common
 {
@@ -97,5 +98,13 @@ namespace ILCompiler.TypeSystem.Common
         public virtual TypeDesc InstantiateSignature(Instantiation? typeInstantiation, Instantiation? methodInstantiation) => this;
 
         public virtual TypeDesc GetTypeDefinition() => this;
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            var typeNameFormatter = new TypeNameFormatter();
+            typeNameFormatter.AppendName(sb, this);
+            return sb.ToString();
+        }
     }
 }

--- a/ILCompiler/TypeSystem/Common/TypeSystemContext.cs
+++ b/ILCompiler/TypeSystem/Common/TypeSystemContext.cs
@@ -72,7 +72,7 @@
         public FieldDesc GetFieldForInstantiatedType(FieldDesc fieldDef, InstantiatedType instantiatedType)
         {
             // TODO: Fix key generation as fullname/instantiation may contain colons
-            var key = fieldDef.FullName + ":" + instantiatedType.Instantiation!.ToString();
+            var key = fieldDef.ToString() + ":" + instantiatedType.Instantiation!.ToString();
             if (_fieldForInstantiatedTypes.TryGetValue(key, out var field)) 
                 return field; 
 

--- a/ILCompiler/TypeSystem/Dnlib/DnlibField.cs
+++ b/ILCompiler/TypeSystem/Dnlib/DnlibField.cs
@@ -14,7 +14,6 @@ namespace ILCompiler.TypeSystem.Dnlib
         }
 
         public override string Name => _fieldDef.Name;
-        public override string FullName => _fieldDef.FullName;
 
         public override DefType OwningType => (DefType)_module.Create(_fieldDef.DeclaringType);
 

--- a/Tests/Generics/GenericFields/TestRunner.cs
+++ b/Tests/Generics/GenericFields/TestRunner.cs
@@ -11,9 +11,8 @@
             //result = InstanceEqualNullClass.RunTests(); if (result != 0) return result;
             //result = InstanceEqualNullStruct.RunTests(); if (result != 0) return result;
 
-            // TODO: Fails - statics in generic types not yet implemented
-            //int result = StaticAssignmentClass.RunTests(); if (result != 0) return result;            
-            //int result = StaticAssignmentStruct.RunTests(); if (result != 0) return result;
+            result = StaticAssignmentClass.RunTests(); if (result != 0) return result;            
+            result = StaticAssignmentStruct.RunTests(); if (result != 0) return result;
 
             return result;
         }


### PR DESCRIPTION
Fixs bugs preventing generic static fields from working.
Also fixed bug in NewObject which was not zeroing sufficient bytes allocated and failed if size of object excluding header was 0

Contributes to #466