### PR TITLE
Add static Equals to Object

### DIFF
--- a/ILCompiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -9,7 +9,7 @@ namespace ILCompiler.Compiler.DependencyAnalysis
     public class NodeFactory
     {
         private readonly IDictionary<string, StaticsNode> _staticNodesByFullName = new Dictionary<string, StaticsNode>();
-        private readonly IDictionary<string, Z80MethodCodeNode> _methodNodesByFullName = new Dictionary<string, Z80MethodCodeNode>();
+        private readonly IDictionary<MethodDesc, Z80MethodCodeNode> _methodNodesByFullName = new Dictionary<MethodDesc, Z80MethodCodeNode>();
         private readonly IDictionary<string, UnboxingStubNode> _unboxingStubsByFullName = new Dictionary<string, UnboxingStubNode>();
 
         private readonly IDictionary<string, VirtualMethodUseNode> _virtualMethodNodesByFullName = new Dictionary<string, VirtualMethodUseNode>();
@@ -88,10 +88,10 @@ namespace ILCompiler.Compiler.DependencyAnalysis
 
         public IMethodNode MethodNode(MethodDesc method, bool unboxingStub = false)
         {
-            if (!_methodNodesByFullName.TryGetValue(method.FullName, out var methodNode))
+            if (!_methodNodesByFullName.TryGetValue(method, out var methodNode))
             {
                 methodNode = new Z80MethodCodeNode(method, _methodCompilerFactory, _module);
-                _methodNodesByFullName[method.FullName] = methodNode;
+                _methodNodesByFullName[method] = methodNode;
             }
 
             if (unboxingStub)

--- a/ILCompiler/Compiler/Importer/NewarrImporter.cs
+++ b/ILCompiler/Compiler/Importer/NewarrImporter.cs
@@ -15,7 +15,7 @@ namespace ILCompiler.Compiler.Importer
             var numElements = importer.PopExpression();
 
             var runtimeDeterminedType = (TypeDesc)instruction.GetOperand();
-            var runtimeDeterminedArrayType = new ArrayType(runtimeDeterminedType, -1);
+            var runtimeDeterminedArrayType = runtimeDeterminedType.MakeArrayType();
 
             StackEntry eeTypeNode;
             if (runtimeDeterminedType.IsRuntimeDeterminedSubtype)

--- a/ILCompiler/Compiler/NameMangler.cs
+++ b/ILCompiler/Compiler/NameMangler.cs
@@ -6,51 +6,49 @@ namespace ILCompiler.Compiler
     public class NameMangler : INameMangler
     {
         private int nextMethodId = 0;
-        private readonly Dictionary<String, String> _mangledMethodNames = new Dictionary<String, String>();
+        private readonly Dictionary<MethodDesc, String> _mangledMethodNames = new Dictionary<MethodDesc, String>();
 
         private int nextFieldId = 0;
-        private readonly Dictionary<String, String> _mangledFieldNames = new Dictionary<String, String>();
+        private readonly Dictionary<FieldDesc, String> _mangledFieldNames = new Dictionary<FieldDesc, String>();
 
         private int nextTypeId = 0;
-        private readonly Dictionary<String, String> _mangledTypeNames = new Dictionary<String, String>();
+        private readonly Dictionary<TypeDesc, String> _mangledTypeNames = new Dictionary<TypeDesc, String>();
 
         public string GetMangledMethodName(MethodDesc method)
         {
-            return GetMangledMethodName(method.FullName);
-        }
-
-        private string GetMangledMethodName(string fullName)
-        {
-            if (_mangledMethodNames.TryGetValue(fullName, out string? mangledName))
+            if (_mangledMethodNames.TryGetValue(method, out string? mangledName))
             {
                 return mangledName;
             }
 
             mangledName = $"m{nextMethodId++}";
-            _mangledMethodNames.Add(fullName, mangledName);
+            _mangledMethodNames.Add(method, mangledName);
 
             return mangledName;
         }
 
         public string GetMangledFieldName(FieldDesc field)
         {
-            return GetMangledFieldName(field.ToString());
+            if (_mangledFieldNames.TryGetValue(field, out string? mangledName))
+            {
+                return mangledName;
+            }
+
+            mangledName = $"f{nextFieldId++}";
+            _mangledFieldNames.Add(field, mangledName);
+
+            return mangledName;
         }
 
         public string GetMangledTypeName(TypeDesc type)
         {
-            return GetMangledTypeName(type.FullName);
-        }
-
-        private string GetMangledTypeName(string fullName)
-        {
-            if (_mangledTypeNames.TryGetValue(fullName, out string? mangledName))
+            if (_mangledTypeNames.TryGetValue(type, out string? mangledName))
             {
                 return mangledName;
             }
 
             mangledName = $"t{nextTypeId++}";
-            _mangledTypeNames.Add(fullName, mangledName);
+            _mangledTypeNames.Add(type, mangledName);
 
             return mangledName;
         }
@@ -58,19 +56,6 @@ namespace ILCompiler.Compiler
         public string GetUniqueName()
         {
             return $"u{nextFieldId++}";
-        }
-
-        private string GetMangledFieldName(string fullName)
-        {
-            if (_mangledFieldNames.TryGetValue(fullName, out string? mangledName))
-            {
-                return mangledName;
-            }
-
-            mangledName = $"f{nextFieldId++}";
-            _mangledFieldNames.Add(fullName, mangledName);
-
-            return mangledName;
         }
     }
 }

--- a/ILCompiler/TypeSystem/Dnlib/DnlibModule.cs
+++ b/ILCompiler/TypeSystem/Dnlib/DnlibModule.cs
@@ -47,7 +47,7 @@ namespace ILCompiler.TypeSystem.Dnlib
             {
                 var elemTypeSig = typeSig.Next;
                 var elemTypeDesc = Create(elemTypeSig);
-                return Context.GetArrayType(elemTypeDesc, -1);
+                return elemTypeDesc.MakeArrayType();
             }
             if (typeSig.IsFunctionPointer)
             {

--- a/System.Private.CoreLib/System/Object.cs
+++ b/System.Private.CoreLib/System/Object.cs
@@ -14,7 +14,15 @@ namespace System
             return new RuntimeTypeHandle((IntPtr)m_pEEType);
         }
 
-        public virtual bool Equals(object? obj) => obj == this;
+        public virtual bool Equals(object? obj) => this == obj;
+
+        public static bool Equals(object? obj1, object? obj2)
+        {
+            if (obj1 == obj2) return true;
+            if (obj1 == null || obj2 == null) return false;
+            return obj1.Equals(obj2);
+        }
+
         public virtual int GetHashCode() => 0;
         public virtual string ToString() => "";
 

--- a/Tests/CoreLib/System.Tests/ObjectTests.cs
+++ b/Tests/CoreLib/System.Tests/ObjectTests.cs
@@ -1,0 +1,27 @@
+﻿namespace System.Tests
+{
+    internal static class ObjectTests
+    {
+        public static void EqualsTests()
+        {
+            var obj1 = new object();
+            var obj2 = new object();
+
+            EqualsTest(obj1, obj1, true);
+            EqualsTest(obj1, null, false);
+            EqualsTest(obj1, obj2, false);
+
+            EqualsTest(null, null, true);
+            EqualsTest(null, obj1, false);
+        }
+
+        public static void EqualsTest(object obj1, object obj2, bool expected)
+        {
+            if (obj1 != null)
+            {
+                Assert.AreEqual(expected, obj1.Equals(obj2));
+            }
+            Assert.AreEqual(expected, Equals(obj1, obj2));
+        }
+    }
+}

--- a/Tests/CoreLib/System.Tests/ObjectTests.cs
+++ b/Tests/CoreLib/System.Tests/ObjectTests.cs
@@ -15,7 +15,7 @@
             EqualsTest(null, obj1, false);
         }
 
-        public static void EqualsTest(object obj1, object obj2, bool expected)
+        public static void EqualsTest(object? obj1, object? obj2, bool expected)
         {
             if (obj1 != null)
             {

--- a/Tests/CoreLib/System.Tests/SystemTests.cs
+++ b/Tests/CoreLib/System.Tests/SystemTests.cs
@@ -7,6 +7,8 @@
             ArrayTests.GetValue_RankOneInt_SetValue();
             ArrayTests.GetEnumerator();
 
+            ObjectTests.EqualsTests();
+
             return 0;
         }
     }


### PR DESCRIPTION
Fix bug with array type creation that could result in multiple ArrayType objects for the same type of array. 
Add object tests.
NodeFactory can use MethodDesc as key as DnlibModule already ensures uniqueness of MethodDescs