### PR TITLE
Default stack start on non trs-80 systems.

### DIFF
--- a/ILCompiler/Compiler/Z80AssemblyWriter.cs
+++ b/ILCompiler/Compiler/Z80AssemblyWriter.cs
@@ -145,7 +145,7 @@ namespace ILCompiler.Compiler
                 }
                 else
                 {
-                    throw new NotImplementedException($"Cannot auto detect stack start on {_configuration.TargetArchitecture}");
+                    instructionsBuilder.Ld(SP, 0xa000);
                 }
             }
         }


### PR DESCRIPTION
For #504.

In future may want to try and auto detect ram on zx spectrum and cpm architectures.