### PR TITLE
Capture console in tests

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/LocalVariableCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/LocalVariableCodeGenerator.cs
@@ -10,7 +10,7 @@ namespace ILCompiler.Compiler.CodeGenerators
             var variable = context.LocalVariableTable[entry.LocalNumber];
             var size = variable.ExactSize;
 
-            if (variable.Type.IsSmall())
+            if (variable.Type.IsSmall() || (variable.Type == VarType.Struct && size == 1))
             {
                 CopyHelper.CopySmallFromIXToStack(context.InstructionsBuilder, variable.Type.IsByte() ? 1 : 2, -variable.StackOffset, !variable.Type.IsUnsigned());
             }

--- a/ILCompiler/Compiler/Z80AssemblyWriter.cs
+++ b/ILCompiler/Compiler/Z80AssemblyWriter.cs
@@ -34,7 +34,7 @@ namespace ILCompiler.Compiler
         {
             if (_configuration.IntegrationTests)
             {
-                return 0x0000;
+                return 0x0050;
             }
             return _configuration.TargetArchitecture switch
             {

--- a/ILCompiler/TypeSystem/Common/InstantiatedType.cs
+++ b/ILCompiler/TypeSystem/Common/InstantiatedType.cs
@@ -107,5 +107,7 @@ namespace ILCompiler.TypeSystem.Common
         public override VarType VarType => _typeDef.VarType;
 
         public override string Name => _typeDef.Name;
+
+        public override bool IsValueType => _typeDef.IsValueType;
     }
 }

--- a/ILCompiler/TypeSystem/Common/TypeSystemContext.cs
+++ b/ILCompiler/TypeSystem/Common/TypeSystemContext.cs
@@ -5,7 +5,6 @@
         public TargetDetails Target { get; } = new TargetDetails(TargetArchitecture.Z80);
 
         private readonly Dictionary<string, ArrayType> _arrayTypes = new Dictionary<string, ArrayType>();
-        private readonly Dictionary<string, ByRefType> _byRefTypes = new Dictionary<string, ByRefType>();
         private readonly Dictionary<string, FunctionPointerType> _functionPointerTypes = new Dictionary<string, FunctionPointerType>();
         private readonly Dictionary<string, PointerType> _pointerTypes = new Dictionary<string, PointerType>();
         private readonly Dictionary<string, FieldDesc> _fieldForInstantiatedTypes = new Dictionary<string, FieldDesc>();
@@ -43,15 +42,6 @@
             }
 
             return ((DefType)type);
-        }
-
-        public ByRefType GetByRefType(TypeDesc parameterType)
-        {
-            var byrefTypeKey = parameterType.FullName;
-            if (_byRefTypes.TryGetValue(byrefTypeKey, out var byrefType))
-                return byrefType;
-
-            return _byRefTypes[byrefTypeKey] = new ByRefType(parameterType);
         }
 
         public ArrayType GetArrayType(TypeDesc elementType, int rank)

--- a/ILCompiler/TypeSystem/Common/TypeSystemContext.cs
+++ b/ILCompiler/TypeSystem/Common/TypeSystemContext.cs
@@ -5,6 +5,7 @@
         public TargetDetails Target { get; } = new TargetDetails(TargetArchitecture.Z80);
 
         private readonly Dictionary<string, ArrayType> _arrayTypes = new Dictionary<string, ArrayType>();
+        private readonly Dictionary<string, ByRefType> _byRefTypes = new Dictionary<string, ByRefType>();
         private readonly Dictionary<string, FunctionPointerType> _functionPointerTypes = new Dictionary<string, FunctionPointerType>();
         private readonly Dictionary<string, PointerType> _pointerTypes = new Dictionary<string, PointerType>();
         private readonly Dictionary<string, FieldDesc> _fieldForInstantiatedTypes = new Dictionary<string, FieldDesc>();
@@ -42,6 +43,15 @@
             }
 
             return ((DefType)type);
+        }
+
+        public ByRefType GetByRefType(TypeDesc parameterType)
+        {
+            var byrefTypeKey = parameterType.FullName;
+            if (_byRefTypes.TryGetValue(byrefTypeKey, out var byrefType))
+                return byrefType;
+
+            return _byRefTypes[byrefTypeKey] = new ByRefType(parameterType);
         }
 
         public ArrayType GetArrayType(TypeDesc elementType, int rank)

--- a/Tests/Generics/GenericFields/InstanceAssignmentClass.cs
+++ b/Tests/Generics/GenericFields/InstanceAssignmentClass.cs
@@ -1,4 +1,6 @@
-﻿namespace GenericFields
+﻿using System;
+
+namespace GenericFields
 {
     internal class InstanceAssignmentClass
     {
@@ -13,18 +15,31 @@
             }
         }
 
-        public static int RunTests()
+        public static int counter = 0;
+        public static bool result = true;
+        public static void Eval(bool exp)
+        {
+            counter++;
+            if (!exp)
+            {
+                result = exp;
+                Console.Write("InstanceAssignmentClass failed at location: ");
+                Console.WriteLine(counter);
+            }
+        }
+
+        public static bool RunTests()
         {
             int _int = 1;
-            if (new Gen<int>().Assign(_int) != _int) return 1;
+            Eval(new Gen<int>().Assign(_int) == _int);
 
             string _string = "string";
-            if (new Gen<string>().Assign(_string) != _string) return 2;
+            Eval(new Gen<string>().Assign(_string) == _string);
 
             var _object = new object();
-            if (new Gen<object>().Assign(_object) != _object) return 3;
+            Eval(new Gen<object>().Assign(_object) == _object);
 
-            return 0;
+            return result;
         }
     }
 }

--- a/Tests/Generics/GenericFields/InstanceAssignmentClass.cs
+++ b/Tests/Generics/GenericFields/InstanceAssignmentClass.cs
@@ -15,16 +15,16 @@ namespace GenericFields
             }
         }
 
-        public static int counter = 0;
-        public static bool result = true;
+        private static int _counter = 0;
+        private static bool _result = true;
         public static void Eval(bool exp)
         {
-            counter++;
+            _counter++;
             if (!exp)
             {
-                result = exp;
+                _result = exp;
                 Console.Write("InstanceAssignmentClass failed at location: ");
-                Console.WriteLine(counter);
+                Console.WriteLine(_counter);
             }
         }
 
@@ -39,7 +39,7 @@ namespace GenericFields
             var _object = new object();
             Eval(new Gen<object>().Assign(_object) == _object);
 
-            return result;
+            return _result;
         }
     }
 }

--- a/Tests/Generics/GenericFields/InstanceAssignmentStruct.cs
+++ b/Tests/Generics/GenericFields/InstanceAssignmentStruct.cs
@@ -1,4 +1,6 @@
-﻿namespace GenericFields
+﻿using System;
+
+namespace GenericFields
 {
     internal class InstanceAssignmentStruct
     {
@@ -13,18 +15,31 @@
             }
         }
 
-        public static int RunTests()
+        public static int counter = 0;
+        public static bool result = true;
+        public static void Eval(bool exp)
+        {
+            counter++;
+            if (!exp)
+            {
+                result = exp;
+                Console.Write("InstanceAssignmentStruct failed at location: ");
+                Console.WriteLine(counter);
+            }
+        }
+
+        public static bool RunTests()
         {
             int _int = 1;
-            if (new Gen<int>().Assign(_int) != _int) return 1;
+            Eval(new Gen<int>().Assign(_int) == _int);
 
             string _string = "string";
-            if (new Gen<string>().Assign(_string) != _string) return 2;
+            Eval(new Gen<string>().Assign(_string) == _string);
 
             var _object = new object();
-            if (new Gen<object>().Assign(_object) != _object) return 3;
+            Eval(new Gen<object>().Assign(_object) == _object);
 
-            return 0;
+            return result;
         }
     }
 }

--- a/Tests/Generics/GenericFields/InstanceAssignmentStruct.cs
+++ b/Tests/Generics/GenericFields/InstanceAssignmentStruct.cs
@@ -15,16 +15,16 @@ namespace GenericFields
             }
         }
 
-        public static int counter = 0;
-        public static bool result = true;
+        private static int _counter = 0;
+        private static bool _result = true;
         public static void Eval(bool exp)
         {
-            counter++;
+            _counter++;
             if (!exp)
             {
-                result = exp;
+                _result = exp;
                 Console.Write("InstanceAssignmentStruct failed at location: ");
-                Console.WriteLine(counter);
+                Console.WriteLine(_counter);
             }
         }
 
@@ -39,7 +39,7 @@ namespace GenericFields
             var _object = new object();
             Eval(new Gen<object>().Assign(_object) == _object);
 
-            return result;
+            return _result;
         }
     }
 }

--- a/Tests/Generics/GenericFields/InstanceEqualNullClass.cs
+++ b/Tests/Generics/GenericFields/InstanceEqualNullClass.cs
@@ -15,16 +15,16 @@ namespace GenericFields
             }
         }
 
-        public static int counter = 0;
-        public static bool result = true;
+        private static int _counter = 0;
+        private static bool _result = true;
         public static void Eval(bool exp)
         {
-            counter++;
+            _counter++;
             if (!exp)
             {
-                result = exp;
+                _result = exp;
                 Console.Write("InstanceEqualNullClass failed at location: ");
-                Console.WriteLine(counter);
+                Console.WriteLine(_counter);
             }
         }
 
@@ -41,7 +41,7 @@ namespace GenericFields
             Eval(!new Gen<object>().EqualNull(_object));
             Eval(new Gen<object>().EqualNull(null));
 
-            return result;
+            return _result;
         }
     }
 }

--- a/Tests/Generics/GenericFields/InstanceEqualNullClass.cs
+++ b/Tests/Generics/GenericFields/InstanceEqualNullClass.cs
@@ -11,7 +11,7 @@ namespace GenericFields
             public bool EqualNull(T? t)
             {
                 Field1 = t;
-                return ((object)Field1! == null);
+                return ((object?)Field1 == null);
             }
         }
 

--- a/Tests/Generics/GenericFields/InstanceEqualNullClass.cs
+++ b/Tests/Generics/GenericFields/InstanceEqualNullClass.cs
@@ -1,4 +1,6 @@
-﻿namespace GenericFields
+﻿using System;
+
+namespace GenericFields
 {
     internal class InstanceEqualNullClass
     {
@@ -13,20 +15,33 @@
             }
         }
 
-        public static int RunTests()
+        public static int counter = 0;
+        public static bool result = true;
+        public static void Eval(bool exp)
+        {
+            counter++;
+            if (!exp)
+            {
+                result = exp;
+                Console.Write("InstanceEqualNullClass failed at location: ");
+                Console.WriteLine(counter);
+            }
+        }
+
+        public static bool RunTests()
         {
             int _int = 1;
-            if (new Gen<int>().EqualNull(_int)) return 1;
+            Eval(!new Gen<int>().EqualNull(_int));
 
-            string _string = "string";
-            if (new Gen<string>().EqualNull(_string)) return 2;
-            if (!new Gen<string>().EqualNull(null)) return 3;
+            string _string = "string";                       
+            Eval(!new Gen<string>().EqualNull(_string));
+            Eval(new Gen<string>().EqualNull(null));
 
             var _object = new object();
-            if (new Gen<object>().EqualNull(_object)) return 4;
-            if (!new Gen<object>().EqualNull(null)) return 5;
+            Eval(!new Gen<object>().EqualNull(_object));
+            Eval(new Gen<object>().EqualNull(null));
 
-            return 0;
+            return result;
         }
     }
 }

--- a/Tests/Generics/GenericFields/InstanceEqualNullStruct.cs
+++ b/Tests/Generics/GenericFields/InstanceEqualNullStruct.cs
@@ -1,4 +1,6 @@
-﻿namespace GenericFields
+﻿using System;
+
+namespace GenericFields
 {
     internal class InstanceEqualNullStruct
     {
@@ -13,20 +15,33 @@
             }
         }
 
-        public static int RunTests()
+        public static int counter = 0;
+        public static bool result = true;
+        public static void Eval(bool exp)
+        {
+            counter++;
+            if (!exp)
+            {
+                result = exp;
+                Console.Write("InstanceEqualNullStruct failed at location: ");
+                Console.WriteLine(counter);
+            }
+        }
+
+        public static bool RunTests()
         {
             int _int = 1;
-            if (new Gen<int>().EqualNull(_int)) return 1;
+            Eval(!new Gen<int>().EqualNull(_int));
 
             string _string = "string";
-            if (new Gen<string>().EqualNull(_string)) return 2;
-            if (!new Gen<string>().EqualNull(null)) return 3;
+            Eval(!new Gen<string>().EqualNull(_string));
+            Eval(new Gen<string>().EqualNull(null));
 
             var _object = new object();
-            if (new Gen<object>().EqualNull(_object)) return 4;
-            if (!new Gen<object>().EqualNull(null)) return 5;
+            Eval(!new Gen<object>().EqualNull(_object));
+            Eval(new Gen<object>().EqualNull(null));
 
-            return 0;
+            return result;
         }
     }
 }

--- a/Tests/Generics/GenericFields/InstanceEqualNullStruct.cs
+++ b/Tests/Generics/GenericFields/InstanceEqualNullStruct.cs
@@ -15,16 +15,16 @@ namespace GenericFields
             }
         }
 
-        public static int counter = 0;
-        public static bool result = true;
+        private static int _counter = 0;
+        private static bool _result = true;
         public static void Eval(bool exp)
         {
-            counter++;
+            _counter++;
             if (!exp)
             {
-                result = exp;
+                _result = exp;
                 Console.Write("InstanceEqualNullStruct failed at location: ");
-                Console.WriteLine(counter);
+                Console.WriteLine(_counter);
             }
         }
 
@@ -41,7 +41,7 @@ namespace GenericFields
             Eval(!new Gen<object>().EqualNull(_object));
             Eval(new Gen<object>().EqualNull(null));
 
-            return result;
+            return _result;
         }
     }
 }

--- a/Tests/Generics/GenericFields/InstanceEqualNullStruct.cs
+++ b/Tests/Generics/GenericFields/InstanceEqualNullStruct.cs
@@ -11,7 +11,7 @@ namespace GenericFields
             public bool EqualNull(T? t)
             {
                 Field1 = t;
-                return ((object)Field1! == null);
+                return ((object?)Field1 == null);
             }
         }
 

--- a/Tests/Generics/GenericFields/StaticAssignmentClass.cs
+++ b/Tests/Generics/GenericFields/StaticAssignmentClass.cs
@@ -15,16 +15,16 @@ namespace GenericFields
             }
         }
 
-        public static int counter = 0;
-        public static bool result = true;
+        private static int _counter = 0;
+        private static bool _result = true;
         public static void Eval(bool exp)
         {
-            counter++;
+            _counter++;
             if (!exp)
             {
-                result = exp;
+                _result = exp;
                 Console.Write("StaticAssignmentClass failed at location: ");
-                Console.WriteLine(counter);
+                Console.WriteLine(_counter);
             }
         }
 
@@ -39,7 +39,7 @@ namespace GenericFields
             var _object = new object();
             Eval(new Gen<object>().Assign(_object) == _object);
 
-            return result;
+            return _result;
         }
     }
 }

--- a/Tests/Generics/GenericFields/StaticAssignmentClass.cs
+++ b/Tests/Generics/GenericFields/StaticAssignmentClass.cs
@@ -1,4 +1,6 @@
-﻿namespace GenericFields
+﻿using System;
+
+namespace GenericFields
 {
     internal class StaticAssignmentClass
     {
@@ -13,18 +15,31 @@
             }
         }
 
-        public static int RunTests()
+        public static int counter = 0;
+        public static bool result = true;
+        public static void Eval(bool exp)
+        {
+            counter++;
+            if (!exp)
+            {
+                result = exp;
+                Console.Write("StaticAssignmentClass failed at location: ");
+                Console.WriteLine(counter);
+            }
+        }
+
+        public static bool RunTests()
         {
             int _int = 1;
-            if (new Gen<int>().Assign(_int) != _int) return 1;
+            Eval(new Gen<int>().Assign(_int) == _int);
 
             string _string = "string";
-            if (new Gen<string>().Assign(_string) != _string) return 2;
+            Eval(new Gen<string>().Assign(_string) == _string);
 
             var _object = new object();
-            if (new Gen<object>().Assign(_object) != _object) return 3;
+            Eval(new Gen<object>().Assign(_object) == _object);
 
-            return 0;
+            return result;
         }
     }
 }

--- a/Tests/Generics/GenericFields/StaticAssignmentStruct.cs
+++ b/Tests/Generics/GenericFields/StaticAssignmentStruct.cs
@@ -1,4 +1,6 @@
-﻿namespace GenericFields
+﻿using System;
+
+namespace GenericFields
 {
     internal class StaticAssignmentStruct
     {
@@ -13,18 +15,31 @@
             }
         }
 
-        public static int RunTests()
+        public static int counter = 0;
+        public static bool result = true;
+        public static void Eval(bool exp)
+        {
+            counter++;
+            if (!exp)
+            {
+                result = exp;
+                Console.Write("StaticAssignmentStruct failed at location: ");
+                Console.WriteLine(counter);
+            }
+        }
+
+        public static bool RunTests()
         {
             int _int = 1;
-            if (new Gen<int>().Assign(_int) != _int) return 1;
+            Eval(new Gen<int>().Assign(_int) == _int);
 
             string _string = "string";
-            if (new Gen<string>().Assign(_string) != _string) return 2;
+            Eval(new Gen<string>().Assign(_string) == _string);
 
             var _object = new object();
-            if (new Gen<object>().Assign(_object) != _object) return 3;
+            Eval(new Gen<object>().Assign(_object) == _object);
 
-            return 0;
+            return result;
         }
     }
 }

--- a/Tests/Generics/GenericFields/StaticAssignmentStruct.cs
+++ b/Tests/Generics/GenericFields/StaticAssignmentStruct.cs
@@ -15,16 +15,16 @@ namespace GenericFields
             }
         }
 
-        public static int counter = 0;
-        public static bool result = true;
+        private static int _counter = 0;
+        private static bool _result = true;
         public static void Eval(bool exp)
         {
-            counter++;
+            _counter++;
             if (!exp)
             {
-                result = exp;
+                _result = exp;
                 Console.Write("StaticAssignmentStruct failed at location: ");
-                Console.WriteLine(counter);
+                Console.WriteLine(_counter);
             }
         }
 
@@ -39,7 +39,7 @@ namespace GenericFields
             var _object = new object();
             Eval(new Gen<object>().Assign(_object) == _object);
 
-            return result;
+            return _result;
         }
     }
 }

--- a/Tests/Generics/GenericFields/StaticEqualNullClass.cs
+++ b/Tests/Generics/GenericFields/StaticEqualNullClass.cs
@@ -15,16 +15,16 @@ namespace GenericFields
             }
         }
 
-        public static int counter = 0;
-        public static bool result = true;
+        private static int _counter = 0;
+        private static bool _result = true;
         public static void Eval(bool exp)
         {
-            counter++;
+            _counter++;
             if (!exp)
             {
-                result = exp;
+                _result = exp;
                 Console.Write("StaticEqualNullClass failed at location: ");
-                Console.WriteLine(counter);
+                Console.WriteLine(_counter);
             }
         }
 
@@ -41,7 +41,7 @@ namespace GenericFields
             Eval(!new Gen<object>().EqualNull(_object));
             Eval(new Gen<object>().EqualNull(null));
 
-            return result;
+            return _result;
         }
     }
 }

--- a/Tests/Generics/GenericFields/StaticEqualNullClass.cs
+++ b/Tests/Generics/GenericFields/StaticEqualNullClass.cs
@@ -1,4 +1,6 @@
-﻿namespace GenericFields
+﻿using System;
+
+namespace GenericFields
 {
     internal class StaticEqualNullClass
     {
@@ -13,20 +15,33 @@
             }
         }
 
-        public static int RunTests()
+        public static int counter = 0;
+        public static bool result = true;
+        public static void Eval(bool exp)
+        {
+            counter++;
+            if (!exp)
+            {
+                result = exp;
+                Console.Write("StaticEqualNullClass failed at location: ");
+                Console.WriteLine(counter);
+            }
+        }
+
+        public static bool RunTests()
         {
             int _int = 1;
-            if (new Gen<int>().EqualNull(_int)) return 1;
+            Eval(!new Gen<int>().EqualNull(_int));
 
             string _string = "string";
-            if (new Gen<string>().EqualNull(_string)) return 2;
-            if (!new Gen<string>().EqualNull(null)) return 3;
+            Eval(!new Gen<string>().EqualNull(_string));
+            Eval(new Gen<string>().EqualNull(null));
 
             var _object = new object();
-            if (new Gen<object>().EqualNull(_object)) return 4;
-            if (!new Gen<object>().EqualNull(null)) return 5;
+            Eval(!new Gen<object>().EqualNull(_object));
+            Eval(new Gen<object>().EqualNull(null));
 
-            return 0;
+            return result;
         }
     }
 }

--- a/Tests/Generics/GenericFields/StaticEqualNullClass.cs
+++ b/Tests/Generics/GenericFields/StaticEqualNullClass.cs
@@ -11,7 +11,7 @@ namespace GenericFields
             public bool EqualNull(T? t)
             {
                 Field1 = t;
-                return ((object)Field1! == null);
+                return ((object?)Field1 == null);
             }
         }
 

--- a/Tests/Generics/GenericFields/StaticEqualNullStruct.cs
+++ b/Tests/Generics/GenericFields/StaticEqualNullStruct.cs
@@ -15,16 +15,16 @@ namespace GenericFields
             }
         }
 
-        public static int counter = 0;
-        public static bool result = true;
+        private static int _counter = 0;
+        private static bool _result = true;
         public static void Eval(bool exp)
         {
-            counter++;
+            _counter++;
             if (!exp)
             {
-                result = exp;
+                _result = exp;
                 Console.Write("StaticEqualNull Struct failed at location: ");
-                Console.WriteLine(counter);
+                Console.WriteLine(_counter);
             }
         }
 
@@ -41,7 +41,7 @@ namespace GenericFields
             Eval(!new Gen<object>().EqualNull(_object));
             Eval(new Gen<object>().EqualNull(null));
 
-            return result;
+            return _result;
         }
     }
 }

--- a/Tests/Generics/GenericFields/StaticEqualNullStruct.cs
+++ b/Tests/Generics/GenericFields/StaticEqualNullStruct.cs
@@ -1,4 +1,6 @@
-﻿namespace GenericFields
+﻿using System;
+
+namespace GenericFields
 {
     internal class StaticEqualNullStruct
     {
@@ -13,20 +15,33 @@
             }
         }
 
-        public static int RunTests()
+        public static int counter = 0;
+        public static bool result = true;
+        public static void Eval(bool exp)
+        {
+            counter++;
+            if (!exp)
+            {
+                result = exp;
+                Console.Write("StaticEqualNull Struct failed at location: ");
+                Console.WriteLine(counter);
+            }
+        }
+
+        public static bool RunTests()
         {
             int _int = 1;
-            if (new Gen<int>().EqualNull(_int)) return 1;
+            Eval(!new Gen<int>().EqualNull(_int));
 
             string _string = "string";
-            if (new Gen<string>().EqualNull(_string)) return 2;
-            if (!new Gen<string>().EqualNull(null)) return 3;
+            Eval(!new Gen<string>().EqualNull(_string));
+            Eval(new Gen<string>().EqualNull(null));
 
             var _object = new object();
-            if (new Gen<object>().EqualNull(_object)) return 4;
-            if (!new Gen<object>().EqualNull(null)) return 5;
+            Eval(!new Gen<object>().EqualNull(_object));
+            Eval(new Gen<object>().EqualNull(null));
 
-            return 0;
+            return result;
         }
     }
 }

--- a/Tests/Generics/GenericFields/StaticEqualNullStruct.cs
+++ b/Tests/Generics/GenericFields/StaticEqualNullStruct.cs
@@ -11,7 +11,7 @@ namespace GenericFields
             public bool EqualNull(T? t)
             {
                 Field1 = t;
-                return ((object)Field1! == null);
+                return ((object?)Field1 == null);
             }
         }
 

--- a/Tests/Generics/GenericFields/TestRunner.cs
+++ b/Tests/Generics/GenericFields/TestRunner.cs
@@ -4,19 +4,17 @@
     {
         public static int Main()
         {
-            bool result = true;
+            bool result = InstanceAssignmentClass.RunTests();
+            result &= InstanceAssignmentStruct.RunTests();
 
-            result = result && InstanceAssignmentClass.RunTests();
-            result = result && InstanceAssignmentStruct.RunTests();
+            result &= InstanceEqualNullClass.RunTests();
+            result &= InstanceEqualNullStruct.RunTests();
 
-            result = result && InstanceEqualNullClass.RunTests();
-            result = result && InstanceEqualNullStruct.RunTests();
+            result &= StaticAssignmentClass.RunTests();
+            result &= StaticAssignmentStruct.RunTests();
 
-            result = result && StaticAssignmentClass.RunTests();
-            result = result && StaticAssignmentStruct.RunTests();
-
-            result = result && StaticEqualNullClass.RunTests();
-            result = result && StaticEqualNullStruct.RunTests();
+            result &= StaticEqualNullClass.RunTests();
+            result &= StaticEqualNullStruct.RunTests();
 
             return result ? 0 : 1;
         }

--- a/Tests/Generics/GenericFields/TestRunner.cs
+++ b/Tests/Generics/GenericFields/TestRunner.cs
@@ -4,19 +4,21 @@
     {
         public static int Main()
         {
-            int result = InstanceAssignmentClass.RunTests(); if (result != 0) return result;
-            result = InstanceAssignmentStruct.RunTests(); if (result != 0) return result;
+            bool result = true;
 
-            result = InstanceEqualNullClass.RunTests(); if (result != 0) return result;
-            result = InstanceEqualNullStruct.RunTests(); if (result != 0) return result;
+            result = result && InstanceAssignmentClass.RunTests();
+            result = result && InstanceAssignmentStruct.RunTests();
 
-            result = StaticAssignmentClass.RunTests(); if (result != 0) return result;            
-            result = StaticAssignmentStruct.RunTests(); if (result != 0) return result;
+            result = result && InstanceEqualNullClass.RunTests();
+            result = result && InstanceEqualNullStruct.RunTests();
 
-            result = StaticEqualNullClass.RunTests(); if (result != 0) return result;
-            result = StaticEqualNullStruct.RunTests(); if (result != 0) return result;
+            result = result && StaticAssignmentClass.RunTests();
+            result = result && StaticAssignmentStruct.RunTests();
 
-            return result;
+            result = result && StaticEqualNullClass.RunTests();
+            result = result && StaticEqualNullStruct.RunTests();
+
+            return result ? 0 : 1;
         }
     }
 }

--- a/Tests/Generics/GenericFields/TestRunner.cs
+++ b/Tests/Generics/GenericFields/TestRunner.cs
@@ -4,7 +4,7 @@
     {
         public static int Main()
         {
-            bool result = InstanceAssignmentClass.RunTests();
+            var result = InstanceAssignmentClass.RunTests();
             result &= InstanceAssignmentStruct.RunTests();
 
             result &= InstanceEqualNullClass.RunTests();

--- a/Tests/Generics/GenericLocals/InstanceAssignmentClass.cs
+++ b/Tests/Generics/GenericLocals/InstanceAssignmentClass.cs
@@ -1,4 +1,6 @@
-﻿namespace GenericLocals
+﻿using System;
+
+namespace GenericLocals
 {
     internal class InstanceAssignmentClass
     {
@@ -11,18 +13,31 @@
             }
         }
 
-        public static int RunTests()
+        public static int counter = 0;
+        public static bool result = true;
+        public static void Eval(bool exp)
+        {
+            counter++;
+            if (!exp)
+            {
+                result = exp;
+                Console.Write("InstanceAssignmentClass failed at location: ");
+                Console.WriteLine(counter);
+            }
+        }
+
+        public static bool RunTests()
         {
             int _int = 1;
-            if (new Gen<int>().Assign(_int) != _int) return 1;
+            Eval(new Gen<int>().Assign(_int) == _int);
 
             string _string = "string";
-            if (new Gen<string>().Assign(_string) != _string) return 2;
+            Eval(new Gen<string>().Assign(_string) == _string);
 
             var _object = new object();
-            if (new Gen<object>().Assign(_object) != _object) return 3;
+            Eval(new Gen<object>().Assign(_object) == _object);
 
-            return 0;
+            return result;
         }
     }
 }

--- a/Tests/Generics/GenericLocals/InstanceAssignmentClass.cs
+++ b/Tests/Generics/GenericLocals/InstanceAssignmentClass.cs
@@ -13,16 +13,16 @@ namespace GenericLocals
             }
         }
 
-        public static int counter = 0;
-        public static bool result = true;
+        private static int _counter = 0;
+        private static bool _result = true;
         public static void Eval(bool exp)
         {
-            counter++;
+            _counter++;
             if (!exp)
             {
-                result = exp;
+                _result = exp;
                 Console.Write("InstanceAssignmentClass failed at location: ");
-                Console.WriteLine(counter);
+                Console.WriteLine(_counter);
             }
         }
 
@@ -37,7 +37,7 @@ namespace GenericLocals
             var _object = new object();
             Eval(new Gen<object>().Assign(_object) == _object);
 
-            return result;
+            return _result;
         }
     }
 }

--- a/Tests/Generics/GenericLocals/InstanceAssignmentStruct.cs
+++ b/Tests/Generics/GenericLocals/InstanceAssignmentStruct.cs
@@ -13,16 +13,16 @@ namespace GenericLocals
             }
         }
 
-        public static int counter = 0;
-        public static bool result = true;
+        private static int _counter = 0;
+        private static bool _result = true;
         public static void Eval(bool exp)
         {
-            counter++;
+            _counter++;
             if (!exp)
             {
-                result = exp;
+                _result = exp;
                 Console.Write("InstanceAssignmentStruct failed at location: ");
-                Console.WriteLine(counter);
+                Console.WriteLine(_counter);
             }
         }
 
@@ -37,7 +37,7 @@ namespace GenericLocals
             var _object = new object();
             Eval(new Gen<object>().Assign(_object) == _object);
 
-            return result;
+            return _result;
         }
     }
 }

--- a/Tests/Generics/GenericLocals/InstanceAssignmentStruct.cs
+++ b/Tests/Generics/GenericLocals/InstanceAssignmentStruct.cs
@@ -1,4 +1,6 @@
-﻿namespace GenericLocals
+﻿using System;
+
+namespace GenericLocals
 {
     internal class InstanceAssignmentStruct
     {
@@ -11,18 +13,31 @@
             }
         }
 
-        public static int RunTests()
+        public static int counter = 0;
+        public static bool result = true;
+        public static void Eval(bool exp)
+        {
+            counter++;
+            if (!exp)
+            {
+                result = exp;
+                Console.Write("InstanceAssignmentStruct failed at location: ");
+                Console.WriteLine(counter);
+            }
+        }
+
+        public static bool RunTests()
         {
             int _int = 1;
-            if (new Gen<int>().Assign(_int) != _int) return 1;
+            Eval(new Gen<int>().Assign(_int) == _int);
 
             string _string = "string";
-            if (new Gen<string>().Assign(_string) != _string) return 2;
+            Eval(new Gen<string>().Assign(_string) == _string);
 
             var _object = new object();
-            if (new Gen<object>().Assign(_object) != _object) return 3;
+            Eval(new Gen<object>().Assign(_object) == _object);
 
-            return 0;
+            return result;
         }
     }
 }

--- a/Tests/Generics/GenericLocals/InstanceEqualNullClass.cs
+++ b/Tests/Generics/GenericLocals/InstanceEqualNullClass.cs
@@ -13,16 +13,16 @@ namespace GenericLocals
             }
         }
 
-        public static int counter = 0;
-        public static bool result = true;
+        private static int _counter = 0;
+        private static bool _result = true;
         public static void Eval(bool exp)
         {
-            counter++;
+            _counter++;
             if (!exp)
             {
-                result = exp;
+                _result = exp;
                 Console.Write("InstanceEqualNullClass failed at location: ");
-                Console.WriteLine(counter);
+                Console.WriteLine(_counter);
             }
         }
 
@@ -39,7 +39,7 @@ namespace GenericLocals
             Eval(!new Gen<object>().EqualNull(_object));
             Eval(new Gen<object>().EqualNull(null));
 
-            return result;
+            return _result;
         }
     }
 }

--- a/Tests/Generics/GenericLocals/InstanceEqualNullClass.cs
+++ b/Tests/Generics/GenericLocals/InstanceEqualNullClass.cs
@@ -8,8 +8,8 @@ namespace GenericLocals
         {
             public bool EqualNull(T? t)
             {
-                T Field1 = t;
-                return ((object)Field1! == null);
+                T? Field1 = t;
+                return ((object?)Field1 == null);
             }
         }
 

--- a/Tests/Generics/GenericLocals/InstanceEqualNullClass.cs
+++ b/Tests/Generics/GenericLocals/InstanceEqualNullClass.cs
@@ -1,4 +1,6 @@
-﻿namespace GenericLocals
+﻿using System;
+
+namespace GenericLocals
 {
     internal class InstanceEqualNullClass
     {
@@ -11,20 +13,33 @@
             }
         }
 
-        public static int RunTests()
+        public static int counter = 0;
+        public static bool result = true;
+        public static void Eval(bool exp)
+        {
+            counter++;
+            if (!exp)
+            {
+                result = exp;
+                Console.Write("InstanceEqualNullClass failed at location: ");
+                Console.WriteLine(counter);
+            }
+        }
+
+        public static bool RunTests()
         {
             int _int = 1;
-            if (new Gen<int>().EqualNull(_int)) return 1;
+            Eval(!new Gen<int>().EqualNull(_int));
 
             string _string = "string";
-            if (new Gen<string>().EqualNull(_string)) return 2;
-            if (!new Gen<string>().EqualNull(null)) return 2;
+            Eval(!new Gen<string>().EqualNull(_string));
+            Eval(new Gen<string>().EqualNull(null));
 
             var _object = new object();
-            if (new Gen<object>().EqualNull(_object)) return 3;
-            if (!new Gen<object>().EqualNull(null)) return 3;
+            Eval(!new Gen<object>().EqualNull(_object));
+            Eval(new Gen<object>().EqualNull(null));
 
-            return 0;
+            return result;
         }
     }
 }

--- a/Tests/Generics/GenericLocals/InstanceEqualNullStruct.cs
+++ b/Tests/Generics/GenericLocals/InstanceEqualNullStruct.cs
@@ -8,8 +8,8 @@ namespace GenericLocals
         {
             public bool EqualNull(T? t)
             {
-                T Field1 = t;
-                return ((object)Field1! == null);
+                T? Field1 = t;
+                return ((object?)Field1 == null);
             }
         }
 

--- a/Tests/Generics/GenericLocals/InstanceEqualNullStruct.cs
+++ b/Tests/Generics/GenericLocals/InstanceEqualNullStruct.cs
@@ -13,16 +13,16 @@ namespace GenericLocals
             }
         }
 
-        public static int counter = 0;
-        public static bool result = true;
+        private static int _counter = 0;
+        private static bool _result = true;
         public static void Eval(bool exp)
         {
-            counter++;
+            _counter++;
             if (!exp)
             {
-                result = exp;
+                _result = exp;
                 Console.Write("InstanceEqualNullStruct failed at location: ");
-                Console.WriteLine(counter);
+                Console.WriteLine(_counter);
             }
         }
 
@@ -39,7 +39,7 @@ namespace GenericLocals
             Eval(!new Gen<object>().EqualNull(_object));
             Eval(new Gen<object>().EqualNull(null));
 
-            return result;
+            return _result;
         }
     }
 }

--- a/Tests/Generics/GenericLocals/InstanceEqualNullStruct.cs
+++ b/Tests/Generics/GenericLocals/InstanceEqualNullStruct.cs
@@ -1,4 +1,6 @@
-﻿namespace GenericLocals
+﻿using System;
+
+namespace GenericLocals
 {
     internal class InstanceEqualNullStruct
     {
@@ -11,20 +13,33 @@
             }
         }
 
-        public static int RunTests()
+        public static int counter = 0;
+        public static bool result = true;
+        public static void Eval(bool exp)
+        {
+            counter++;
+            if (!exp)
+            {
+                result = exp;
+                Console.Write("InstanceEqualNullStruct failed at location: ");
+                Console.WriteLine(counter);
+            }
+        }
+
+        public static bool RunTests()
         {
             int _int = 1;
-            if (new Gen<int>().EqualNull(_int)) return 1;
+            Eval(!new Gen<int>().EqualNull(_int));
 
             string _string = "string";
-            if (new Gen<string>().EqualNull(_string)) return 2;
-            if (!new Gen<string>().EqualNull(null)) return 3;
+            Eval(!new Gen<string>().EqualNull(_string));
+            Eval(new Gen<string>().EqualNull(null));
 
             var _object = new object();
-            if (new Gen<object>().EqualNull(_object)) return 4;
-            if (!new Gen<object>().EqualNull(null)) return 5;
+            Eval(!new Gen<object>().EqualNull(_object));
+            Eval(new Gen<object>().EqualNull(null));
 
-            return 0;
+            return result;
         }
     }
 }

--- a/Tests/Generics/GenericLocals/StaticAssignmentClass.cs
+++ b/Tests/Generics/GenericLocals/StaticAssignmentClass.cs
@@ -13,16 +13,16 @@ namespace GenericLocals
             }
         }
 
-        public static int counter = 0;
-        public static bool result = true;
+        private static int _counter = 0;
+        private static bool _result = true;
         public static void Eval(bool exp)
         {
-            counter++;
+            _counter++;
             if (!exp)
             {
-                result = exp;
+                _result = exp;
                 Console.Write("StaticAssignmentClass failed at location: ");
-                Console.WriteLine(counter);
+                Console.WriteLine(_counter);
             }
         }
 
@@ -37,7 +37,7 @@ namespace GenericLocals
             var _object = new object();
             Eval(Gen<object>.Assign(_object) == _object);
 
-            return result;
+            return _result;
         }
     }
 }

--- a/Tests/Generics/GenericLocals/StaticAssignmentClass.cs
+++ b/Tests/Generics/GenericLocals/StaticAssignmentClass.cs
@@ -1,4 +1,6 @@
-﻿namespace GenericLocals
+﻿using System;
+
+namespace GenericLocals
 {
     internal class StaticAssignmentClass
     {
@@ -11,18 +13,31 @@
             }
         }
 
-        public static int RunTests()
+        public static int counter = 0;
+        public static bool result = true;
+        public static void Eval(bool exp)
+        {
+            counter++;
+            if (!exp)
+            {
+                result = exp;
+                Console.Write("StaticAssignmentClass failed at location: ");
+                Console.WriteLine(counter);
+            }
+        }
+
+        public static bool RunTests()
         {
             int _int = 1;
-            if (Gen<int>.Assign(_int) != _int) return 1;
+            Eval(Gen<int>.Assign(_int) == _int);
 
             string _string = "string";
-            if (Gen<string>.Assign(_string) != _string) return 2;
+            Eval(Gen<string>.Assign(_string) == _string);
 
             var _object = new object();
-            if (Gen<object>.Assign(_object) != _object) return 3;
+            Eval(Gen<object>.Assign(_object) == _object);
 
-            return 0;
+            return result;
         }
     }
 }

--- a/Tests/Generics/GenericLocals/StaticAssignmentStruct.cs
+++ b/Tests/Generics/GenericLocals/StaticAssignmentStruct.cs
@@ -13,16 +13,16 @@ namespace GenericLocals
             }
         }
 
-        public static int counter = 0;
-        public static bool result = true;
+        private static int _counter = 0;
+        private static bool _result = true;
         public static void Eval(bool exp)
         {
-            counter++;
+            _counter++;
             if (!exp)
             {
-                result = exp;
+                _result = exp;
                 Console.Write("StaticAssignmentStruct failed at location: ");
-                Console.WriteLine(counter);
+                Console.WriteLine(_counter);
             }
         }
 
@@ -37,7 +37,7 @@ namespace GenericLocals
             var _object = new object();
             Eval(Gen<object>.Assign(_object) == _object);
 
-            return result;
+            return _result;
         }
     }
 }

--- a/Tests/Generics/GenericLocals/StaticAssignmentStruct.cs
+++ b/Tests/Generics/GenericLocals/StaticAssignmentStruct.cs
@@ -1,4 +1,6 @@
-﻿namespace GenericLocals
+﻿using System;
+
+namespace GenericLocals
 {
     internal class StaticAssignmentStruct
     {
@@ -11,18 +13,31 @@
             }
         }
 
-        public static int RunTests()
+        public static int counter = 0;
+        public static bool result = true;
+        public static void Eval(bool exp)
+        {
+            counter++;
+            if (!exp)
+            {
+                result = exp;
+                Console.Write("StaticAssignmentStruct failed at location: ");
+                Console.WriteLine(counter);
+            }
+        }
+
+        public static bool RunTests()
         {
             int _int = 1;
-            if (Gen<int>.Assign(_int) != _int) return 1;
+            Eval(Gen<int>.Assign(_int) == _int);
 
             string _string = "string";
-            if (Gen<string>.Assign(_string) != _string) return 2;
+            Eval(Gen<string>.Assign(_string) == _string);
 
             var _object = new object();
-            if (Gen<object>.Assign(_object) != _object) return 3;
+            Eval(Gen<object>.Assign(_object) == _object);
 
-            return 0;
+            return result;
         }
     }
 }

--- a/Tests/Generics/GenericLocals/StaticEqualNullClass.cs
+++ b/Tests/Generics/GenericLocals/StaticEqualNullClass.cs
@@ -1,4 +1,6 @@
-﻿namespace GenericLocals
+﻿using System;
+
+namespace GenericLocals
 {
     internal class StaticEqualNullClass
     {
@@ -11,20 +13,33 @@
             }
         }
 
-        public static int RunTests()
+        public static int counter = 0;
+        public static bool result = true;
+        public static void Eval(bool exp)
+        {
+            counter++;
+            if (!exp)
+            {
+                result = exp;
+                Console.Write("StaticEqualNullClass failed at location: ");
+                Console.WriteLine(counter);
+            }
+        }
+
+        public static bool RunTests()
         {
             int _int = 1;
-            if (Gen<int>.EqualNull(_int)) return 1;
+            Eval(!Gen<int>.EqualNull(_int));
 
             string _string = "string";
-            if (Gen<string>.EqualNull(_string)) return 2;
-            if (!Gen<string>.EqualNull(null)) return 3;
+            Eval(!Gen<string>.EqualNull(_string));
+            Eval(Gen<string>.EqualNull(null));
 
             var _object = new object();
-            if (Gen<object>.EqualNull(_object)) return 4;
-            if (!Gen<object>.EqualNull(null)) return 5;
+            Eval(!Gen<object>.EqualNull(_object));
+            Eval(Gen<object>.EqualNull(null));
 
-            return 0;
+            return result;
         }
     }
 }

--- a/Tests/Generics/GenericLocals/StaticEqualNullClass.cs
+++ b/Tests/Generics/GenericLocals/StaticEqualNullClass.cs
@@ -8,8 +8,8 @@ namespace GenericLocals
         {
             public static bool EqualNull(T? t)
             {
-                T Field1 = t;
-                return ((object)Field1! == null);
+                T? Field1 = t;
+                return ((object?)Field1 == null);
             }
         }
 

--- a/Tests/Generics/GenericLocals/StaticEqualNullClass.cs
+++ b/Tests/Generics/GenericLocals/StaticEqualNullClass.cs
@@ -13,16 +13,16 @@ namespace GenericLocals
             }
         }
 
-        public static int counter = 0;
-        public static bool result = true;
+        private static int _counter = 0;
+        private static bool _result = true;
         public static void Eval(bool exp)
         {
-            counter++;
+            _counter++;
             if (!exp)
             {
-                result = exp;
+                _result = exp;
                 Console.Write("StaticEqualNullClass failed at location: ");
-                Console.WriteLine(counter);
+                Console.WriteLine(_counter);
             }
         }
 
@@ -39,7 +39,7 @@ namespace GenericLocals
             Eval(!Gen<object>.EqualNull(_object));
             Eval(Gen<object>.EqualNull(null));
 
-            return result;
+            return _result;
         }
     }
 }

--- a/Tests/Generics/GenericLocals/StaticEqualNullStruct.cs
+++ b/Tests/Generics/GenericLocals/StaticEqualNullStruct.cs
@@ -13,16 +13,16 @@ namespace GenericLocals
             }
         }
 
-        public static int counter = 0;
-        public static bool result = true;
+        private static int _counter = 0;
+        private static bool _result = true;
         public static void Eval(bool exp)
         {
-            counter++;
+            _counter++;
             if (!exp)
             {
-                result = exp;
+                _result = exp;
                 Console.Write("StaticEqualNullStruct failed at location: ");
-                Console.WriteLine(counter);
+                Console.WriteLine(_counter);
             }
         }
 
@@ -39,7 +39,7 @@ namespace GenericLocals
             Eval(!Gen<object>.EqualNull(_object));
             Eval(Gen<object>.EqualNull(null));
 
-            return result;
+            return _result;
         }
     }
 }

--- a/Tests/Generics/GenericLocals/StaticEqualNullStruct.cs
+++ b/Tests/Generics/GenericLocals/StaticEqualNullStruct.cs
@@ -1,4 +1,6 @@
-﻿namespace GenericLocals
+﻿using System;
+
+namespace GenericLocals
 {
     internal class StaticEqualNullStruct
     {
@@ -11,20 +13,33 @@
             }
         }
 
-        public static int RunTests()
+        public static int counter = 0;
+        public static bool result = true;
+        public static void Eval(bool exp)
+        {
+            counter++;
+            if (!exp)
+            {
+                result = exp;
+                Console.Write("StaticEqualNullStruct failed at location: ");
+                Console.WriteLine(counter);
+            }
+        }
+
+        public static bool RunTests()
         {
             int _int = 1;
-            if (Gen<int>.EqualNull(_int)) return 1;
+            Eval(!Gen<int>.EqualNull(_int));
 
             string _string = "string";
-            if (Gen<string>.EqualNull(_string)) return 2;
-            if (!Gen<string>.EqualNull(null)) return 3;
+            Eval(!Gen<string>.EqualNull(_string));
+            Eval(Gen<string>.EqualNull(null));
 
             var _object = new object();
-            if (Gen<object>.EqualNull(_object)) return 4;
-            if (!Gen<object>.EqualNull(null)) return 5;
+            Eval(!Gen<object>.EqualNull(_object));
+            Eval(Gen<object>.EqualNull(null));
 
-            return 0;
+            return result;
         }
     }
 }

--- a/Tests/Generics/GenericLocals/StaticEqualNullStruct.cs
+++ b/Tests/Generics/GenericLocals/StaticEqualNullStruct.cs
@@ -8,8 +8,8 @@ namespace GenericLocals
         {
             public static bool EqualNull(T? t)
             {
-                T Field1 = t;
-                return ((object)Field1! == null);
+                T? Field1 = t;
+                return ((object?)Field1 == null);
             }
         }
 

--- a/Tests/Generics/GenericLocals/TestRunner.cs
+++ b/Tests/Generics/GenericLocals/TestRunner.cs
@@ -4,19 +4,19 @@
     {
         public static int Main()
         {
-            int result = InstanceAssignmentClass.RunTests(); if (result != 0) return result;
-            result = InstanceAssignmentStruct.RunTests(); if (result != 0) return result;
+            var result = InstanceAssignmentClass.RunTests();
+            result &= InstanceAssignmentStruct.RunTests();
 
-            result = InstanceEqualNullClass.RunTests(); if (result != 0) return result;
-            result = InstanceEqualNullStruct.RunTests(); if (result != 0) return result;
+            result &= InstanceEqualNullClass.RunTests();
+            result &= InstanceEqualNullStruct.RunTests();
 
-            result = StaticAssignmentClass.RunTests(); if (result != 0) return result;            
-            result = StaticAssignmentStruct.RunTests(); if (result != 0) return result;
+            result &= StaticAssignmentClass.RunTests();
+            result &= StaticAssignmentStruct.RunTests();
 
-            result = StaticEqualNullClass.RunTests(); if (result != 0) return result;
-            result = StaticEqualNullStruct.RunTests(); if (result != 0) return result;
+            result &= StaticEqualNullClass.RunTests();
+            result &= StaticEqualNullStruct.RunTests();
 
-            return result;
+            return result ? 0 : 1;
         }
     }
 }

--- a/Tests/Generics/GenericTypeParameters/DefaultClass.cs
+++ b/Tests/Generics/GenericTypeParameters/DefaultClass.cs
@@ -17,7 +17,7 @@ namespace GenericTypeParameters
             public bool DefaultTest(bool status)
             {
                 T? t = default(T);
-                return ((object)t == null) == status;
+                return ((object?)t == null) == status;
             }
         }
 

--- a/Tests/Generics/GenericTypeParameters/DefaultClass.cs
+++ b/Tests/Generics/GenericTypeParameters/DefaultClass.cs
@@ -21,16 +21,16 @@ namespace GenericTypeParameters
             }
         }
 
-        public static int counter = 0;
-        public static bool result = true;
+        private static int _counter = 0;
+        private static bool _result = true;
         public static void Eval(bool exp)
         {
-            counter++;
+            _counter++;
             if (!exp)
             {
-                result = exp;
+                _result = exp;
                 Console.Write("DefaultClass failed at location: ");
-                Console.WriteLine(counter);
+                Console.WriteLine(_counter);
             }
         }
 
@@ -60,7 +60,7 @@ namespace GenericTypeParameters
             Eval(new Gen<ValX1<ValX2<int, string>>>().DefaultTest(false));
             Eval(new Gen<ValX2<ValX2<ValX1<int>, ValX3<int, string, ValX1<ValX2<int, string>>>>, ValX2<ValX1<int>, ValX3<int, string, ValX1<ValX2<int, string>>>>>>().DefaultTest(false));
 
-            return result;
+            return _result;
         }
     }
 }

--- a/Tests/Generics/GenericTypeParameters/DefaultClass.cs
+++ b/Tests/Generics/GenericTypeParameters/DefaultClass.cs
@@ -1,4 +1,6 @@
-﻿namespace GenericTypeParameters
+﻿using System;
+
+namespace GenericTypeParameters
 {
     public struct ValX1<T> { }
     public struct ValX2<T, U> { }
@@ -19,36 +21,46 @@
             }
         }
 
-        public static int RunTests()
+        public static int counter = 0;
+        public static bool result = true;
+        public static void Eval(bool exp)
         {
-            if (!new Gen<int>().DefaultTest(false)) return 1;            
-            if (!new Gen<string>().DefaultTest(true)) return 2;
-            if (!new Gen<object>().DefaultTest(true)) return 3;
+            counter++;
+            if (!exp)
+            {
+                result = exp;
+                Console.Write("DefaultClass failed at location: ");
+                Console.WriteLine(counter);
+            }
+        }
 
-            if (!new Gen<RefX1<int>>().DefaultTest(true)) return 4;
-            if (!new Gen<RefX1<ValX1<int>>>().DefaultTest(true)) return 5;
-            if (!new Gen<RefX2<int, string>>().DefaultTest(true)) return 6;
+        public static bool RunTests()
+        {
+            Eval(new Gen<int>().DefaultTest(false));
+            Eval(new Gen<string>().DefaultTest(true));
+            Eval(new Gen<object>().DefaultTest(true));
 
-            if (!new Gen<RefX1<RefX1<int>>>().DefaultTest(true)) return 7;
-            if (!new Gen<RefX1<RefX1<RefX1<string>>>>().DefaultTest(true)) return 8;
-            if (!new Gen<RefX1<RefX2<int, string>>>().DefaultTest(true)) return 9;
+            Eval(new Gen<RefX1<int>>().DefaultTest(true));
+            Eval(new Gen<RefX1<ValX1<int>>>().DefaultTest(true));
+            Eval(new Gen<RefX2<int, string>>().DefaultTest(true));
+
+            Eval(new Gen<RefX1<RefX1<int>>>().DefaultTest(true));
+            Eval(new Gen<RefX1<RefX1<RefX1<string>>>>().DefaultTest(true));
+            Eval(new Gen<RefX1<RefX2<int, string>>>().DefaultTest(true));
             
-            if (!new Gen<RefX2<RefX2<RefX1<int>, RefX3<int, string, RefX1<RefX2<int, string>>>>, RefX2<RefX1<int>, RefX3<int, string, RefX1<RefX2<int, string>>>>>>().DefaultTest(true)) return 10;
+            Eval(new Gen<RefX2<RefX2<RefX1<int>, RefX3<int, string, RefX1<RefX2<int, string>>>>, RefX2<RefX1<int>, RefX3<int, string, RefX1<RefX2<int, string>>>>>>().DefaultTest(true));
 
-            // These fail - Eq on struct not implemented
-            /*
-            if (!new Gen<ValX1<int>>().DefaultTest(false)) return 11;
-            if (!new Gen<ValX1<RefX1<int>>>().DefaultTest(false)) return 12;
-            if (!new Gen<ValX2<int, string>>().DefaultTest(false)) return 13;
+            Eval(new Gen<ValX1<int>>().DefaultTest(false));
+            Eval(new Gen<ValX1<RefX1<int>>>().DefaultTest(false));
+            Eval(new Gen<ValX2<int, string>>().DefaultTest(false));
 
-            if (!new Gen<ValX1<ValX1<int>>>().DefaultTest(false)) return 14;
-            if (!new Gen<ValX1<ValX1<ValX1<string>>>>().DefaultTest(false)) return 15;
+            Eval(new Gen<ValX1<ValX1<int>>>().DefaultTest(false));
+            Eval(new Gen<ValX1<ValX1<ValX1<string>>>>().DefaultTest(false));
 
-            if (!new Gen<ValX1<ValX2<int, string>>>().DefaultTest(false)) return 16;
-            if (!new Gen<ValX2<ValX2<ValX1<int>, ValX3<int, string, ValX1<ValX2<int, string>>>>, ValX2<ValX1<int>, ValX3<int, string, ValX1<ValX2<int, string>>>>>>().DefaultTest(false)) return 17;
-            */
+            Eval(new Gen<ValX1<ValX2<int, string>>>().DefaultTest(false));
+            Eval(new Gen<ValX2<ValX2<ValX1<int>, ValX3<int, string, ValX1<ValX2<int, string>>>>, ValX2<ValX1<int>, ValX3<int, string, ValX1<ValX2<int, string>>>>>>().DefaultTest(false));
 
-            return 0;
+            return result;
         }
     }
 }

--- a/Tests/Generics/GenericTypeParameters/DefaultStruct.cs
+++ b/Tests/Generics/GenericTypeParameters/DefaultStruct.cs
@@ -1,10 +1,58 @@
-﻿namespace GenericTypeParameters
+﻿using System;
+
+namespace GenericTypeParameters
 {
     internal class DefaultStruct
     {
-        public static int RunTests()
+        public struct Gen<T>
         {
-            return 0;
+            public bool DefaultTest(bool status)
+            {
+                T t = default(T);
+                return (((object)t == null) == status);
+            }
+        }
+
+        public static int counter = 0;
+        public static bool result = true;
+        public static void Eval(bool exp)
+        {
+            counter++;
+            if (!exp)
+            {
+                result = exp;
+                Console.Write("DefaultStruct failed at location: ");
+                Console.WriteLine(counter);
+            }
+        }
+
+        public static bool RunTests()
+        {
+            Eval(new Gen<int>().DefaultTest(false));
+            Eval(new Gen<string>().DefaultTest(true));
+            Eval(new Gen<object>().DefaultTest(true));
+
+            Eval(new Gen<RefX1<int>>().DefaultTest(true));
+            Eval(new Gen<RefX1<ValX1<int>>>().DefaultTest(true));
+            Eval(new Gen<RefX2<int, string>>().DefaultTest(true));
+
+            Eval(new Gen<RefX1<RefX1<int>>>().DefaultTest(true));
+            Eval(new Gen<RefX1<RefX1<RefX1<string>>>>().DefaultTest(true));
+            Eval(new Gen<RefX1<RefX2<int, string>>>().DefaultTest(true));
+
+            Eval(new Gen<RefX2<RefX2<RefX1<int>, RefX3<int, string, RefX1<RefX2<int, string>>>>, RefX2<RefX1<int>, RefX3<int, string, RefX1<RefX2<int, string>>>>>>().DefaultTest(true));
+
+            Eval(new Gen<ValX1<int>>().DefaultTest(false));
+            Eval(new Gen<ValX1<RefX1<int>>>().DefaultTest(false));
+            Eval(new Gen<ValX2<int, string>>().DefaultTest(false));
+
+            Eval(new Gen<ValX1<ValX1<int>>>().DefaultTest(false));
+            Eval(new Gen<ValX1<ValX1<ValX1<string>>>>().DefaultTest(false));
+
+            Eval(new Gen<ValX1<ValX2<int, string>>>().DefaultTest(false));
+            Eval(new Gen<ValX2<ValX2<ValX1<int>, ValX3<int, string, ValX1<ValX2<int, string>>>>, ValX2<ValX1<int>, ValX3<int, string, ValX1<ValX2<int, string>>>>>>().DefaultTest(false));
+
+            return result;
         }
     }
 }

--- a/Tests/Generics/GenericTypeParameters/DefaultStruct.cs
+++ b/Tests/Generics/GenericTypeParameters/DefaultStruct.cs
@@ -8,8 +8,8 @@ namespace GenericTypeParameters
         {
             public bool DefaultTest(bool status)
             {
-                T t = default(T);
-                return (((object)t == null) == status);
+                T? t = default(T);
+                return (((object?)t == null) == status);
             }
         }
 

--- a/Tests/Generics/GenericTypeParameters/DefaultStruct.cs
+++ b/Tests/Generics/GenericTypeParameters/DefaultStruct.cs
@@ -13,16 +13,16 @@ namespace GenericTypeParameters
             }
         }
 
-        public static int counter = 0;
-        public static bool result = true;
+        private static int _counter = 0;
+        private static bool _result = true;
         public static void Eval(bool exp)
         {
-            counter++;
+            _counter++;
             if (!exp)
             {
-                result = exp;
+                _result = exp;
                 Console.Write("DefaultStruct failed at location: ");
-                Console.WriteLine(counter);
+                Console.WriteLine(_counter);
             }
         }
 
@@ -52,7 +52,7 @@ namespace GenericTypeParameters
             Eval(new Gen<ValX1<ValX2<int, string>>>().DefaultTest(false));
             Eval(new Gen<ValX2<ValX2<ValX1<int>, ValX3<int, string, ValX1<ValX2<int, string>>>>, ValX2<ValX1<int>, ValX3<int, string, ValX1<ValX2<int, string>>>>>>().DefaultTest(false));
 
-            return result;
+            return _result;
         }
     }
 }

--- a/Tests/Generics/GenericTypeParameters/TestRunner.cs
+++ b/Tests/Generics/GenericTypeParameters/TestRunner.cs
@@ -4,10 +4,10 @@
     {
         public static int Main()
         {
-            int result = DefaultClass.RunTests(); if (result != 0) return result;
-            result = DefaultStruct.RunTests(); if (result != 0) return result;
+            var result = DefaultClass.RunTests();
+            result &= DefaultStruct.RunTests();
 
-            return result;
+            return result ? 0 : 1;
         }
     }
 }


### PR DESCRIPTION
Support use of console output in tests using z80dotnet. Any console output during test is captured and emitted to the real console at the end of the test.

Use console output in generic tests

Also fixed bug in copying data for empty structs which get padded to 1 byte.

Contributes to #466