### PR TITLE
Improve performance of Life Sample

### DIFF
--- a/Samples/Life/Life.cs
+++ b/Samples/Life/Life.cs
@@ -12,11 +12,14 @@ namespace Life
             var columns = Console.WindowWidth - 1;
 
             byte* currentCells = stackalloc byte[rows * columns];
-            var currentMap = new CellMap(rows, columns, currentCells);
+            byte* workerCells = stackalloc byte[rows * columns];
+            var currentMap = new CellMap(rows, columns, currentCells, workerCells);
 
             Console.Clear();
 
             currentMap.Init();
+
+            var startTime = DateTime.Now;
 
             for (var generation = 1; generation < 50; generation++)
             {
@@ -24,17 +27,23 @@ namespace Life
                 Console.Write("Generation : ");
                 Console.Write(generation);
 
-                var startTime = DateTime.Now;
+                var nextGenerationStartTime = DateTime.Now;
 
                 currentMap.NextGeneration();
 
-                var endTime = DateTime.Now;
-                var elapsedTime = endTime.TotalSeconds - startTime.TotalSeconds;
+                var nextGenerationEndTime = DateTime.Now;
+                var elapsedTime = nextGenerationEndTime.TotalSeconds - nextGenerationStartTime.TotalSeconds;
 
                 Console.SetCursorPosition(25, 0);
                 Console.Write("Time: ");
                 Console.Write(elapsedTime);
             }
+
+            var endTime = DateTime.Now;
+            var overallTime = endTime.TotalSeconds - startTime.TotalSeconds;
+            Console.SetCursorPosition(25, 0);
+            Console.Write("Overall Time: ");
+            Console.Write(overallTime);
         }
     }
 }


### PR DESCRIPTION
Improve performance of NextGeneration by avoiding use of multiplicaton in SetCell/ClearCell
Add overall timing to main program

Prior to this PR overall timing is 124s:

<img width="452" alt="image" src="https://github.com/user-attachments/assets/039d5523-3c32-4ae0-b215-f1656f7e6296">

With changes in this PR overall timing is 92s:

<img width="365" alt="image" src="https://github.com/user-attachments/assets/0d6b24db-5d79-4f04-aa16-3dec061a98e8">

Which is a 25% improvement. :)