### PR TITLE
Add simplest equality comparer and use in Array.IndexOf<T>

### DIFF
--- a/System.Private.CoreLib/System/Array.cs
+++ b/System.Private.CoreLib/System/Array.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace System
 {
@@ -84,27 +85,14 @@ namespace System
             return -1;
         }
 
-        public static int IndexOf<T>(T[] array, object? value, int startIndex, int count)
+        public static int IndexOf<T>(T[] array, T value, int startIndex, int count)
         {
-            
             int endIndex = startIndex + count;
-            if (value is null)
+            for (int i = startIndex; i < endIndex; i++)
             {
-                for (int i = startIndex; i < endIndex; i++)
+                if (EqualOnlyComparer<T>.Equals(array[i], value))
                 {
-                    if (array[i] is null)
-                    {
-                        return i;
-                    }
-                }
-            }
-            else
-            {
-                for (int i = startIndex; i < endIndex; i++)
-                {
-                    object? obj = array[i];
-                    if (obj is not null && obj.Equals(value))
-                        return i;
+                    return i;
                 }
             }
             return -1;

--- a/System.Private.CoreLib/System/Collections/Generic/LowLevelEqualityComparer.cs
+++ b/System.Private.CoreLib/System/Collections/Generic/LowLevelEqualityComparer.cs
@@ -1,0 +1,41 @@
+﻿namespace System.Collections.Generic
+{
+    internal static class EqualOnlyComparerHelper
+    {
+        public static bool Equals(sbyte x, sbyte y) => x == y;
+        public static bool Equals(byte x, byte y) => x == y;
+        public static bool Equals(Int16 x, Int16 y) => x == y;
+        public static bool Equals(UInt16 x, UInt16 y) => x == y;
+        public static bool Equals(Int32 x, Int32 y) => x == y;
+        public static bool Equals(UInt32 x, UInt32 y) => x == y;
+    }
+
+    internal class EqualOnlyComparer<T>
+    {
+        public static bool Equals(T x, T y)
+        {
+            /*
+            if (typeof(T) == typeof(sbyte))
+                return EqualOnlyComparerHelper.Equals((sbyte)(Object)x, (sbyte)(Object)y);
+            else if (typeof(T) == typeof(byte))
+                return EqualOnlyComparerHelper.Equals((byte)(Object)x, (byte)(Object)y);
+            else if (typeof(T) == typeof(Int16))
+                return EqualOnlyComparerHelper.Equals((Int16)(Object)x, (Int16)(Object)y);
+            else if (typeof(T) == typeof(UInt16))
+                return EqualOnlyComparerHelper.Equals((UInt16)(Object)x, (UInt16)(Object)y);
+            else if (typeof(T) == typeof(Int32))
+                return EqualOnlyComparerHelper.Equals((Int32)(Object)x, (Int32)(Object)y);
+            else if (typeof(T) == typeof(UInt32))
+                return EqualOnlyComparerHelper.Equals((UInt32)(Object)x, (UInt32)(Object)y);
+            */
+
+            if (x == null)
+                return y == null;
+
+            if (y == null)
+                return false;
+
+            return x.Equals(y);
+        }
+    }
+}

--- a/System.Private.CoreLib/System/Collections/Generic/LowLevelEqualityComparer.cs
+++ b/System.Private.CoreLib/System/Collections/Generic/LowLevelEqualityComparer.cs
@@ -10,7 +10,7 @@
         public static bool Equals(UInt32 x, UInt32 y) => x == y;
     }
 
-    internal class EqualOnlyComparer<T>
+    internal static class EqualOnlyComparer<T>
     {
         public static bool Equals(T x, T y)
         {


### PR DESCRIPTION
Value types get boxed currently so no saving in heap allocations but EqualityComparer will be extended in future to compare Value Types using methods in EqualOnlyComparerHelper avoiding boxing.