### PR TITLE
Support non generic enumerators

### DIFF
--- a/ILCompiler/Compiler/BasicBlockAnalyser.cs
+++ b/ILCompiler/Compiler/BasicBlockAnalyser.cs
@@ -80,8 +80,8 @@ namespace ILCompiler.Compiler
 
                 if (exceptionHandler.Kind != ILExceptionRegionKind.Catch)
                 {
-                    // TODO: Can this be removed
-                    throw new NotSupportedException("Only catch handlers supported");
+                    // TODO: Implement finally blocks - just ignore them for now
+                    continue;
                 }
 
                 if (exceptionHandler.Kind == ILExceptionRegionKind.Filter)

--- a/ILCompiler/Compiler/Importer/IsInstImporter.cs
+++ b/ILCompiler/Compiler/Importer/IsInstImporter.cs
@@ -25,7 +25,7 @@ namespace ILCompiler.Compiler.Importer
             }
             else if (typeDesc.IsInterface)
             {
-                throw new NotImplementedException("IsInst only supports class types");
+                helperMethodName = "IsInstanceOfInterface";
             }
 
             // Create call to helper method passing eetypeptr and object reference

--- a/ILCompiler/TypeSystem/Dnlib/DnlibModule.cs
+++ b/ILCompiler/TypeSystem/Dnlib/DnlibModule.cs
@@ -203,6 +203,12 @@ namespace ILCompiler.TypeSystem.Dnlib
                     return Create(typeDefOrRefSig);
                 }
 
+                var ptrSig = ts.TryGetPtrSig();
+                if (ptrSig != null)
+                {
+                    return Create(ptrSig);
+                }
+
                 // TODO: should this also check for other sig types?
             }
 

--- a/System.Private.CoreLib/Internal/Runtime/EEType.cs
+++ b/System.Private.CoreLib/Internal/Runtime/EEType.cs
@@ -1,5 +1,4 @@
 ﻿using Internal.Runtime.CompilerServices;
-using System;
 using System.Runtime.CompilerServices;
 
 namespace Internal.Runtime
@@ -8,16 +7,12 @@ namespace Internal.Runtime
     {
         // CS0649: Field '{blah}' is never assigned to, and will always have its default value
 #pragma warning disable 649
-        private ushort _usFlags = 0;
-        private ushort _usBaseSize = 0;
-        private EEType* _relatedType = null;
-        private byte _numVtableSlots = 0;
-        private byte _numInterfaces = 0;
+        private ushort _usFlags;
+        private ushort _usBaseSize;
+        private EEType* _relatedType;
+        private byte _numVtableSlots;
+        private byte _numInterfaces;
 #pragma warning restore
-
-        public EEType()
-        {
-        }
 
         internal readonly ushort GetFlags() { return _usFlags; }
 

--- a/System.Private.CoreLib/Internal/Runtime/EEType.cs
+++ b/System.Private.CoreLib/Internal/Runtime/EEType.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using Internal.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
 
 namespace Internal.Runtime
 {
@@ -7,6 +8,8 @@ namespace Internal.Runtime
         private ushort _usFlags;
         private ushort _usBaseSize;
         private EEType* _relatedType;
+        private byte _numVtableSlots;
+        private byte _numInterfaces;
 
         internal readonly ushort GetFlags() { return _usFlags; }
 
@@ -22,5 +25,10 @@ namespace Internal.Runtime
                 return _usFlags == 1;
             }
         }
+
+        internal byte NumVTableSlots => _numVtableSlots;
+        internal byte NumInterfaces => _numInterfaces;
+
+        internal EEType** InterfaceMap => (EEType**)((byte*)Unsafe.AsPointer(ref this) + sizeof(EEType) + sizeof(void*) * _numVtableSlots);
     }
 }

--- a/System.Private.CoreLib/Internal/Runtime/EEType.cs
+++ b/System.Private.CoreLib/Internal/Runtime/EEType.cs
@@ -1,4 +1,5 @@
 ﻿using Internal.Runtime.CompilerServices;
+using System;
 using System.Runtime.CompilerServices;
 
 namespace Internal.Runtime
@@ -7,12 +8,16 @@ namespace Internal.Runtime
     {
         // CS0649: Field '{blah}' is never assigned to, and will always have its default value
 #pragma warning disable 649
-        private ushort _usFlags;
-        private ushort _usBaseSize;
-        private EEType* _relatedType;
-        private byte _numVtableSlots;
-        private byte _numInterfaces;
+        private ushort _usFlags = 0;
+        private ushort _usBaseSize = 0;
+        private EEType* _relatedType = null;
+        private byte _numVtableSlots = 0;
+        private byte _numInterfaces = 0;
 #pragma warning restore
+
+        public EEType()
+        {
+        }
 
         internal readonly ushort GetFlags() { return _usFlags; }
 

--- a/System.Private.CoreLib/Internal/Runtime/EEType.cs
+++ b/System.Private.CoreLib/Internal/Runtime/EEType.cs
@@ -5,11 +5,14 @@ namespace Internal.Runtime
 {
     internal unsafe struct EEType
     {
+        // CS0649: Field '{blah}' is never assigned to, and will always have its default value
+#pragma warning disable 649
         private ushort _usFlags;
         private ushort _usBaseSize;
         private EEType* _relatedType;
         private byte _numVtableSlots;
         private byte _numInterfaces;
+#pragma warning restore
 
         internal readonly ushort GetFlags() { return _usFlags; }
 

--- a/System.Private.CoreLib/System/Collections/Generic/IEnumerable.cs
+++ b/System.Private.CoreLib/System/Collections/Generic/IEnumerable.cs
@@ -1,0 +1,7 @@
+﻿namespace System.Collections.Generic
+{
+    public interface IEnumerable<out T> : IEnumerable
+    {
+        new IEnumerator<T> GetEnumerator();
+    }
+}

--- a/System.Private.CoreLib/System/Collections/Generic/IEnumerator.cs
+++ b/System.Private.CoreLib/System/Collections/Generic/IEnumerator.cs
@@ -1,0 +1,7 @@
+﻿namespace System.Collections.Generic
+{
+    public interface IEnumerator<out T> : IDisposable, IEnumerator
+    {
+        new T Current { get; }
+    }
+}

--- a/System.Private.CoreLib/System/IDisposable.cs
+++ b/System.Private.CoreLib/System/IDisposable.cs
@@ -1,0 +1,7 @@
+﻿namespace System
+{
+    public interface IDisposable
+    {
+        void Dispose();
+    }
+}

--- a/System.Private.CoreLib/System/NotSupportedException.cs
+++ b/System.Private.CoreLib/System/NotSupportedException.cs
@@ -1,0 +1,8 @@
+﻿namespace System
+{
+    public class NotSupportedException : Exception
+    {
+        public NotSupportedException() : base("Specified method is not supported.")
+        { }
+    }
+}

--- a/System.Private.CoreLib/System/Runtime/TypeCast.cs
+++ b/System.Private.CoreLib/System/Runtime/TypeCast.cs
@@ -4,6 +4,32 @@ namespace System.Runtime
 {
     internal static class TypeCast
     {
+        public static unsafe object IsInstanceOfInterface(EEType* pTargetType, object obj)
+        {
+            if (obj == null)
+            {
+                return null;
+            }
+
+            var pObjType = obj.m_pEEType;
+            byte interfaceCount = pObjType->NumInterfaces;
+
+            EEType** interfaceMap = pObjType->InterfaceMap;
+
+            while (interfaceCount > 0)
+            {
+                if (interfaceMap[0] == pTargetType)
+                {
+                    return obj;
+                }
+
+                interfaceMap++;
+                interfaceCount--;
+            }
+
+            return null;
+        }
+
         public static unsafe object IsInstanceOfClass(EEType* pTargetType, object obj)
         {
             if (obj == null)

--- a/Tests/CoreLib/CoreLib/CoreLib.cs
+++ b/Tests/CoreLib/CoreLib/CoreLib.cs
@@ -27,6 +27,7 @@
             ArrayTests.ForEachArrayEnumerationTests();
 
             TypeCastTests.ClassTypeCastTests();
+            TypeCastTests.InterfaceTypeCastTests();
 
             InterpolatedStringHandlerTests.ToStringAndClear_Clears();
             InterpolatedStringHandlerTests.AppendLiteral();

--- a/Tests/CoreLib/CoreLib/CoreLib.cs
+++ b/Tests/CoreLib/CoreLib/CoreLib.cs
@@ -32,6 +32,9 @@
             InterpolatedStringHandlerTests.AppendLiteral();
             InterpolatedStringHandlerTests.AppendFormatted();
 
+            EnumerableTests.ArrayEnumerator_EnumeratesArrayElements();
+            EnumerableTests.FibonacciEnumerable_FirstFifteenNumbers_AreCorrect();
+
             return 0;
         }
     }

--- a/Tests/CoreLib/CoreLib/EnumerableTests.cs
+++ b/Tests/CoreLib/CoreLib/EnumerableTests.cs
@@ -33,7 +33,7 @@ namespace CoreLib
         }
     }
 
-    public class EnumerableTests
+    public static class EnumerableTests
     {
         public static void ArrayEnumerator_EnumeratesArrayElements()
         {

--- a/Tests/CoreLib/CoreLib/EnumerableTests.cs
+++ b/Tests/CoreLib/CoreLib/EnumerableTests.cs
@@ -1,0 +1,79 @@
+﻿using System.Collections;
+
+namespace CoreLib
+{
+    public class ArrayEnumerable(int[] array) : IEnumerable
+    {
+        public IEnumerator GetEnumerator()
+        {
+            var index = 0;
+            while (index < array.Length)
+            {
+                yield return array[index++];
+            }
+        }
+    }
+
+    public class FibonacciEnumerable : IEnumerable
+    {
+        public IEnumerator GetEnumerator()
+        {
+            yield return 0;
+            yield return 1;
+
+            int previous = 0;
+            int next = 1;
+            while (true)
+            {
+                int sum = previous + next;
+                previous = next;
+                next = sum;
+                yield return sum; 
+            }
+        }
+    }
+
+    public class EnumerableTests
+    {
+        public static void ArrayEnumerator_EnumeratesArrayElements()
+        {
+            var testArray = new int[] { 1, 2, 3 };
+            var enumerable = new ArrayEnumerable(testArray);
+
+            int index = 0;
+            foreach (var item in enumerable)
+            {
+                Assert.AreEquals(testArray[index++], item);
+            }
+        }
+
+        public static void FibonacciEnumerable_FirstFifteenNumbers_AreCorrect()
+        {
+            var sequence = new FibonacciEnumerable().GetEnumerator();
+
+            Assert.IsTrue(sequence.MoveNext());
+            Assert.AreEquals(0, sequence.Current);
+
+            Assert.IsTrue(sequence.MoveNext());
+            Assert.AreEquals(1, sequence.Current);
+
+            Assert.IsTrue(sequence.MoveNext());
+            Assert.AreEquals(1, sequence.Current);
+
+            Assert.IsTrue(sequence.MoveNext());
+            Assert.AreEquals(2, sequence.Current);
+
+            Assert.IsTrue(sequence.MoveNext());
+            Assert.AreEquals(3, sequence.Current);
+
+            Assert.IsTrue(sequence.MoveNext());
+            Assert.AreEquals(5, sequence.Current);
+
+            Assert.IsTrue(sequence.MoveNext());
+            Assert.AreEquals(8, sequence.Current);
+
+            Assert.IsTrue(sequence.MoveNext());
+            Assert.AreEquals(13, sequence.Current);
+        }
+    }
+}

--- a/Tests/CoreLib/CoreLib/TypeCastTests.cs
+++ b/Tests/CoreLib/CoreLib/TypeCastTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using dnlib.DotNet;
+using System;
 
 namespace CoreLib
 {
@@ -10,6 +11,27 @@ namespace CoreLib
     internal class  SubClass : SuperClass
     {
         public SubClass() : base() { }
+    }
+
+    internal interface IOne
+    {
+    }
+
+    internal interface ITwo
+    {
+
+    }
+
+    internal class One : IOne
+    {
+    }
+
+    internal class Two : ITwo
+    {
+    }
+
+    internal class OneAndTwo : IOne, ITwo
+    {
     }
 
     internal class TypeCastTests
@@ -25,6 +47,22 @@ namespace CoreLib
             Assert.IsFalse(super is SubClass);
             Assert.IsTrue(super is Object);
             Assert.IsTrue(sub is Object);
+        }
+
+        public static void InterfaceTypeCastTests()
+        {
+            var one = new One();
+            var two = new Two();
+            var oneAndTwo = new OneAndTwo();
+
+            Assert.IsTrue(one is IOne);
+            Assert.IsFalse(one is ITwo);
+
+            Assert.IsFalse(two is IOne);
+            Assert.IsTrue(two is ITwo);
+
+            Assert.IsTrue(oneAndTwo is IOne);
+            Assert.IsTrue(oneAndTwo is ITwo);
         }
     }
 }


### PR DESCRIPTION
Add missing types including
- IEnumerable
- IEnumerator
- IEnumerable<T>
- IEnumerator<T>
- NotSupportedException

Note generic interfaces are required to satisfy type presence checks in roslyn.

foreach statements get lowered into try/finally with finally disposing of the enumerator. Improved IsInst support to handle interfaces as this is used within the finally block.

However, note that the finally block is ignored for now as need to improve exception handling to call finally blocks.

Some simple tests exercise the non-generic enumerators