### PR TITLE
Fix indexof array tests for IntPtr and UIntPtr

### DIFF
--- a/System.Private.CoreLib/System/IntPtr.cs
+++ b/System.Private.CoreLib/System/IntPtr.cs
@@ -9,11 +9,11 @@
             _value = (nint)value;
         }
 
-        public static unsafe explicit operator IntPtr(void* value) => new(value);
-        public static unsafe explicit operator void*(IntPtr value) => (void*)value._value;
+        public static unsafe explicit operator nint(void* value) => (nint)value;
+        public static unsafe explicit operator void*(nint value) => (void*)value;
 
-        public static unsafe bool operator ==(IntPtr value1, IntPtr value2) => value1._value == value2._value;
-        public static unsafe bool operator !=(IntPtr value1, IntPtr value2) => value1._value != value2._value;
+        public static unsafe bool operator ==(nint value1, nint value2) => value1._value == value2._value;
+        public static unsafe bool operator !=(nint value1, nint value2) => value1._value != value2._value;
 
         public override bool Equals(object? obj) => (obj is nint other) && Equals(other);
         public bool Equals(nint other) => _value == other;

--- a/System.Private.CoreLib/System/Runtime/CompilerServices/RuntimeFeature.cs
+++ b/System.Private.CoreLib/System/Runtime/CompilerServices/RuntimeFeature.cs
@@ -3,7 +3,7 @@
     public static class RuntimeFeature
     {
         public const string DefaultImplementationsOfInterfaces = nameof(DefaultImplementationsOfInterfaces);
-
+        public const string NumericIntPtr = nameof(NumericIntPtr);
         public static bool IsSupported(string feature)
         {
             return true;

--- a/System.Private.CoreLib/System/UIntPtr.cs
+++ b/System.Private.CoreLib/System/UIntPtr.cs
@@ -9,11 +9,11 @@
             _value = (nuint)value;
         }
 
-        public static unsafe explicit operator UIntPtr(void* value) => new(value);
-        public static unsafe explicit operator void*(UIntPtr value) => (void*)value._value;
+        public static unsafe explicit operator nuint(void* value) => (nuint)value;
+        public static unsafe explicit operator void*(nuint value) => (void*)value;
 
-        public static unsafe bool operator ==(UIntPtr value1, UIntPtr value2) => value1._value == value2._value;
-        public static unsafe bool operator !=(UIntPtr value1, UIntPtr value2) => value1._value != value2._value;
+        public static unsafe bool operator ==(nuint value1, nuint value2) => value1._value == value2._value;
+        public static unsafe bool operator !=(nuint value1, nuint value2) => value1._value != value2._value;
 
         public override bool Equals(object? obj) => (obj is nuint other) && Equals(other);
         public bool Equals(nuint other) => _value == other;

--- a/Tests/CoreLib/System.Tests/ArrayTests.cs
+++ b/Tests/CoreLib/System.Tests/ArrayTests.cs
@@ -70,8 +70,6 @@ namespace System.Tests
             IndexOf_SZArray<bool>(boolArray, false, 1);
             IndexOf_SZArray<bool>(new bool[0], true, -1);
 
-            /*
-             * Needs missing explicit conversion operators on IntPtr and UIntPtr
             var intPtrArray = new IntPtr[] { (IntPtr)1, (IntPtr)2, (IntPtr)3, (IntPtr)3 };
             IndexOf_SZArray<IntPtr>(intPtrArray, (IntPtr)1, 0);
             IndexOf_SZArray<IntPtr>(intPtrArray, (IntPtr)3, 2);
@@ -83,7 +81,6 @@ namespace System.Tests
             IndexOf_SZArray<UIntPtr>(uintPtrArray, (UIntPtr)3, 2);
             IndexOf_SZArray<UIntPtr>(uintPtrArray, (UIntPtr)2, 1);
             IndexOf_SZArray<UIntPtr>(new UIntPtr[0], (UIntPtr)1, -1);
-            */
         }
 
         private static void IndexOf_SZArray<T>(T[] array, T value, int expected)


### PR DESCRIPTION
Enable NumericIntPtr feature flag
Use nint and nuint in IntPtr and UIntPtr
Enable array tests for indexof covering IntPtr and UIntPtr