### PR TITLE
Fixes virtual calls with arguments.

### DIFF
--- a/ILCompiler/Compiler/Importer/CallImporter.cs
+++ b/ILCompiler/Compiler/Importer/CallImporter.cs
@@ -101,7 +101,7 @@ namespace ILCompiler.Compiler.Importer
                 arguments[0] = new NullCheckEntry(arguments[0]);
             }
 
-            if (methodToCall.OwningType.IsInterface)
+            if (methodToCall.OwningType.IsInterface || (instruction.Opcode == ILOpcode.callvirt && methodToCall.IsVirtual))
             {
                 // Need to add this pointer as extra param which will be consumed by InterfaceCall routine
                 var thisEntry = arguments[0];

--- a/ILCompiler/Runtime/VirtualCall.asm
+++ b/ILCompiler/Runtime/VirtualCall.asm
@@ -8,7 +8,6 @@ VirtualCall:
 	POP DE		; Return address
 	POP HL		; This pointer
 
-	PUSH HL		; Restore stack
 	PUSH DE
 
 	LD E, (HL)	; Get EEType Ptr into HL

--- a/Tests/Methodical/VirtualMethods/VirtualMethods.cs
+++ b/Tests/Methodical/VirtualMethods/VirtualMethods.cs
@@ -1,15 +1,21 @@
-﻿namespace VirtualMethods
+﻿using System.Runtime.CompilerServices;
+
+namespace VirtualMethods
 {
     public class BaseClass
     {
         public virtual int F1() => 1;
         public virtual int F2() => 20;
+
+        public virtual int F3(int a, int b, int c) => (a + b) * c;
     }
 
     public class  DerivedClass : BaseClass
     {
         public override int F1() => base.F1() + 1;
         public new virtual int F2() => 30;
+
+        public override int F3(int a, int b, int c) => a + (b * c);
     }
 
     public static class Test
@@ -25,6 +31,11 @@
             {
                 return 1;
             }
+
+            if (baseClass.F3(1, 2, 3) != 9)
+            {
+                return 1;
+            }
             
             var derivedClass = new DerivedClass();
             if (derivedClass.F1() != 2) 
@@ -32,6 +43,11 @@
                 return 1;
             }
             if (derivedClass.F2() != 30)
+            {
+                return 1;
+            }
+
+            if (derivedClass.F3(1, 2, 3) != 7)
             {
                 return 1;
             }


### PR DESCRIPTION
These are passed on the stack in left to right order after the this parameter. The runtime VirtualCall routine expects the this pointer to be on top of the stack behind the return address - this fix adds the this pointer after the arguments and changes the VirtualCall routine to pop this off the stack to access the vtable.

Resolves #527. Note however it may be worth revisiting the call abi as if the parameters were placed on the stack such that the left most parameter is pushed to the stack last, i.e. from right to left, instead of from left to right, then the this pointer would be the last parameter pushed to the stack making the InterfaceCall and VirtualCall runtime routines able to access it much easier.