### PR TITLE
Fix VS builds by disabling accelerate builds for projects using post build events

### DIFF
--- a/Samples/CalcPi/CalcPi.csproj
+++ b/Samples/CalcPi/CalcPi.csproj
@@ -21,8 +21,10 @@
     <OutputType>Exe</OutputType>
 	<TargetPlatform>Trs80</TargetPlatform>
     <BaseOutputPath>bin\$(TargetPlatform)</BaseOutputPath>
-
+	  
 	<ILCompilerPath>$(SolutionDir)ILCompiler\bin\$(Configuration)\$(TargetFramework)\ILCompiler.exe</ILCompilerPath>
+
+	<AccelerateBuildsInVisualStudio>false</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/Checksum/Checksum.csproj
+++ b/Samples/Checksum/Checksum.csproj
@@ -23,6 +23,8 @@
 	<BaseOutputPath>bin\$(TargetPlatform)</BaseOutputPath>
 
 	<ILCompilerPath>$(SolutionDir)ILCompiler\bin\$(Configuration)\$(TargetFramework)\ILCompiler.exe</ILCompilerPath>
+
+	<AccelerateBuildsInVisualStudio>false</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/Chess/Chess.csproj
+++ b/Samples/Chess/Chess.csproj
@@ -23,6 +23,7 @@
     <BaseOutputPath>bin\$(TargetPlatform)</BaseOutputPath>
 
 	<ILCompilerPath>$(SolutionDir)ILCompiler\bin\$(Configuration)\$(TargetFramework)\ILCompiler.exe</ILCompilerPath>
+	<AccelerateBuildsInVisualStudio>false</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/DoomFire/DoomFire.csproj
+++ b/Samples/DoomFire/DoomFire.csproj
@@ -23,6 +23,7 @@
 	<BaseOutputPath>bin\$(TargetPlatform)</BaseOutputPath>
 
 	<ILCompilerPath>$(SolutionDir)ILCompiler\bin\$(Configuration)\$(TargetFramework)\ILCompiler.exe</ILCompilerPath>
+	<AccelerateBuildsInVisualStudio>false</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/Fib/Fib.csproj
+++ b/Samples/Fib/Fib.csproj
@@ -23,6 +23,7 @@
 	<BaseOutputPath>bin\$(TargetPlatform)</BaseOutputPath>
 
 	<ILCompilerPath>$(SolutionDir)ILCompiler\bin\$(Configuration)\$(TargetFramework)\ILCompiler.exe</ILCompilerPath>
+	<AccelerateBuildsInVisualStudio>false</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/GfxDemos/GfxDemos.csproj
+++ b/Samples/GfxDemos/GfxDemos.csproj
@@ -23,6 +23,7 @@
 	<BaseOutputPath>bin\$(TargetPlatform)</BaseOutputPath>
 
 	<ILCompilerPath>$(SolutionDir)ILCompiler\bin\$(Configuration)\$(TargetFramework)\ILCompiler.exe</ILCompilerPath>
+	<AccelerateBuildsInVisualStudio>false</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/Hanoi/Hanoi.csproj
+++ b/Samples/Hanoi/Hanoi.csproj
@@ -23,6 +23,7 @@
 	<BaseOutputPath>bin\$(TargetPlatform)</BaseOutputPath>
 
 	<ILCompilerPath>$(SolutionDir)ILCompiler\bin\$(Configuration)\$(TargetFramework)\ILCompiler.exe</ILCompilerPath>
+	<AccelerateBuildsInVisualStudio>false</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/Hello/Hello.csproj
+++ b/Samples/Hello/Hello.csproj
@@ -23,6 +23,7 @@
 	<BaseOutputPath>bin\$(TargetPlatform)</BaseOutputPath>
 
 	<ILCompilerPath>$(SolutionDir)ILCompiler\bin\$(Configuration)\$(TargetFramework)\ILCompiler.exe</ILCompilerPath>
+	<AccelerateBuildsInVisualStudio>false</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/Life/Life.csproj
+++ b/Samples/Life/Life.csproj
@@ -23,6 +23,7 @@
 	<BaseOutputPath>bin\$(TargetPlatform)</BaseOutputPath>
 
 	<ILCompilerPath>$(SolutionDir)ILCompiler\bin\$(Configuration)\$(TargetFramework)\ILCompiler.exe</ILCompilerPath>
+	<AccelerateBuildsInVisualStudio>false</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/Mandel/Mandel.csproj
+++ b/Samples/Mandel/Mandel.csproj
@@ -23,6 +23,7 @@
 	<BaseOutputPath>bin\$(TargetPlatform)</BaseOutputPath>
 
 	<ILCompilerPath>$(SolutionDir)ILCompiler\bin\$(Configuration)\$(TargetFramework)\ILCompiler.exe</ILCompilerPath>
+	<AccelerateBuildsInVisualStudio>false</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/Matrix/Matrix.csproj
+++ b/Samples/Matrix/Matrix.csproj
@@ -23,6 +23,7 @@
 	<BaseOutputPath>bin\$(TargetPlatform)</BaseOutputPath>
 
 	<ILCompilerPath>$(SolutionDir)ILCompiler\bin\$(Configuration)\$(TargetFramework)\ILCompiler.exe</ILCompilerPath>
+	<AccelerateBuildsInVisualStudio>false</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/Mines/Mines.csproj
+++ b/Samples/Mines/Mines.csproj
@@ -23,6 +23,7 @@
 	<BaseOutputPath>bin\$(TargetPlatform)</BaseOutputPath>
 
 	<ILCompilerPath>$(SolutionDir)ILCompiler\bin\$(Configuration)\$(TargetFramework)\ILCompiler.exe</ILCompilerPath>
+	<AccelerateBuildsInVisualStudio>false</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/Music/Music.csproj
+++ b/Samples/Music/Music.csproj
@@ -23,6 +23,7 @@
 	<BaseOutputPath>bin\$(TargetPlatform)</BaseOutputPath>
 
 	<ILCompilerPath>$(SolutionDir)ILCompiler\bin\$(Configuration)\$(TargetFramework)\ILCompiler.exe</ILCompilerPath>
+	<AccelerateBuildsInVisualStudio>false</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/NetBot/NetBot.csproj
+++ b/Samples/NetBot/NetBot.csproj
@@ -23,6 +23,7 @@
 	<BaseOutputPath>bin\$(TargetPlatform)</BaseOutputPath>
 
 	<ILCompilerPath>$(SolutionDir)ILCompiler\bin\$(Configuration)\$(TargetFramework)\ILCompiler.exe</ILCompilerPath>
+	<AccelerateBuildsInVisualStudio>false</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/Paint/Paint.csproj
+++ b/Samples/Paint/Paint.csproj
@@ -23,6 +23,7 @@
 	<BaseOutputPath>bin\$(TargetPlatform)</BaseOutputPath>
 
 	<ILCompilerPath>$(SolutionDir)ILCompiler\bin\$(Configuration)\$(TargetFramework)\ILCompiler.exe</ILCompilerPath>
+	<AccelerateBuildsInVisualStudio>false</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/Primes/Primes.csproj
+++ b/Samples/Primes/Primes.csproj
@@ -23,6 +23,7 @@
 	<BaseOutputPath>bin\$(TargetPlatform)</BaseOutputPath>
 
 	<ILCompilerPath>$(SolutionDir)ILCompiler\bin\$(Configuration)\$(TargetFramework)\ILCompiler.exe</ILCompilerPath>
+	<AccelerateBuildsInVisualStudio>false</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/QSort/QSort.csproj
+++ b/Samples/QSort/QSort.csproj
@@ -23,6 +23,7 @@
 	<BaseOutputPath>bin\$(TargetPlatform)</BaseOutputPath>
 
 	<ILCompilerPath>$(SolutionDir)ILCompiler\bin\$(Configuration)\$(TargetFramework)\ILCompiler.exe</ILCompilerPath>
+	<AccelerateBuildsInVisualStudio>false</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/Sample/Sample.csproj
+++ b/Samples/Sample/Sample.csproj
@@ -23,6 +23,7 @@
 	<BaseOutputPath>bin\$(TargetPlatform)</BaseOutputPath>
 
 	<ILCompilerPath>$(SolutionDir)ILCompiler\bin\$(Configuration)\$(TargetFramework)\ILCompiler.exe</ILCompilerPath>
+	<AccelerateBuildsInVisualStudio>false</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/SampleDsk/SampleDsk.csproj
+++ b/Samples/SampleDsk/SampleDsk.csproj
@@ -16,6 +16,8 @@
 	  <TargetPlatform>Trs80</TargetPlatform>
 
 	  <Trs80OutDir>bin\Trs80\$(Configuration)\$(TargetFramework)</Trs80OutDir>
+
+	  <AccelerateBuildsInVisualStudio>false</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/Snake/Snake.csproj
+++ b/Samples/Snake/Snake.csproj
@@ -23,6 +23,7 @@
 	<BaseOutputPath>bin\$(TargetPlatform)</BaseOutputPath>
 
 	<ILCompilerPath>$(SolutionDir)ILCompiler\bin\$(Configuration)\$(TargetFramework)\ILCompiler.exe</ILCompilerPath>
+	<AccelerateBuildsInVisualStudio>false</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/Structs/Structs.csproj
+++ b/Samples/Structs/Structs.csproj
@@ -22,7 +22,8 @@
 	<TargetPlatform>Trs80</TargetPlatform>
 	<BaseOutputPath>bin\$(TargetPlatform)</BaseOutputPath>
 
-	<ILCompilerPath>$(SolutionDir)ILCompiler\bin\$(Configuration)\$(TargetFramework)\ILCompiler.exe</ILCompilerPath>	  
+	<ILCompilerPath>$(SolutionDir)ILCompiler\bin\$(Configuration)\$(TargetFramework)\ILCompiler.exe</ILCompilerPath>
+	<AccelerateBuildsInVisualStudio>false</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/Wumpus/Wumpus.csproj
+++ b/Samples/Wumpus/Wumpus.csproj
@@ -23,6 +23,7 @@
 	<BaseOutputPath>bin\$(TargetPlatform)</BaseOutputPath>
 
 	<ILCompilerPath>$(SolutionDir)ILCompiler\bin\$(Configuration)\$(TargetFramework)\ILCompiler.exe</ILCompilerPath>
+	<AccelerateBuildsInVisualStudio>false</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Making a change to code in any of the sample projects and building does not cause the sampledsk project to build. This causes issues with developer workflow as you can end up testing using the dsk file from the sampledsk project that is out of date.

Based on information in https://github.com/dotnet/project-system/issues/9421 I have disabled build acceleration on the projects using post build events.
These are mainly the sample projects that are using post build event to run the ilcompiler. Also the samplesdsk project uses post build events to create the disk image containing the sample cmd files.