### PR TITLE
Extend ComputeFlags to deal with more element types

### DIFF
--- a/Common/Internal/Runtime/EEType.cs
+++ b/Common/Internal/Runtime/EEType.cs
@@ -41,7 +41,7 @@ namespace Internal.Runtime
 
         internal bool IsValueType => ElementType < EETypeElementType.Class;
 
-        internal EETypeElementType ElementType => (EETypeElementType)((_usFlags & (ushort)EETypeFlags.ElementTypeMask) >> (byte)EETypeFlags.ElementTypeShift);
+        internal EETypeElementType ElementType => (EETypeElementType)(_usFlags);
 
         internal uint ValueTypeSize => (uint)(BaseSize - 2);
     }

--- a/ILCompiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -355,18 +355,24 @@ namespace ILCompiler.Compiler.DependencyAnalysis
 
         private static ushort ComputeFlags(TypeDesc type)
         {
+            EETypeElementType elementType = ComputeEETypeElementType(type);
+            return (ushort)elementType;
+        }
+
+        private static EETypeElementType ComputeEETypeElementType(TypeDesc type)
+        {
             // Enums are represented as their underlying type
             type = type.UnderlyingType;
 
-            if (type.IsValueType)
-            {
-                return (ushort)EETypeElementType.ValueType;
-            }
             if (type.IsWellKnownType(WellKnownType.Array))
             {
-                return (ushort)EETypeElementType.SystemArray;
+                return EETypeElementType.SystemArray;
             }
-            return 0;
+            else
+            {
+                EETypeElementType elementType = (EETypeElementType)type.Category;
+                return elementType;
+            }
         }
 
         private static int ComputeBaseSize(TypeDesc type)

--- a/ILCompiler/TypeSystem/Dnlib/DnlibType.cs
+++ b/ILCompiler/TypeSystem/Dnlib/DnlibType.cs
@@ -197,11 +197,6 @@ namespace ILCompiler.TypeSystem.Dnlib
                 case ElementType.U4:
                     return VarType.UInt;
 
-                case ElementType.I8:
-                    return VarType.Long;
-                case ElementType.U8:
-                    return VarType.ULong;
-
                 case ElementType.Ptr:
                 case ElementType.I:
                 case ElementType.U:

--- a/ILCompiler/TypeSystem/Dnlib/DnlibType.cs
+++ b/ILCompiler/TypeSystem/Dnlib/DnlibType.cs
@@ -142,6 +142,7 @@ namespace ILCompiler.TypeSystem.Dnlib
                     ElementType.ByRef => TypeFlags.ByRef,
                     ElementType.Array => TypeFlags.Array,
                     ElementType.SZArray => TypeFlags.SzArray,
+                    ElementType.Object => TypeFlags.Class,
                     _ => TypeFlags.Unknown
                 };
             }
@@ -195,6 +196,11 @@ namespace ILCompiler.TypeSystem.Dnlib
                     return VarType.Int;
                 case ElementType.U4:
                     return VarType.UInt;
+
+                case ElementType.I8:
+                    return VarType.Long;
+                case ElementType.U8:
+                    return VarType.ULong;
 
                 case ElementType.Ptr:
                 case ElementType.I:


### PR DESCRIPTION
Fixes bug with boxing in RuntimeExports.Box failing to determine correct element type when element is a class.

Map Object to Class TypeFlag
Fix EEType.ElementType as no shifting/masking required
