### PR TITLE
Remove use of dnlib in ILProvider

### DIFF
--- a/ILCompiler/IL/ILProvider.cs
+++ b/ILCompiler/IL/ILProvider.cs
@@ -1,11 +1,10 @@
 ﻿using ILCompiler.TypeSystem.Common;
-using ILCompiler.TypeSystem.Dnlib;
 using ILCompiler.TypeSystem.IL;
 
 namespace ILCompiler.IL
 {
     public abstract class ILProvider
     {
-        public abstract MethodIL? GetMethodIL(MethodDesc method, DnlibModule module);
+        public abstract MethodIL? GetMethodIL(MethodDesc method);
     }
 }

--- a/ILCompiler/IL/RTILProvider.cs
+++ b/ILCompiler/IL/RTILProvider.cs
@@ -1,32 +1,28 @@
-﻿using dnlib.DotNet.Emit;
-using ILCompiler.Common.TypeSystem.IL;
+﻿using ILCompiler.Common.TypeSystem.IL;
 using ILCompiler.IL.Stubs;
 using ILCompiler.TypeSystem.Common;
-using ILCompiler.TypeSystem.Dnlib;
 using ILCompiler.TypeSystem.IL;
 
 namespace ILCompiler.IL
 {
     public class RTILProvider : ILProvider
     {
-        public override MethodIL? GetMethodIL(MethodDesc method, DnlibModule module)
+        public override MethodIL? GetMethodIL(MethodDesc method)
         {
-            if (method is DnlibMethod)
-            {
-                if (method.IsIntrinsic)
-                {
-                    var cilbody = TryGetIntrinsicMethodIL(method);
-                    if (cilbody != null)
-                    {
-                        return new DnlibMethodIL(module, cilbody);
-                    }
-                }
-            }
-            else if (method is MethodForInstantiatedType || method is InstantiatedMethod)
+            if (method is MethodForInstantiatedType || method is InstantiatedMethod)
             {
                 if (method.IsIntrinsic)
                 {
                     var methodIL = TryGetPerInstantiationIntrinsicMethodIL(method);
+                    if (methodIL != null)
+                        return methodIL;
+                }
+            }
+            else
+            {
+                if (method.IsIntrinsic)
+                {
+                    var methodIL = TryGetIntrinsicMethodIL(method);
                     if (methodIL != null)
                         return methodIL;
                 }
@@ -53,7 +49,7 @@ namespace ILCompiler.IL
             return null;
         }
 
-        private static CilBody? TryGetIntrinsicMethodIL(MethodDesc method)
+        private static MethodIL? TryGetIntrinsicMethodIL(MethodDesc method)
         {
             var declaringType = method.OwningType;
             switch (declaringType.Name)

--- a/ILCompiler/IL/Stubs/UnsafeIntrinsics.cs
+++ b/ILCompiler/IL/Stubs/UnsafeIntrinsics.cs
@@ -1,12 +1,11 @@
-﻿using dnlib.DotNet;
-using dnlib.DotNet.Emit;
-using ILCompiler.TypeSystem.Common;
+﻿using ILCompiler.TypeSystem.Common;
+using ILCompiler.TypeSystem.IL;
 
 namespace ILCompiler.Common.TypeSystem.IL
 {
     public static class UnsafeIntrinsics
     {
-        public static CilBody? EmitIL(MethodDesc method)
+        public static MethodIL? EmitIL(MethodDesc method)
         {
             switch (method.Name)
             {
@@ -29,100 +28,86 @@ namespace ILCompiler.Common.TypeSystem.IL
             return null;
         }
 
-        private static CilBody? EmitAs() 
+        private static MethodIL? EmitAs() 
         {
-            var body = new CilBody();
+            var body = new MethodIL();
 
-            body.Instructions.Add(OpCodes.Ldarg_0.ToInstruction());
-            body.Instructions.Add(OpCodes.Ret.ToInstruction());
-
-            body.UpdateInstructionOffsets();
+            body.Instructions.Add(new Instruction(ILOpcode.ldarg_0, 0));
+            body.Instructions.Add(new Instruction(ILOpcode.ret, 1));
 
             return body;
         }
 
-        private static CilBody? EmitAsPointer()
+        private static MethodIL? EmitAsPointer()
         {
-            var body = new CilBody();
+            var body = new MethodIL();
 
-            body.Instructions.Add(OpCodes.Ldarg_0.ToInstruction());
-            body.Instructions.Add(OpCodes.Conv_U.ToInstruction());
-            body.Instructions.Add(OpCodes.Ret.ToInstruction());
-
-            body.UpdateInstructionOffsets();
+            body.Instructions.Add(new Instruction(ILOpcode.ldarg_0, 0));
+            body.Instructions.Add(new Instruction(ILOpcode.conv_u, 1));
+            body.Instructions.Add(new Instruction(ILOpcode.ret, 2));
 
             return body;
         }
 
-        private static CilBody? EmitSizeOf(MethodDesc method) 
+        private static MethodIL? EmitSizeOf(MethodDesc method) 
         {
-            var body = new CilBody();
+            var body = new MethodIL();
 
-            body.Instructions.Add(OpCodes.Sizeof.ToInstruction(new GenericMVar(0).ToTypeDefOrRef()));
-            body.Instructions.Add(OpCodes.Ret.ToInstruction());
-
-            body.UpdateInstructionOffsets();
-
-            return body;            
-        }
-
-        private static CilBody? EmitInitBlock()
-        {
-            var body = new CilBody();
-
-            body.Instructions.Add(OpCodes.Ldarg_0.ToInstruction());
-            body.Instructions.Add(OpCodes.Ldarg_1.ToInstruction());
-            body.Instructions.Add(OpCodes.Ldarg_2.ToInstruction());
-            body.Instructions.Add(OpCodes.Initblk.ToInstruction());
-            body.Instructions.Add(OpCodes.Ret.ToInstruction());
-
-            body.UpdateInstructionOffsets();
+            body.Instructions.Add(new Instruction(ILOpcode.sizeof_, 0, new SignatureMethodVariable(method.Context, 0)));
+            body.Instructions.Add(new Instruction(ILOpcode.ret, 1));
 
             return body;
         }
 
-        private static CilBody? EmitCopyBlock()
+        private static MethodIL? EmitInitBlock()
         {
-            var body = new CilBody();
+            var body = new MethodIL();
 
-            body.Instructions.Add(OpCodes.Ldarg_0.ToInstruction());
-            body.Instructions.Add(OpCodes.Ldarg_1.ToInstruction());
-            body.Instructions.Add(OpCodes.Ldarg_2.ToInstruction());
-            body.Instructions.Add(OpCodes.Cpblk.ToInstruction());
-            body.Instructions.Add(OpCodes.Ret.ToInstruction());
-
-            body.UpdateInstructionOffsets();
+            body.Instructions.Add(new Instruction(ILOpcode.ldarg_0, 0));
+            body.Instructions.Add(new Instruction(ILOpcode.ldarg_1, 1));
+            body.Instructions.Add(new Instruction(ILOpcode.ldarg_2, 2));
+            body.Instructions.Add(new Instruction(ILOpcode.initblk, 3));
+            body.Instructions.Add(new Instruction(ILOpcode.ret, 4));
 
             return body;
         }
 
-        private static CilBody? EmitAdd(MethodDesc method)
+        private static MethodIL? EmitCopyBlock()
         {
-            var body = new CilBody();
+            var body = new MethodIL();
 
-            body.Instructions.Add(OpCodes.Ldarg_1.ToInstruction());
-            body.Instructions.Add(OpCodes.Sizeof.ToInstruction(new GenericMVar(0).ToTypeDefOrRef()));
-            body.Instructions.Add(OpCodes.Conv_I.ToInstruction());
-            body.Instructions.Add(OpCodes.Mul.ToInstruction());
-            body.Instructions.Add(OpCodes.Ldarg_0.ToInstruction());
-            body.Instructions.Add(OpCodes.Add.ToInstruction());
-            body.Instructions.Add(OpCodes.Ret.ToInstruction());
-
-            body.UpdateInstructionOffsets();
+            body.Instructions.Add(new Instruction(ILOpcode.ldarg_0, 0));
+            body.Instructions.Add(new Instruction(ILOpcode.ldarg_1, 1));
+            body.Instructions.Add(new Instruction(ILOpcode.ldarg_2, 2));
+            body.Instructions.Add(new Instruction(ILOpcode.cpblk, 3));
+            body.Instructions.Add(new Instruction(ILOpcode.ret, 4));
 
             return body;
         }
 
-        private static CilBody? EmitAddByteOffset(MethodDesc method) 
+        private static MethodIL? EmitAdd(MethodDesc method)
         {
-            var body = new CilBody();
+            var body = new MethodIL();
 
-            body.Instructions.Add(OpCodes.Ldarg_0.ToInstruction());
-            body.Instructions.Add(OpCodes.Ldarg_1.ToInstruction());
-            body.Instructions.Add(OpCodes.Add.ToInstruction());
-            body.Instructions.Add(OpCodes.Ret.ToInstruction());
+            body.Instructions.Add(new Instruction(ILOpcode.ldarg_1, 0));
+            body.Instructions.Add(new Instruction(ILOpcode.sizeof_, 1, new SignatureMethodVariable(method.Context, 0)));
+            body.Instructions.Add(new Instruction(ILOpcode.conv_i, 2));
+            body.Instructions.Add(new Instruction(ILOpcode.mul, 3));
+            body.Instructions.Add(new Instruction(ILOpcode.ldarg_0, 4));
+            body.Instructions.Add(new Instruction(ILOpcode.add, 5));
+            body.Instructions.Add(new Instruction(ILOpcode.ret, 6));
 
-            body.UpdateInstructionOffsets();
+            return body;
+        }
+
+        private static MethodIL? EmitAddByteOffset(MethodDesc method) 
+        {
+            var body = new MethodIL();
+
+            body.Instructions.Add(new Instruction(ILOpcode.ldarg_0, 0));
+            body.Instructions.Add(new Instruction(ILOpcode.ldarg_1, 1));
+            body.Instructions.Add(new Instruction(ILOpcode.add, 2));
+            body.Instructions.Add(new Instruction(ILOpcode.ret, 3));
 
             return body;
         }

--- a/ILCompiler/TypeSystem/Dnlib/DnlibMethod.cs
+++ b/ILCompiler/TypeSystem/Dnlib/DnlibMethod.cs
@@ -131,7 +131,7 @@ namespace ILCompiler.TypeSystem.Dnlib
                     if (IsIntrinsic)
                     {
                         // Use IL Provider
-                        _methodIL = _ilProvider.GetMethodIL(this, _module);
+                        _methodIL = _ilProvider.GetMethodIL(this);
                     }
 
                     if (_methodIL == null && _methodDef.Body != null)

--- a/ILCompiler/TypeSystem/IL/InstantiatedMethodIL.cs
+++ b/ILCompiler/TypeSystem/IL/InstantiatedMethodIL.cs
@@ -47,7 +47,7 @@ namespace ILCompiler.TypeSystem.IL
             var dnlibModule = (DnlibModule)context.SystemModule!;
             var ilProvider = dnlibModule.ILProvider;
 
-            _methodIL = ilProvider.GetMethodIL(owningMethod, dnlibModule) ?? methodIL;
+            _methodIL = ilProvider.GetMethodIL(owningMethod) ?? methodIL;
 
             foreach (var instruction in _methodIL.Instructions)
             {


### PR DESCRIPTION
Can now create Instructions without relying on dnlib