### PR TITLE
Refactor Number.Int32ToDecStr to use ternary operator.

### DIFF
--- a/System.Private.CoreLib/System/Number.cs
+++ b/System.Private.CoreLib/System/Number.cs
@@ -5,13 +5,10 @@ namespace System
 {
     internal static class Number
     {
-        public unsafe static string Int32ToDecStr(int value)
-        {
-            if (value >= 0)
-                return UInt32ToDecStr((uint)value);
-            else
-                return NegativeInt32ToDecStr(value);
-        }
+        public unsafe static string Int32ToDecStr(int value) 
+            => value >= 0 ? 
+                UInt32ToDecStr((uint)value) : 
+                NegativeInt32ToDecStr(value);
 
         private static unsafe string UInt32ToDecStr(uint value)
         {


### PR DESCRIPTION
Now that signed comparisions have been fixed, see #582, can refactor Int32ToDecStr to use tenary operator
This ties up #563 properly.