### PR TITLE
Lower signed integer division by power of 2

### DIFF
--- a/ILCompiler/Compiler/BasicBlock.cs
+++ b/ILCompiler/Compiler/BasicBlock.cs
@@ -11,7 +11,7 @@ namespace ILCompiler.Compiler
         Switch,         // block ends with a switch statement
     }
 
-    public class BasicBlock
+    public class BasicBlock : LinearIR.Range
     {
         public BasicBlock? Next { get; set; }
         public int StartOffset { get; set; }
@@ -30,7 +30,6 @@ namespace ILCompiler.Compiler
         // High level intermediate representation - main output of importation process
         public IList<StackEntry> Statements { get; } = new List<StackEntry>();
 
-        public StackEntry? FirstNode { get; set; }
         public bool Marked { get; set; } = false;
 
         public string Label { get; private set; }

--- a/ILCompiler/Compiler/EvaluationStack/AllocObjEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/AllocObjEntry.cs
@@ -11,10 +11,7 @@
             Size = objSize;
         }
 
-        public override void Accept(IStackEntryVisitor visitor)
-        {
-            visitor.Visit(this);
-        }
+        public override void Accept(IStackEntryVisitor visitor) => visitor.Visit(this);
 
         public override StackEntry Duplicate()
         {

--- a/ILCompiler/Compiler/EvaluationStack/BinaryOperatorEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/BinaryOperatorEntry.cs
@@ -1,9 +1,12 @@
-﻿namespace ILCompiler.Compiler.EvaluationStack
+﻿using ILCompiler.Compiler.LinearIR;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ILCompiler.Compiler.EvaluationStack
 {
     public class BinaryOperator : StackEntry
     {
-        public StackEntry Op1 { get; }
-        public StackEntry Op2 { get; }
+        public StackEntry Op1 { get; set; } 
+        public StackEntry Op2 { get; set; }
         public bool IsComparison { get; }
         public Operation Operation { get; set; }
         public bool ResultUsedInJump { get; set; } = false;
@@ -23,9 +26,21 @@
             return clone;
         }
 
-        public override void Accept(IStackEntryVisitor visitor)
+        public override void Accept(IStackEntryVisitor visitor) => visitor.Visit(this);
+
+        public override bool TryGetUse(StackEntry operand, [NotNullWhen(true)] out Edge<StackEntry>? edge)
         {
-            visitor.Visit(this);
+            if (operand == Op1)
+            {
+                edge = new Edge<StackEntry>(() => Op1, x => Op1 = x);
+                return true;
+            }
+            if (operand == Op2)
+            {
+                edge = new Edge<StackEntry>(() => Op2, x => Op2 = x);
+                return true;
+            }
+            return base.TryGetUse(operand, out edge);
         }
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/BoundsCheck.cs
+++ b/ILCompiler/Compiler/EvaluationStack/BoundsCheck.cs
@@ -1,8 +1,11 @@
-﻿namespace ILCompiler.Compiler.EvaluationStack
+﻿using ILCompiler.Compiler.LinearIR;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ILCompiler.Compiler.EvaluationStack
 {
     public class BoundsCheck : StackEntry
     {
-        public StackEntry Index { get; }
+        public StackEntry Index { get; set; }
         public StackEntry ArrayLength { get; }
 
         public BoundsCheck(StackEntry index, StackEntry arrayLength) : base(VarType.Void)
@@ -11,14 +14,21 @@
             ArrayLength = arrayLength;
         }
 
-        public override void Accept(IStackEntryVisitor visitor)
-        {
-            visitor.Visit(this);
-        }
+        public override void Accept(IStackEntryVisitor visitor) => visitor.Visit(this);
 
         public override StackEntry Duplicate()
         {
             return new BoundsCheck(Index.Duplicate(), ArrayLength.Duplicate());
+        }
+
+        public override bool TryGetUse(StackEntry operand, [NotNullWhen(true)] out Edge<StackEntry>? edge)
+        {
+            if (Index == operand)
+            {
+                edge = new Edge<StackEntry>(() => Index, x => Index = x);
+                return true;
+            }
+            return base.TryGetUse(operand, out edge);
         }
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/CallEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/CallEntry.cs
@@ -1,4 +1,6 @@
-﻿using ILCompiler.TypeSystem.Common;
+﻿using ILCompiler.Compiler.LinearIR;
+using ILCompiler.TypeSystem.Common;
+using System.Diagnostics.CodeAnalysis;
 
 namespace ILCompiler.Compiler.EvaluationStack
 {
@@ -23,9 +25,19 @@ namespace ILCompiler.Compiler.EvaluationStack
             return new CallEntry(TargetMethod, Arguments, Type, ExactSize, IsVirtual, Method);
         }
 
-        public override void Accept(IStackEntryVisitor visitor)
+        public override void Accept(IStackEntryVisitor visitor) => visitor.Visit(this);
+
+        public override bool TryGetUse(StackEntry operand, [NotNullWhen(true)] out Edge<StackEntry>? edge)
         {
-            visitor.Visit(this);
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                if (Arguments[i] == operand)
+                {
+                    edge = new Edge<StackEntry>(() => Arguments[i], x => Arguments[i] = x);
+                    return true;
+                }
+            }
+            return base.TryGetUse(operand, out edge);
         }
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/CastEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/CastEntry.cs
@@ -1,8 +1,11 @@
-﻿namespace ILCompiler.Compiler.EvaluationStack
+﻿using ILCompiler.Compiler.LinearIR;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ILCompiler.Compiler.EvaluationStack
 {
     public class CastEntry : StackEntry
     {
-        public StackEntry Op1 { get; }
+        public StackEntry Op1 { get; set; }
 
         public CastEntry(StackEntry op1, VarType type) : base(type, type.GetTypeSize() /*op1.ExactSize */)
         {
@@ -14,9 +17,16 @@
             return new CastEntry(Op1.Duplicate(), Type);
         }
 
-        public override void Accept(IStackEntryVisitor visitor)
+        public override void Accept(IStackEntryVisitor visitor) => visitor.Visit(this);
+
+        public override bool TryGetUse(StackEntry operand, [NotNullWhen(true)] out Edge<StackEntry>? edge)
         {
-            visitor.Visit(this);
+            if (operand == Op1)
+            {
+                edge = new Edge<StackEntry>(() => Op1, x => Op1 = x);
+                return true;
+            }
+            return base.TryGetUse(operand, out edge);
         }
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/CatchArgumentEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/CatchArgumentEntry.cs
@@ -11,9 +11,6 @@
             return new CatchArgumentEntry();
         }
 
-        public override void Accept(IStackEntryVisitor visitor)
-        {
-            visitor.Visit(this);
-        }
+        public override void Accept(IStackEntryVisitor visitor) => visitor.Visit(this);
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/CommaEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/CommaEntry.cs
@@ -1,9 +1,12 @@
-﻿namespace ILCompiler.Compiler.EvaluationStack
+﻿using ILCompiler.Compiler.LinearIR;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ILCompiler.Compiler.EvaluationStack
 {
     public class CommaEntry : StackEntry
     {
-        public StackEntry Op1 { get; }
-        public StackEntry Op2 { get; }
+        public StackEntry Op1 { get; set; }
+        public StackEntry Op2 { get; set; }
 
         public CommaEntry(StackEntry op1, StackEntry op2) : base(op2.Type, op2.ExactSize)
         {
@@ -16,9 +19,21 @@
             return new CommaEntry(Op1.Duplicate(), Op2.Duplicate());
         }
 
-        public override void Accept(IStackEntryVisitor visitor)
+        public override void Accept(IStackEntryVisitor visitor) => visitor.Visit(this);
+
+        public override bool TryGetUse(StackEntry operand, [NotNullWhen(true)] out Edge<StackEntry>? edge)
         {
-            visitor.Visit(this);
+            if (operand == Op1)
+            {
+                edge = new Edge<StackEntry>(() => Op1, x => Op1 = x);
+                return true;
+            }
+            if (operand == Op2)
+            {
+                edge = new Edge<StackEntry>(() => Op2, x => Op2 = x);
+                return true;
+            }
+            return base.TryGetUse(operand, out edge);
         }
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/ConstantEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/ConstantEntry.cs
@@ -82,9 +82,6 @@
             return duplicate;
         }
 
-        public override void Accept(IStackEntryVisitor visitor)
-        {
-            visitor.Visit(this);
-        }
+        public override void Accept(IStackEntryVisitor visitor) => visitor.Visit(this);
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/FieldAddressEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/FieldAddressEntry.cs
@@ -1,10 +1,13 @@
-﻿namespace ILCompiler.Compiler.EvaluationStack
+﻿using ILCompiler.Compiler.LinearIR;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ILCompiler.Compiler.EvaluationStack
 {
     public class FieldAddressEntry : StackEntry
     {
         public uint Offset { get; }
 
-        public StackEntry Op1 { get; }
+        public StackEntry Op1 { get; set; }
 
         public string Name { get; }
 
@@ -20,9 +23,16 @@
             return new FieldAddressEntry(Name, Op1.Duplicate(), Offset);
         }
 
-        public override void Accept(IStackEntryVisitor visitor)
+        public override void Accept(IStackEntryVisitor visitor) => visitor.Visit(this);
+
+        public override bool TryGetUse(StackEntry operand, [NotNullWhen(true)] out Edge<StackEntry>? edge)
         {
-            visitor.Visit(this);
+            if (operand == Op1)
+            {
+                edge = new Edge<StackEntry>(() => Op1, x => Op1 = x);
+                return true;
+            }
+            return base.TryGetUse(operand, out edge);
         }
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/IndexRefEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/IndexRefEntry.cs
@@ -1,9 +1,12 @@
-﻿namespace ILCompiler.Compiler.EvaluationStack
+﻿using ILCompiler.Compiler.LinearIR;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ILCompiler.Compiler.EvaluationStack
 {
     public class IndexRefEntry : StackEntry
     {
-        public StackEntry IndexOp { get; }
-        public StackEntry ArrayOp { get; }
+        public StackEntry IndexOp { get; set; }
+        public StackEntry ArrayOp { get; set; }
 
         public short FirstElementOffset { get; }
 
@@ -19,14 +22,27 @@
             BoundsCheck = boundsCheck;
         }
 
-        public override void Accept(IStackEntryVisitor visitor)
-        {
-            visitor.Visit(this);
-        }
+        public override void Accept(IStackEntryVisitor visitor) => visitor.Visit(this);
 
         public override StackEntry Duplicate()
         {
             return new IndexRefEntry(IndexOp.Duplicate(), ArrayOp.Duplicate(), ElemSize, Type, FirstElementOffset, BoundsCheck);
+        }
+
+        public override bool TryGetUse(StackEntry operand, [NotNullWhen(true)] out Edge<StackEntry>? edge)
+        {
+            if (operand == IndexOp)
+            {
+                edge = new Edge<StackEntry>(() => IndexOp, x => IndexOp = x);
+                return true;
+            }
+            if (operand == ArrayOp)
+            {
+                edge = new Edge<StackEntry>(() => ArrayOp, x => ArrayOp = x);
+                return true;
+            }
+
+            return base.TryGetUse(operand, out edge);
         }
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/IndirectEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/IndirectEntry.cs
@@ -1,9 +1,12 @@
-﻿namespace ILCompiler.Compiler.EvaluationStack
+﻿using ILCompiler.Compiler.LinearIR;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ILCompiler.Compiler.EvaluationStack
 {
     public class IndirectEntry : StackEntry
     {
 
-        public StackEntry Op1 { get; }
+        public StackEntry Op1 { get; set; }
 
         public uint Offset { get; }
 
@@ -18,9 +21,17 @@
             return new IndirectEntry(Op1.Duplicate(), Type, ExactSize, Offset);
         }
 
-        public override void Accept(IStackEntryVisitor visitor)
+        public override void Accept(IStackEntryVisitor visitor) => visitor.Visit(this);
+
+        public override bool TryGetUse(StackEntry operand, [NotNullWhen(true)] out Edge<StackEntry>? edge)
         {
-            visitor.Visit(this);
+            if (operand == Op1)
+            {
+                edge = new Edge<StackEntry>(() => Op1, x => Op1 = x);
+                return true;
+
+            }
+            return base.TryGetUse(operand, out edge);
         }
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/IntrinsicEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/IntrinsicEntry.cs
@@ -1,4 +1,7 @@
-﻿namespace ILCompiler.Compiler.EvaluationStack
+﻿using ILCompiler.Compiler.LinearIR;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ILCompiler.Compiler.EvaluationStack
 {
     public class IntrinsicEntry : StackEntry
     {
@@ -16,9 +19,19 @@
             return new IntrinsicEntry(TargetMethod, Arguments, Type);
         }
 
-        public override void Accept(IStackEntryVisitor visitor)
+        public override void Accept(IStackEntryVisitor visitor) => visitor.Visit(this);
+
+        public override bool TryGetUse(StackEntry operand, [NotNullWhen(true)] out Edge<StackEntry>? edge)
         {
-            visitor.Visit(this);
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                if (operand == Arguments[i])
+                {
+                    edge = new Edge<StackEntry>(() => Arguments[i], x => Arguments[i] = x);
+                    return true;
+                }
+            }
+            return base.TryGetUse(operand, out edge);
         }
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/JumpEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/JumpEntry.cs
@@ -14,9 +14,6 @@
             return new JumpEntry(TargetLabel);
         }
 
-        public override void Accept(IStackEntryVisitor visitor)
-        {
-            visitor.Visit(this);
-        }
+        public override void Accept(IStackEntryVisitor visitor) => visitor.Visit(this);
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/JumpTrueEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/JumpTrueEntry.cs
@@ -15,9 +15,6 @@
             return new JumpTrueEntry(TargetLabel, Condition.Duplicate());
         }
 
-        public override void Accept(IStackEntryVisitor visitor)
-        {
-            visitor.Visit(this);
-        }
+        public override void Accept(IStackEntryVisitor visitor) => visitor.Visit(this);
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/LocalHeapEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/LocalHeapEntry.cs
@@ -1,22 +1,32 @@
-﻿namespace ILCompiler.Compiler.EvaluationStack
+﻿using ILCompiler.Compiler.LinearIR;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ILCompiler.Compiler.EvaluationStack
 {
     public class LocalHeapEntry : StackEntry
     {
-        public StackEntry Op1 { get; }
+        public StackEntry Op1 { get; set; }
 
         public LocalHeapEntry(StackEntry op1) : base(VarType.Ptr, VarType.Ptr.GetTypeSize())
         {
             Op1 = op1;
         }
 
-        public override void Accept(IStackEntryVisitor visitor)
-        {
-            visitor.Visit(this);
-        }
+        public override void Accept(IStackEntryVisitor visitor) => visitor.Visit(this);
 
         public override StackEntry Duplicate()
         {
             return new LocalHeapEntry(Op1);
+        }
+
+        public override bool TryGetUse(StackEntry operand, [NotNullWhen(true)] out Edge<StackEntry>? edge)
+        {
+            if (operand == Op1)
+            {
+                edge = new Edge<StackEntry>(() => Op1, x => Op1 = x);
+                return true;
+            }
+            return base.TryGetUse(operand, out edge);
         }
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/LocalVariableAddressEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/LocalVariableAddressEntry.cs
@@ -15,9 +15,6 @@
             return new LocalVariableAddressEntry(LocalNumber);
         }
 
-        public override void Accept(IStackEntryVisitor visitor)
-        {
-            visitor.Visit(this);
-        }
+        public override void Accept(IStackEntryVisitor visitor) => visitor.Visit(this);
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/LocalVariableEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/LocalVariableEntry.cs
@@ -14,9 +14,6 @@
             return new LocalVariableEntry(LocalNumber, Type, ExactSize);
         }
 
-        public override void Accept(IStackEntryVisitor visitor)
-        {
-            visitor.Visit(this);
-        }
+        public override void Accept(IStackEntryVisitor visitor) => visitor.Visit(this);
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/NullCheckEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/NullCheckEntry.cs
@@ -1,8 +1,11 @@
-﻿namespace ILCompiler.Compiler.EvaluationStack
+﻿using ILCompiler.Compiler.LinearIR;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ILCompiler.Compiler.EvaluationStack
 {
     public class NullCheckEntry : StackEntry
     {
-        public StackEntry Op1 { get; }
+        public StackEntry Op1 { get; set; }
 
         public NullCheckEntry(StackEntry op1) : base(op1.Type, op1.Type.GetTypeSize() /*op1.ExactSize */)
         {
@@ -14,9 +17,16 @@
             return new NullCheckEntry(Op1.Duplicate());
         }
 
-        public override void Accept(IStackEntryVisitor visitor)
+        public override void Accept(IStackEntryVisitor visitor) => visitor.Visit(this);
+
+        public override bool TryGetUse(StackEntry operand, [NotNullWhen(true)] out Edge<StackEntry>? edge)
         {
-            visitor.Visit(this);
+            if (operand == Op1)
+            {
+                edge = new Edge<StackEntry>(() => Op1, x => Op1 = x);
+                return true;
+            }
+            return base.TryGetUse(operand, out edge);
         }
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/PutArgTypeEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/PutArgTypeEntry.cs
@@ -1,9 +1,12 @@
-﻿namespace ILCompiler.Compiler.EvaluationStack
+﻿using ILCompiler.Compiler.LinearIR;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ILCompiler.Compiler.EvaluationStack
 {
     public class PutArgTypeEntry : StackEntry
     {
         public VarType ArgType { get; }
-        public StackEntry Op1 { get; }
+        public StackEntry Op1 { get; set; }
 
         public PutArgTypeEntry(VarType argType, StackEntry op1) : base(op1.Type, op1.ExactSize)
         {
@@ -16,9 +19,17 @@
             return new PutArgTypeEntry(ArgType, Op1.Duplicate());
         }
 
-        public override void Accept(IStackEntryVisitor visitor)
+        public override void Accept(IStackEntryVisitor visitor) => visitor.Visit(this);
+
+        public override bool TryGetUse(StackEntry operand, [NotNullWhen(true)] out Edge<StackEntry>? edge)
         {
-            visitor.Visit(this);
+            if (operand == Op1)
+            {
+                edge = new Edge<StackEntry>(() => Op1, x => Op1 = x);
+                return true;
+            }
+            return base.TryGetUse(operand, out edge);
         }
+
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/ReturnEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/ReturnEntry.cs
@@ -1,8 +1,11 @@
-﻿namespace ILCompiler.Compiler.EvaluationStack
+﻿using ILCompiler.Compiler.LinearIR;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ILCompiler.Compiler.EvaluationStack
 {
     public class ReturnEntry : StackEntry
     {
-        public StackEntry? Return { get; }
+        public StackEntry? Return { get; set; }
         public int? ReturnBufferArgIndex { get; }
         public int? ReturnTypeExactSize { get; }
 
@@ -22,9 +25,18 @@
             return new ReturnEntry(Return, ReturnBufferArgIndex, ReturnTypeExactSize);
         }
 
-        public override void Accept(IStackEntryVisitor visitor)
+        public override void Accept(IStackEntryVisitor visitor) => visitor.Visit(this);
+
+        public override bool TryGetUse(StackEntry operand, [NotNullWhen(true)] out Edge<StackEntry>? edge)
         {
-            visitor.Visit(this);
+            edge = null;
+
+            if (operand == Return)
+            {
+                edge = new Edge<StackEntry>(() => Return, x => Return = x);
+                return true;
+            }
+            return false;
         }
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/StackEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/StackEntry.cs
@@ -73,6 +73,6 @@ namespace ILCompiler.Compiler.EvaluationStack
             return false;
         }
 
-        public void ReplaceOperand(Edge<StackEntry> useEdge, StackEntry replacement) => useEdge.Set(replacement);
+        public static void ReplaceOperand(Edge<StackEntry> useEdge, StackEntry replacement) => useEdge.Set(replacement);
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/StackEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/StackEntry.cs
@@ -1,4 +1,7 @@
-﻿namespace ILCompiler.Compiler.EvaluationStack
+﻿using ILCompiler.Compiler.LinearIR;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ILCompiler.Compiler.EvaluationStack
 {
     public enum Operation
     {
@@ -57,12 +60,19 @@
 
         // TODO: Consider using a visitor to do the duplication
         public abstract StackEntry Duplicate();
-
         abstract public void Accept(IStackEntryVisitor visitor);
 
         public T As<T>() where T : StackEntry
         {
             return (T)this;
         }
+
+        public virtual bool TryGetUse(StackEntry operand, [NotNullWhen(returnValue: true)] out Edge<StackEntry>? edge)
+        {
+            edge = null;
+            return false;
+        }
+
+        public void ReplaceOperand(Edge<StackEntry> useEdge, StackEntry replacement) => useEdge.Set(replacement);
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/StoreLocalVariableEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/StoreLocalVariableEntry.cs
@@ -1,8 +1,11 @@
-﻿namespace ILCompiler.Compiler.EvaluationStack
+﻿using ILCompiler.Compiler.LinearIR;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ILCompiler.Compiler.EvaluationStack
 {
     public class StoreLocalVariableEntry : StackEntry, ILocalVariable
     {
-        public StackEntry Op1 { get; }
+        public StackEntry Op1 { get; set; }
 
         public int LocalNumber { get; }
         public int SsaNumber { get; set; }
@@ -21,9 +24,16 @@
             return new StoreLocalVariableEntry(LocalNumber, IsParameter, Op1.Duplicate());
         }
 
-        public override void Accept(IStackEntryVisitor visitor)
+        public override void Accept(IStackEntryVisitor visitor) => visitor.Visit(this);
+
+        public override bool TryGetUse(StackEntry operand, [NotNullWhen(true)] out Edge<StackEntry>? edge)
         {
-            visitor.Visit(this);
+            if (operand == Op1)
+            {
+                edge = new Edge<StackEntry>(() => Op1, x => Op1 = x);
+                return true;
+            }
+            return base.TryGetUse(operand, out edge);
         }
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/SwitchEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/SwitchEntry.cs
@@ -1,8 +1,11 @@
-﻿namespace ILCompiler.Compiler.EvaluationStack
+﻿using ILCompiler.Compiler.LinearIR;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ILCompiler.Compiler.EvaluationStack
 {
     public class SwitchEntry : StackEntry
     {
-        public StackEntry Op1 { get; }
+        public StackEntry Op1 { get; set; }
         public IList<string> JumpTable { get; }
 
         public SwitchEntry(StackEntry op1, IList<string> jumpTable) : base(VarType.Void)
@@ -16,9 +19,16 @@
             return new SwitchEntry(Op1, JumpTable);
         }
 
-        public override void Accept(IStackEntryVisitor visitor)
+        public override void Accept(IStackEntryVisitor visitor) => visitor.Visit(this);
+
+        public override bool TryGetUse(StackEntry operand, [NotNullWhen(true)] out Edge<StackEntry>? edge)
         {
-            visitor.Visit(this);
+            if (operand == Op1)
+            {
+                edge = new Edge<StackEntry>(() => Op1, x => Op1 = x);
+                return true;
+            }
+            return base.TryGetUse(operand, out edge);
         }
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/UnaryOperatorEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/UnaryOperatorEntry.cs
@@ -1,8 +1,11 @@
-﻿namespace ILCompiler.Compiler.EvaluationStack
+﻿using ILCompiler.Compiler.LinearIR;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ILCompiler.Compiler.EvaluationStack
 {
     public class UnaryOperator : StackEntry
     {
-        public StackEntry Op1 { get; }
+        public StackEntry Op1 { get; set; }
         public Operation Operation { get; }
 
         public UnaryOperator(Operation operation, StackEntry op1) : base(op1.Type, op1.ExactSize)
@@ -16,9 +19,16 @@
             return new UnaryOperator(Operation, Op1.Duplicate());
         }
 
-        public override void Accept(IStackEntryVisitor visitor)
+        public override void Accept(IStackEntryVisitor visitor) => visitor.Visit(this);
+
+        public override bool TryGetUse(StackEntry operand, [NotNullWhen(true)] out Edge<StackEntry>? edge)
         {
-            visitor.Visit(this);
+            if (operand == Op1)
+            {
+                edge = new Edge<StackEntry>(() => Op1, x => Op1 = x);
+                return true;
+            }
+            return base.TryGetUse(operand, out edge);
         }
     }
 }

--- a/ILCompiler/Compiler/LinearIR/Edge.cs
+++ b/ILCompiler/Compiler/LinearIR/Edge.cs
@@ -1,0 +1,8 @@
+﻿namespace ILCompiler.Compiler.LinearIR
+{
+    public class Edge<T>(Func<T> getter, Action<T> setter)
+    {
+        public T Get() => getter();
+        public void Set(T value) => setter(value);
+    }
+}

--- a/ILCompiler/Compiler/LinearIR/LIR.cs
+++ b/ILCompiler/Compiler/LinearIR/LIR.cs
@@ -1,0 +1,25 @@
+﻿using ILCompiler.Compiler.EvaluationStack;
+using System.Diagnostics;
+
+namespace ILCompiler.Compiler.LinearIR
+{
+    public static class LIR
+    {
+        public static Range SeqTree(StackEntry tree)
+        {
+            var orderingVisitor = new PostOrderTraversalVisitor(tree);
+            tree.Accept(orderingVisitor);
+
+            var lastNode = tree;
+            var firstNode = orderingVisitor.First;
+
+            Debug.Assert(firstNode != null);
+
+            //var firstNode = tree.Next;
+            lastNode.Next = null;
+            firstNode.Prev = null;
+
+            return new Range(firstNode, lastNode);
+        }
+    }
+}

--- a/ILCompiler/Compiler/LinearIR/LIR.cs
+++ b/ILCompiler/Compiler/LinearIR/LIR.cs
@@ -15,7 +15,6 @@ namespace ILCompiler.Compiler.LinearIR
 
             Debug.Assert(firstNode != null);
 
-            //var firstNode = tree.Next;
             lastNode.Next = null;
             firstNode.Prev = null;
 

--- a/ILCompiler/Compiler/LinearIR/Range.cs
+++ b/ILCompiler/Compiler/LinearIR/Range.cs
@@ -34,13 +34,10 @@ namespace ILCompiler.Compiler.LinearIR
 
                 foreach (var n in range)
                 {
-                    if (n != null)
+                    if (n != null && n.TryGetUse(node, out Edge<StackEntry>? edge))
                     {
-                        if (n.TryGetUse(node, out Edge<StackEntry>? edge))
-                        {
-                            use = new Use(this, edge, n);
-                            return true;
-                        }
+                        use = new Use(this, edge, n);
+                        return true;
                     }
                 }
             }

--- a/ILCompiler/Compiler/LinearIR/Range.cs
+++ b/ILCompiler/Compiler/LinearIR/Range.cs
@@ -1,0 +1,169 @@
+﻿using ILCompiler.Compiler.EvaluationStack;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Collections;
+
+namespace ILCompiler.Compiler.LinearIR
+{
+    public class Range : IEnumerable<StackEntry?>
+    {
+        public StackEntry? FirstNode { get; set; }
+        public StackEntry? LastNode { get; set; }
+
+        public Range()
+        {
+        }
+
+        public Range(StackEntry? firstNode, StackEntry? lastNode)
+        {
+            FirstNode = firstNode;
+            LastNode = lastNode;
+        }
+
+        /// <summary>
+        /// Try to find the use for a given node
+        /// </summary>
+        /// <param name="node">node to find the corresponding use</param>
+        /// <param name="use">use of the corresponding node if any</param>
+        /// <returns></returns>
+        public bool TryGetUse(StackEntry node, [NotNullWhen(returnValue: true)] out Use? use)
+        {
+            if (node != LastNode)
+            {
+                var range = new Range(node.Next, LastNode);
+
+                foreach (var n in range)
+                {
+                    if (n != null)
+                    {
+                        if (n.TryGetUse(node, out Edge<StackEntry>? edge))
+                        {
+                            use = new Use(this, edge, n);
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            use = null;
+            return false;
+        }
+
+        public void Remove(StackEntry node)
+        {
+            var prev = node.Prev;
+            var next = node.Next;
+
+            if (prev != null)
+            {
+                prev.Next = next;
+            }
+            else
+            {
+                FirstNode = next;
+            }
+
+            if (next != null)
+            {
+                next.Prev = prev;
+            }
+            else
+            {
+                LastNode = prev;
+            }
+
+            node.Prev = null;
+            node.Next = null;
+        }
+
+        public void InsertBefore(StackEntry insertion, Range range)
+        {
+            Debug.Assert(range.FirstNode != null);
+            Debug.Assert(range.LastNode != null);
+            FinishInsertionBefore(insertion, range.FirstNode, range.LastNode);
+        }
+
+        private void FinishInsertionBefore(StackEntry insertionPoint, StackEntry first, StackEntry last)
+        {
+            if (insertionPoint == null)
+            {
+                if (FirstNode == null)
+                {
+                    FirstNode = first;
+                }
+                else
+                {
+                    LastNode!.Next = first;
+                    first.Next = LastNode;
+                }
+                LastNode = last;
+            }
+            else
+            {
+                first.Prev = insertionPoint.Prev;
+                if (first.Prev == null)
+                {
+                    FirstNode = first;
+                }
+                else
+                {
+                    first.Prev.Next = first;
+                }
+                last.Next = insertionPoint;
+                insertionPoint.Prev = last;
+            }
+        }
+
+        public void InsertAfter(StackEntry insertionPoint, StackEntry node1, StackEntry node2)
+        {
+            node1.Next = node2;
+            node2.Prev = node1;
+
+            FinishInsertionAfter(insertionPoint, node1, node2);
+        }
+
+        private void FinishInsertionAfter(StackEntry insertionPoint, StackEntry first, StackEntry last)
+        {
+            if (insertionPoint == null)
+            {
+                if (LastNode == null)
+                {
+                    LastNode = last;
+                }
+                else
+                {
+                    FirstNode!.Prev = last;
+                    last.Next = FirstNode;
+                }
+                FirstNode = first;
+            }
+            else
+            {
+                last.Next = insertionPoint.Next;
+                if (last.Next == null)
+                {
+                    LastNode = last;
+                }
+                else
+                {
+                    last.Next.Prev = last;
+                }
+
+                first.Prev = insertionPoint;
+                insertionPoint.Next = first;
+            }
+        }
+
+        public IEnumerator<StackEntry?> GetEnumerator()
+        {
+            var current = FirstNode;
+            do
+            {
+                yield return current;
+                current = current?.Next;
+            } while (current != LastNode);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+    }
+}

--- a/ILCompiler/Compiler/LinearIR/Use.cs
+++ b/ILCompiler/Compiler/LinearIR/Use.cs
@@ -1,0 +1,45 @@
+﻿using ILCompiler.Compiler.EvaluationStack;
+
+namespace ILCompiler.Compiler.LinearIR
+{
+    /// <summary>
+    /// Represents a use <-> def edge between two nodes
+    /// in a range of LinearIR.
+    /// </summary>
+    public class Use
+    {
+        private readonly Range _range;
+        private readonly Edge<StackEntry> _edge;
+        private StackEntry User { get; init; }
+
+        public Use(Range range, Edge<StackEntry> edge, StackEntry user)
+        {
+            _range = range;
+            _edge = edge;
+            User = user;
+        }
+
+        public StackEntry Def => _edge.Get();
+
+        public void ReplaceWith(StackEntry replacement)
+        {
+            User.ReplaceOperand(_edge, replacement);
+        }
+
+        public StackEntry ReplaceWithLclVar(LocalVariableTable locals)
+        {
+            var node = _edge.Get();
+
+            var type = Def.Type;
+            var lclNum = locals.GrabTemp(node.Type, node.Type.GetTypeSize());
+            var store = new StoreLocalVariableEntry(lclNum, false, node);
+            var load = new LocalVariableEntry(store.LocalNumber, store.Type, type.GetTypeSize());
+
+            _range.InsertAfter(node, store, load);
+
+            ReplaceWith(load);
+
+            return Def;
+        }
+    }
+}

--- a/ILCompiler/Compiler/LinearIR/Use.cs
+++ b/ILCompiler/Compiler/LinearIR/Use.cs
@@ -23,7 +23,7 @@ namespace ILCompiler.Compiler.LinearIR
 
         public void ReplaceWith(StackEntry replacement)
         {
-            User.ReplaceOperand(_edge, replacement);
+            StackEntry.ReplaceOperand(_edge, replacement);
         }
 
         public StackEntry ReplaceWithLclVar(LocalVariableTable locals)

--- a/ILCompiler/Compiler/Lowering.cs
+++ b/ILCompiler/Compiler/Lowering.cs
@@ -13,10 +13,15 @@ namespace ILCompiler.Compiler
             _loweringFactory = loweringFactory;
         }
 
-        public void Run(IList<BasicBlock> blocks)
+        private BasicBlock _currentBlock = null!;
+        private LocalVariableTable _locals = null!;
+
+        public void Run(IList<BasicBlock> blocks, LocalVariableTable locals)
         {
+            _locals = locals;
             foreach (var block in blocks)
             {
+                _currentBlock = block;
                 LowerBlock(block);
             }
         }
@@ -28,7 +33,7 @@ namespace ILCompiler.Compiler
             var lowering = _loweringFactory.GetLowering<T>();
             if (lowering != null)
             {
-                _nextNode = lowering.Lower(entry);
+                _nextNode = lowering.Lower(entry, _currentBlock, _locals);
             }
         }
 

--- a/ILCompiler/Compiler/Lowerings/ILowering.cs
+++ b/ILCompiler/Compiler/Lowerings/ILowering.cs
@@ -4,6 +4,6 @@ namespace ILCompiler.Compiler.Lowerings
 {
     public interface ILowering<T> where T : StackEntry
     {
-        public StackEntry? Lower(T entry);
+        public StackEntry? Lower(T entry, BasicBlock block, LocalVariableTable locals);
     }
 }

--- a/ILCompiler/Compiler/Lowerings/IndirectLowering.cs
+++ b/ILCompiler/Compiler/Lowerings/IndirectLowering.cs
@@ -4,7 +4,7 @@ namespace ILCompiler.Compiler.Lowerings
 {
     internal class IndirectLowering : ILowering<IndirectEntry>
     {
-        public StackEntry? Lower(IndirectEntry entry)
+        public StackEntry? Lower(IndirectEntry entry, BasicBlock block, LocalVariableTable locals)
         {
             if (entry.Op1 is LocalVariableAddressEntry lvaAddress)
             {

--- a/ILCompiler/Compiler/Lowerings/JumpTrueLowering.cs
+++ b/ILCompiler/Compiler/Lowerings/JumpTrueLowering.cs
@@ -4,7 +4,7 @@ namespace ILCompiler.Compiler.Lowerings
 {
     internal class JumpTrueLowering : ILowering<JumpTrueEntry>
     {
-        public StackEntry? Lower(JumpTrueEntry entry)
+        public StackEntry? Lower(JumpTrueEntry entry, BasicBlock block, LocalVariableTable locals)
         {
             var condition = entry.Condition;
 

--- a/ILCompiler/Compiler/Lowerings/StoreLocalVariableLowering.cs
+++ b/ILCompiler/Compiler/Lowerings/StoreLocalVariableLowering.cs
@@ -4,7 +4,7 @@ namespace ILCompiler.Compiler.Lowerings
 {
     internal class StoreLocalVariableLowering : ILowering<StoreLocalVariableEntry>
     {
-        public StackEntry? Lower(StoreLocalVariableEntry entry)
+        public StackEntry? Lower(StoreLocalVariableEntry entry, BasicBlock block, LocalVariableTable locals)
         {
             if (entry.Op1.IsIntCnsOrI())
             {

--- a/ILCompiler/Compiler/MethodCompiler.cs
+++ b/ILCompiler/Compiler/MethodCompiler.cs
@@ -176,7 +176,7 @@ namespace ILCompiler.Compiler
 
             // Lower
             var lowering = _phaseFactory.Create<ILowering>();
-            lowering.Run(basicBlocks);
+            lowering.Run(basicBlocks, _locals);
 
             var codeGenerator = _phaseFactory.Create<ICodeGenerator>();
             var instructions = codeGenerator.Generate(basicBlocks, _locals, methodCodeNodeNeedingCode);

--- a/ILCompiler/Interfaces/ILowering.cs
+++ b/ILCompiler/Interfaces/ILowering.cs
@@ -4,6 +4,6 @@ namespace ILCompiler.Interfaces
 {
     public interface ILowering : IPhase
     {
-        public void Run(IList<BasicBlock> blocks);
+        public void Run(IList<BasicBlock> blocks, LocalVariableTable locals);
     }
 }


### PR DESCRIPTION
Add Linear IR classes including Range, Use, Edge, LIR
Update HIR classes to support TryGetUse
Extend Lowering of signed division by power of 2 to optimize into shift operation.

Addresses #533

Using simple benchmark running 1000 unsigned division of 42 by -2 results in:

|                     | Debug T-States           | Release T-States  |
| ------------- |:-------------:| -----:|
| Lowering enabled     | 3757672 | 3395212 |
| Lowering disabled     | 7398672 |  6813212 |

About a 50% speedup