### PR TITLE
Initial implementation of constrained opcode prefix

### DIFF
--- a/ILCompiler/Compiler/ILImporter.cs
+++ b/ILCompiler/Compiler/ILImporter.cs
@@ -226,7 +226,7 @@ namespace ILCompiler.Compiler
         {
             if (_configuration.IgnoreUnknownCil)
             {
-                _logger.LogWarning("Unsupported IL opcode {opcode} in {_method.FullName}", currentInstruction.Opcode);
+                _logger.LogWarning("Unsupported IL opcode {Opcode} in {MethodFullName}", currentInstruction.Opcode, _method.FullName);
             }
             else
             {

--- a/ILCompiler/Compiler/Importer/BoxImporter.cs
+++ b/ILCompiler/Compiler/Importer/BoxImporter.cs
@@ -1,5 +1,4 @@
-﻿using ILCompiler.Compiler.DependencyAnalysis;
-using ILCompiler.Compiler.EvaluationStack;
+﻿using ILCompiler.Compiler.EvaluationStack;
 using ILCompiler.Interfaces;
 using ILCompiler.TypeSystem.Common;
 using ILCompiler.TypeSystem.IL;
@@ -16,40 +15,45 @@ namespace ILCompiler.Compiler.Importer
 
             if (objType.IsValueType)
             {
-                // TODO: Consider creating a bespoke Box assembly code runtime routine to do the below
-                // Note - nativeaot implements this in C# in System.Runtime.RuntimeExports.RhBox
-
-                var lclNum = importer.GrabTemp(VarType.Ref, 2);
-
-                var mangledEETypeName = context.NameMangler.GetMangledTypeName(objType);
-                var eeTypeNode = new NativeIntConstantEntry(mangledEETypeName);
-
-                int unboxedObjectSize = GetUnboxedSize(objType);
-
-                // Determine required size on GC heap. Have to explicitly add PointerSize for EETypePtr
-                var allocSize = unboxedObjectSize + 2;
-
-                // Allocate memory for object
-                var op1 = new AllocObjEntry(eeTypeNode, allocSize, VarType.Ref);
-                var asg = new StoreLocalVariableEntry(lclNum, false, op1);
-                importer.ImportAppendTree(asg);
-
-                // Copy value type into box
-                var newObjThisPtr = new LocalVariableEntry(lclNum, VarType.Ref, 2);
-                var headerOffset = new NativeIntConstantEntry(2);
-                var addr = new BinaryOperator(Operation.Add, isComparison: false, newObjThisPtr, headerOffset, VarType.Ptr);
-
                 var value = importer.PopExpression();
-
-                var op = new StoreIndEntry(addr, value, VarType.Ref, 0, unboxedObjectSize);
-                importer.ImportAppendTree(op);
-
-                // Push temp
-                var node = new LocalVariableEntry(lclNum, VarType.Ref, 2);
-                importer.PushExpression(node);
+                var boxedNode = BoxValue(value, objType, context, importer);
+                importer.PushExpression(boxedNode);
             }
 
             return true;
+        }
+
+        public static StackEntry BoxValue(StackEntry value, TypeDesc objType, ImportContext context, IILImporterProxy importer)
+        {
+            // TODO: Consider creating a bespoke Box assembly code runtime routine to do the below
+            // Note - nativeaot implements this in C# in System.Runtime.RuntimeExports.RhBox
+
+            var lclNum = importer.GrabTemp(VarType.Ref, 2);
+
+            var mangledEETypeName = context.NameMangler.GetMangledTypeName(objType);
+            var eeTypeNode = new NativeIntConstantEntry(mangledEETypeName);
+
+            int unboxedObjectSize = GetUnboxedSize(objType);
+
+            // Determine required size on GC heap. Have to explicitly add PointerSize for EETypePtr
+            var allocSize = unboxedObjectSize + 2;
+
+            // Allocate memory for object
+            var op1 = new AllocObjEntry(eeTypeNode, allocSize, VarType.Ref);
+            var asg = new StoreLocalVariableEntry(lclNum, false, op1);
+            importer.ImportAppendTree(asg);
+
+            // Copy value type into box
+            var newObjThisPtr = new LocalVariableEntry(lclNum, VarType.Ref, 2);
+            var headerOffset = new NativeIntConstantEntry(2);
+            var addr = new BinaryOperator(Operation.Add, isComparison: false, newObjThisPtr, headerOffset, VarType.Ptr);
+
+            var op = new StoreIndEntry(addr, value, objType.VarType, 0, unboxedObjectSize);
+            importer.ImportAppendTree(op);
+
+            // Push temp
+            var node = new LocalVariableEntry(lclNum, VarType.Ref, 2);
+            return node;
         }
 
         private static int GetUnboxedSize(TypeDesc objType)

--- a/ILCompiler/Compiler/Importer/CallImporter.cs
+++ b/ILCompiler/Compiler/Importer/CallImporter.cs
@@ -97,13 +97,10 @@ namespace ILCompiler.Compiler.Importer
                     if (constrained.IsRuntimeDeterminedSubtype)
                         constrained = constrained.ConvertToCanonForm(TypeSystem.Canon.CanonicalFormKind.Specific);
 
-                    MethodDesc? directMethod = null;
                     var constrainedType = constrained.Context.GetClosestDefType(constrained);
-                    //var directMethod = constrainedType.TryResolveConstraintMethodApprox(method.OwningType, method, out forceUseRuntimeLookup);
 
-                    // if (forceUseRuntimeLookup)
-                    //    throw new NotImplementedException();
-
+                    // TODO: attempt to resolve constrained method into direct method call
+                    MethodDesc? directMethod = null;
                     if (directMethod is not null)
                     {
                         throw new NotImplementedException();
@@ -111,14 +108,14 @@ namespace ILCompiler.Compiler.Importer
                     else if (constrained.IsValueType)
                     {
                         // Deference this ptr and box it
-                        var dereferencedThisPtr = new IndirectEntry(arguments[0], constrainedType.VarType, constrainedType.GetElementSize().AsInt);
+                        var dereferencedThisPtr = DereferenceThisPtr(arguments[0], constrainedType);
                         var boxedNode = BoxImporter.BoxValue(dereferencedThisPtr, constrainedType, context, importer);
                         arguments[0] = boxedNode;
                     }
                     else
                     {
                         // Dereference this ptr
-                        arguments[0] = new IndirectEntry(arguments[0], VarType.Ref, 2);
+                        arguments[0] = DereferenceThisPtr(arguments[0], constrainedType);
                     }
 
                     context.Constrained = null;
@@ -403,6 +400,11 @@ namespace ILCompiler.Compiler.Importer
                 return false;
             }
             return metadataType.Namespace == typeNamespace && metadataType.Name == typeName;
+        }
+
+        private static StackEntry DereferenceThisPtr(StackEntry thisPtr, TypeDesc thisType)
+        {
+            return new IndirectEntry(thisPtr, thisType.VarType, thisType.GetElementSize().AsInt);
         }
     }
 }

--- a/ILCompiler/Compiler/Importer/ConstrainedImporter.cs
+++ b/ILCompiler/Compiler/Importer/ConstrainedImporter.cs
@@ -1,0 +1,18 @@
+﻿using ILCompiler.Interfaces;
+using ILCompiler.TypeSystem.Common;
+using ILCompiler.TypeSystem.IL;
+
+namespace ILCompiler.Compiler.Importer
+{
+    public class ConstrainedImporter : IOpcodeImporter
+    {
+        public bool Import(Instruction instruction, ImportContext context, IILImporterProxy importer)
+        {
+            if (instruction.Opcode != ILOpcode.constrained) return false;
+
+            context.Constrained = (TypeDesc)instruction.GetOperand();
+
+            return true;
+        }
+    }
+}

--- a/ILCompiler/Compiler/Importer/ImportContext.cs
+++ b/ILCompiler/Compiler/Importer/ImportContext.cs
@@ -1,9 +1,9 @@
-﻿using ILCompiler.TypeSystem.Common;
-using ILCompiler.TypeSystem.Dnlib;
-using ILCompiler.Compiler.DependencyAnalysis;
+﻿using ILCompiler.Compiler.DependencyAnalysis;
+using ILCompiler.Compiler.EvaluationStack;
 using ILCompiler.Compiler.PreInit;
 using ILCompiler.Interfaces;
-using ILCompiler.Compiler.EvaluationStack;
+using ILCompiler.TypeSystem.Common;
+using ILCompiler.TypeSystem.Dnlib;
 using StackEntry = ILCompiler.Compiler.EvaluationStack.StackEntry;
 
 namespace ILCompiler.Compiler.Importer
@@ -11,7 +11,7 @@ namespace ILCompiler.Compiler.Importer
     public record ImportContext
     {
         public required BasicBlock CurrentBlock { get; init; }
-        public required BasicBlock? FallThroughBlock { get; init; }
+        public BasicBlock? FallThroughBlock { get; set; } = null;
         public bool StopImporting { get; set; }
         public required MethodDesc Method { get; init; }
         public required INameMangler NameMangler { get; init; }
@@ -20,6 +20,7 @@ namespace ILCompiler.Compiler.Importer
         public required CorLibModuleProvider CorLibModuleProvider { get; init; }
         public required NodeFactory NodeFactory { get; init; }
         public required DnlibModule Module { get; init; }
+        public TypeDesc? Constrained { get; set; } = null;
 
         public StackEntry GetGenericContext()
         {

--- a/ILCompiler/Compiler/Importer/ServiceCollectionExtensions.cs
+++ b/ILCompiler/Compiler/Importer/ServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ namespace ILCompiler.Compiler.Importer
     {
         public static IServiceCollection AddImporters(this IServiceCollection services)
         {
+            services.AddSingleton<IOpcodeImporter, ConstrainedImporter>();
             services.AddSingleton<IOpcodeImporter, UnboxImporter>();
             services.AddSingleton<IOpcodeImporter, BoxImporter>();
             services.AddSingleton<IOpcodeImporter, NopImporter>();


### PR DESCRIPTION
Initial implementation converts callvirt prefixed by constrained to either:
* For reference types deference the this pointer
* For value types deference the this pointer and box it

No attempt is made to optimise the constrained call into a direct call currently.