### PR TITLE
Split native sized integer comparison routines into signed and unsigned.

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/CompareCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/CompareCodeGenerator.cs
@@ -16,14 +16,14 @@ namespace ILCompiler.Compiler.CodeGenerators
 
             { Tuple.Create(Operation.Ne_Un, VarType.Ptr), "i_neq16" },
             { Tuple.Create(Operation.Eq, VarType.Ptr), "i_eq16" },
-            { Tuple.Create(Operation.Ge_Un, VarType.Ptr), "i_ge16" },
-            { Tuple.Create(Operation.Gt_Un, VarType.Ptr), "i_gt16" },
+            { Tuple.Create(Operation.Ge_Un, VarType.Ptr), "i_ge16_un" },
+            { Tuple.Create(Operation.Gt_Un, VarType.Ptr), "i_gt16_un" },
             { Tuple.Create(Operation.Gt, VarType.Ptr), "i_gt16" },
             { Tuple.Create(Operation.Ge, VarType.Ptr), "i_ge16" },
 
             { Tuple.Create(Operation.Ne_Un, VarType.Ref), "i_neq16" },
             { Tuple.Create(Operation.Eq, VarType.Ref), "i_eq16" },
-            { Tuple.Create(Operation.Gt_Un, VarType.Ref), "i_gt16" },
+            { Tuple.Create(Operation.Gt_Un, VarType.Ref), "i_gt16_un" },
 
             { Tuple.Create(Operation.Ne_Un, VarType.ByRef), "i_neq16" },
             { Tuple.Create(Operation.Eq, VarType.ByRef), "i_eq16" },

--- a/ILCompiler/ILCompiler.csproj
+++ b/ILCompiler/ILCompiler.csproj
@@ -106,6 +106,8 @@
     <EmbeddedResource Include="Runtime\CPM\cls.asm" />
     <EmbeddedResource Include="Runtime\CPM\printchr.asm" />
     <EmbeddedResource Include="Runtime\CallCatchHandler.asm" />
+    <EmbeddedResource Include="Runtime\i_ge16_un.asm" />
+    <EmbeddedResource Include="Runtime\i_gt16_un.asm" />
     <EmbeddedResource Include="Runtime\SFINext.asm" />
     <EmbeddedResource Include="Runtime\EHEnumNext.asm" />
     <EmbeddedResource Include="Runtime\EHEnumInit.asm" />

--- a/ILCompiler/Runtime/i_ge16.asm
+++ b/ILCompiler/Runtime/i_ge16.asm
@@ -1,25 +1,25 @@
-; 16 bit greater than or equal comparison
+; 16 bit signed greater than or equal comparison
 ; Args from Stack, HL >= DE
 ; Carry set if true
 
 i_ge16:
-	POP BC
-
 	POP HL
+
+	POP BC
 	POP DE
 
-	AND A			; Clear carry flag
-	SBC HL, DE
+	LD A, C
+	SUB A, E
+	LD A, B
+	SBC A, D
 
-	JR C, i_ge16_1	; value1 >= value2
+	JP PO, $+5
+	XOR A, 0x80
+	JP M, i_ge16_1
 
-	SCF				; set carry flag
-
-	JP i_ge16_2
+	SCF
+	JP (HL)
 
 i_ge16_1:
-	XOR A			; Clear carry flag
-
-i_ge16_2:
-	PUSH BC
-	RET
+	AND A
+	JP (HL)

--- a/ILCompiler/Runtime/i_ge16_un.asm
+++ b/ILCompiler/Runtime/i_ge16_un.asm
@@ -1,0 +1,25 @@
+; 16 bit unsigned greater than or equal comparison
+; Args from Stack, HL >= DE
+; Carry set if true
+
+i_ge16_un:
+	POP BC
+
+	POP HL
+	POP DE
+
+	AND A			; Clear carry flag
+	SBC HL, DE
+
+	JR C, i_ge16_un_1	; value1 >= value2
+
+	SCF				; set carry flag
+
+	JP i_ge16_un_2
+
+i_ge16_un_1:
+	XOR A			; Clear carry flag
+
+i_ge16_un_2:
+	PUSH BC
+	RET

--- a/ILCompiler/Runtime/i_gt16.asm
+++ b/ILCompiler/Runtime/i_gt16.asm
@@ -1,27 +1,25 @@
-; 16 bit greater than comparison
+; 16 bit signed greater than comparison
 ; Args from Stack, HL > DE
 ; Carry set if true
 
 i_gt16:
-	POP BC
-
 	POP HL
-	POP DE
 
-	AND A			; Clear zero flag
-	SBC HL, DE
+	POP DE		; min
+	POP BC		; one
 
-	JR C, i_gt16_1
+	LD A, C
+	SUB A, E
+	LD A, B
+	SBC A, D
 
-	JR Z, i_gt16_1
+	JP PO, $+5
+	XOR A, 0x80
+	JP M, i_gt16_1
 
-	SCF				; set carry flag
-
-	JP i_gt16_2
+	AND A
+	JP (HL)
 
 i_gt16_1:
-	XOR A			; Clear carry flag
-
-i_gt16_2:
-	PUSH BC
-	RET
+	SCF
+	JP (HL)

--- a/ILCompiler/Runtime/i_gt16_un.asm
+++ b/ILCompiler/Runtime/i_gt16_un.asm
@@ -1,0 +1,27 @@
+; 16 bit unsigned greater than comparison
+; Args from Stack, HL > DE
+; Carry set if true
+
+i_gt16_un:
+	POP BC
+
+	POP HL
+	POP DE
+
+	AND A			; Clear zero flag
+	SBC HL, DE
+
+	JR C, i_gt16_un_1
+
+	JR Z, i_gt16_un_1
+
+	SCF				; set carry flag
+
+	JP i_gt16_un_2
+
+i_gt16_un_1:
+	XOR A			; Clear carry flag
+
+i_gt16_un_2:
+	PUSH BC
+	RET

--- a/Tests/ILCompiler.IntegrationTests/il_bvt/cgt_i.il
+++ b/Tests/ILCompiler.IntegrationTests/il_bvt/cgt_i.il
@@ -1,0 +1,305 @@
+﻿.assembly extern System.Private.CoreLib as mscorlib
+{
+    .ver 0:0:0:0
+}
+.assembly TestAssembly
+{
+}
+.class public _cgt_i {
+
+.field public static	native int min
+.field public static	native int _one
+.field public static	native int zero
+.field public static	native int one
+.field public static	native int max
+.field public static	native int odd
+.field public static	native int even
+
+.method public static	void initialize() {
+.maxstack	10
+	ldc.i4		0x00008000
+	conv.i
+	stsfld	native int _cgt_i::min
+	ldc.i4		0x0000FFFF
+	conv.i
+	stsfld	native int _cgt_i::_one
+	ldc.i4		0x00000000
+	conv.i
+	stsfld	native int _cgt_i::zero
+	ldc.i4		0x00000001
+	conv.i
+	stsfld	native int _cgt_i::one
+	ldc.i4		0x00007FFF
+	conv.i
+	stsfld	native int _cgt_i::max
+	ldc.i4		0x00005555
+	conv.i
+	stsfld	native int _cgt_i::odd
+	ldc.i4		0x0000AAAA
+	conv.i
+	stsfld	native int _cgt_i::even
+	ret
+}
+
+
+.method public static int32 Main() {
+.entrypoint
+.maxstack 10
+
+	call	void _cgt_i::initialize()
+
+	ldsfld	native int _cgt_i::min
+	ldsfld	native int _cgt_i::min
+	cgt
+	brtrue fail
+
+	ldsfld	native int _cgt_i::min
+	ldsfld	native int _cgt_i::_one
+	cgt
+	brtrue fail
+
+	ldsfld	native int _cgt_i::min
+	ldsfld	native int _cgt_i::zero
+	cgt
+	brtrue fail
+
+	ldsfld	native int _cgt_i::min
+	ldsfld	native int _cgt_i::one
+	cgt
+	brtrue fail
+
+	ldsfld	native int _cgt_i::min
+	ldsfld	native int _cgt_i::max
+	cgt
+	brtrue fail
+
+	ldsfld	native int _cgt_i::min
+	ldsfld	native int _cgt_i::odd
+	cgt
+	brtrue fail
+
+	ldsfld	native int _cgt_i::min
+	ldsfld	native int _cgt_i::even
+	cgt
+	brtrue fail
+
+	ldsfld	native int _cgt_i::_one
+	ldsfld	native int _cgt_i::min
+	cgt
+	brfalse fail
+
+	ldsfld	native int _cgt_i::_one
+	ldsfld	native int _cgt_i::_one
+	cgt
+	brtrue fail
+
+	ldsfld	native int _cgt_i::_one
+	ldsfld	native int _cgt_i::zero
+	cgt
+	brtrue fail
+
+	ldsfld	native int _cgt_i::_one
+	ldsfld	native int _cgt_i::one
+	cgt
+	brtrue fail
+
+	ldsfld	native int _cgt_i::_one
+	ldsfld	native int _cgt_i::max
+	cgt
+	brtrue fail
+
+	ldsfld	native int _cgt_i::_one
+	ldsfld	native int _cgt_i::odd
+	cgt
+	brtrue fail
+
+	ldsfld	native int _cgt_i::_one
+	ldsfld	native int _cgt_i::even
+	cgt
+	brfalse fail
+
+	ldsfld	native int _cgt_i::zero
+	ldsfld	native int _cgt_i::min
+	cgt
+	brfalse fail
+
+	ldsfld	native int _cgt_i::zero
+	ldsfld	native int _cgt_i::_one
+	cgt
+	brfalse fail
+
+	ldsfld	native int _cgt_i::zero
+	ldsfld	native int _cgt_i::zero
+	cgt
+	brtrue fail
+
+	ldsfld	native int _cgt_i::zero
+	ldsfld	native int _cgt_i::one
+	cgt
+	brtrue fail
+
+	ldsfld	native int _cgt_i::zero
+	ldsfld	native int _cgt_i::max
+	cgt
+	brtrue fail
+
+	ldsfld	native int _cgt_i::zero
+	ldsfld	native int _cgt_i::odd
+	cgt
+	brtrue fail
+
+	ldsfld	native int _cgt_i::zero
+	ldsfld	native int _cgt_i::even
+	cgt
+	brfalse fail
+
+	ldsfld	native int _cgt_i::one
+	ldsfld	native int _cgt_i::min
+	cgt
+	brfalse fail
+
+	ldsfld	native int _cgt_i::one
+	ldsfld	native int _cgt_i::_one
+	cgt
+	brfalse fail
+
+	ldsfld	native int _cgt_i::one
+	ldsfld	native int _cgt_i::zero
+	cgt
+	brfalse fail
+
+	ldsfld	native int _cgt_i::one
+	ldsfld	native int _cgt_i::one
+	cgt
+	brtrue fail
+
+	ldsfld	native int _cgt_i::one
+	ldsfld	native int _cgt_i::max
+	cgt
+	brtrue fail
+
+	ldsfld	native int _cgt_i::one
+	ldsfld	native int _cgt_i::odd
+	cgt
+	brtrue fail
+
+	ldsfld	native int _cgt_i::one
+	ldsfld	native int _cgt_i::even
+	cgt
+	brfalse fail
+
+	//
+
+	ldsfld	native int _cgt_i::max
+	ldsfld	native int _cgt_i::min
+	cgt
+	brfalse fail
+
+	ldsfld	native int _cgt_i::max
+	ldsfld	native int _cgt_i::_one
+	cgt
+	brfalse fail
+
+	ldsfld	native int _cgt_i::max
+	ldsfld	native int _cgt_i::zero
+	cgt
+	brfalse fail
+
+	ldsfld	native int _cgt_i::max
+	ldsfld	native int _cgt_i::one
+	cgt
+	brfalse fail
+
+	ldsfld	native int _cgt_i::max
+	ldsfld	native int _cgt_i::max
+	cgt
+	brtrue fail
+
+	ldsfld	native int _cgt_i::max
+	ldsfld	native int _cgt_i::odd
+	cgt
+	brfalse fail
+
+	ldsfld	native int _cgt_i::max
+	ldsfld	native int _cgt_i::even
+	cgt
+	brfalse fail
+
+	ldsfld	native int _cgt_i::odd
+	ldsfld	native int _cgt_i::min
+	cgt
+	brfalse fail
+
+	ldsfld	native int _cgt_i::odd
+	ldsfld	native int _cgt_i::_one
+	cgt
+	brfalse fail
+
+	ldsfld	native int _cgt_i::odd
+	ldsfld	native int _cgt_i::zero
+	cgt
+	brfalse fail
+
+	ldsfld	native int _cgt_i::odd
+	ldsfld	native int _cgt_i::one
+	cgt
+	brfalse fail
+
+	ldsfld	native int _cgt_i::odd
+	ldsfld	native int _cgt_i::max
+	cgt
+	brtrue fail
+
+	ldsfld	native int _cgt_i::odd
+	ldsfld	native int _cgt_i::odd
+	cgt
+	brtrue fail
+
+	ldsfld	native int _cgt_i::odd
+	ldsfld	native int _cgt_i::even
+	cgt
+	brfalse fail
+
+	ldsfld	native int _cgt_i::even
+	ldsfld	native int _cgt_i::min
+	cgt
+	brfalse fail
+
+	ldsfld	native int _cgt_i::even
+	ldsfld	native int _cgt_i::_one
+	cgt
+	brtrue fail
+
+	ldsfld	native int _cgt_i::even
+	ldsfld	native int _cgt_i::zero
+	cgt
+	brtrue fail
+
+	ldsfld	native int _cgt_i::even
+	ldsfld	native int _cgt_i::one
+	cgt
+	brtrue fail
+
+	ldsfld	native int _cgt_i::even
+	ldsfld	native int _cgt_i::max
+	cgt
+	brtrue fail
+
+	ldsfld	native int _cgt_i::even
+	ldsfld	native int _cgt_i::odd
+	cgt
+	brtrue fail
+
+	ldsfld	native int _cgt_i::even
+	ldsfld	native int _cgt_i::even
+	cgt
+	brtrue fail
+
+pass:
+	ldc.i4 0x0000
+	ret
+fail:
+	ldc.i4 0x0001
+	ret
+}
+}

--- a/Tests/ILCompiler.IntegrationTests/il_bvt/cgt_u.il
+++ b/Tests/ILCompiler.IntegrationTests/il_bvt/cgt_u.il
@@ -1,0 +1,125 @@
+﻿.assembly extern System.Private.CoreLib as mscorlib
+{
+    .ver 0:0:0:0
+}
+.assembly TestAssembly
+{
+}
+.class public _cgt_u {
+
+.field public static	native uint all
+.field public static	native uint none
+.field public static	native uint odd
+.field public static	native uint even
+
+.method public static	void initialize() {
+.maxstack	10
+	ldc.i4		0xFFFFFFFF
+	conv.u
+	stsfld	native uint _cgt_u::all
+	ldc.i4		0x00000000
+	conv.u
+	stsfld	native uint _cgt_u::none
+	ldc.i4		0x55555555
+	conv.u
+	stsfld	native uint _cgt_u::odd
+	ldc.i4		0xAAAAAAAA
+	conv.u
+	stsfld	native uint _cgt_u::even
+	ret
+}
+
+.method public static int32 Main() {
+.entrypoint
+.maxstack 10
+
+	call	void _cgt_u::initialize()
+
+	ldsfld	native uint _cgt_u::all
+	ldsfld	native uint _cgt_u::all
+	cgt.un
+	brtrue fail
+
+	ldsfld	native uint _cgt_u::all
+	ldsfld	native uint _cgt_u::none
+	cgt.un
+	brfalse fail
+
+	ldsfld	native uint _cgt_u::all
+	ldsfld	native uint _cgt_u::odd
+	cgt.un
+	brfalse fail
+
+	ldsfld	native uint _cgt_u::all
+	ldsfld	native uint _cgt_u::even
+	cgt.un
+	brfalse fail
+
+	ldsfld	native uint _cgt_u::none
+	ldsfld	native uint _cgt_u::all
+	cgt.un
+	brtrue fail
+
+	ldsfld	native uint _cgt_u::none
+	ldsfld	native uint _cgt_u::none
+	cgt.un
+	brtrue fail
+
+	ldsfld	native uint _cgt_u::none
+	ldsfld	native uint _cgt_u::odd
+	cgt.un
+	brtrue fail
+
+	ldsfld	native uint _cgt_u::none
+	ldsfld	native uint _cgt_u::even
+	cgt.un
+	brtrue fail
+
+	ldsfld	native uint _cgt_u::odd
+	ldsfld	native uint _cgt_u::all
+	cgt.un
+	brtrue fail
+
+	ldsfld	native uint _cgt_u::odd
+	ldsfld	native uint _cgt_u::none
+	cgt.un
+	brfalse fail
+
+	ldsfld	native uint _cgt_u::odd
+	ldsfld	native uint _cgt_u::odd
+	cgt.un
+	brtrue fail
+
+	ldsfld	native uint _cgt_u::odd
+	ldsfld	native uint _cgt_u::even
+	cgt.un
+	brtrue fail
+
+	ldsfld	native uint _cgt_u::even
+	ldsfld	native uint _cgt_u::all
+	cgt.un
+	brtrue fail
+
+	ldsfld	native uint _cgt_u::even
+	ldsfld	native uint _cgt_u::none
+	cgt.un
+	brfalse fail
+
+	ldsfld	native uint _cgt_u::even
+	ldsfld	native uint _cgt_u::odd
+	cgt.un
+	brfalse fail
+
+	ldsfld	native uint _cgt_u::even
+	ldsfld	native uint _cgt_u::even
+	cgt.un
+	brtrue fail
+
+pass:
+	ldc.i4 0x0000
+	ret
+fail:
+	ldc.i4 0x0001
+	ret
+}
+}

--- a/Tests/ILCompiler.IntegrationTests/il_bvt/clt_i.il
+++ b/Tests/ILCompiler.IntegrationTests/il_bvt/clt_i.il
@@ -1,0 +1,302 @@
+﻿.assembly extern System.Private.CoreLib as mscorlib
+{
+    .ver 0:0:0:0
+}
+.assembly TestAssembly
+{
+}
+.class public _clt_i {
+
+.field public static	native int min
+.field public static	native int _one
+.field public static	native int zero
+.field public static	native int one
+.field public static	native int max
+.field public static	native int odd
+.field public static	native int even
+
+.method public static	void initialize() {
+.maxstack	10
+	ldc.i4		0x00008000
+	conv.i
+	stsfld	native int _clt_i::min
+	ldc.i4		0x0000FFFF
+	conv.i
+	stsfld	native int _clt_i::_one
+	ldc.i4		0x00000000
+	conv.i
+	stsfld	native int _clt_i::zero
+	ldc.i4		0x00000001
+	conv.i
+	stsfld	native int _clt_i::one
+	ldc.i4		0x00007FFF
+	conv.i
+	stsfld	native int _clt_i::max
+	ldc.i4		0x00005555
+	conv.i
+	stsfld	native int _clt_i::odd
+	ldc.i4		0x0000AAAA
+	conv.i
+	stsfld	native int _clt_i::even
+	ret
+}
+
+.method public static int32 Main() {
+.entrypoint
+.maxstack 10
+
+	call	void _clt_i::initialize()
+
+	ldsfld	native int _clt_i::min
+	ldsfld	native int _clt_i::min
+	clt
+	brtrue fail
+
+	ldsfld	native int _clt_i::min
+	ldsfld	native int _clt_i::_one
+	clt
+	brfalse fail
+
+	ldsfld	native int _clt_i::min
+	ldsfld	native int _clt_i::zero
+	clt
+	brfalse fail
+
+	ldsfld	native int _clt_i::min
+	ldsfld	native int _clt_i::one
+	clt
+	brfalse fail
+
+	ldsfld	native int _clt_i::min
+	ldsfld	native int _clt_i::max
+	clt
+	brfalse fail
+
+	ldsfld	native int _clt_i::min
+	ldsfld	native int _clt_i::odd
+	clt
+	brfalse fail
+
+	ldsfld	native int _clt_i::min
+	ldsfld	native int _clt_i::even
+	clt
+	brfalse fail
+
+	ldsfld	native int _clt_i::_one
+	ldsfld	native int _clt_i::min
+	clt
+	brtrue fail
+
+	ldsfld	native int _clt_i::_one
+	ldsfld	native int _clt_i::_one
+	clt
+	brtrue fail
+
+	ldsfld	native int _clt_i::_one
+	ldsfld	native int _clt_i::zero
+	clt
+	brfalse fail
+
+	ldsfld	native int _clt_i::_one
+	ldsfld	native int _clt_i::one
+	clt
+	brfalse fail
+
+	ldsfld	native int _clt_i::_one
+	ldsfld	native int _clt_i::max
+	clt
+	brfalse fail
+
+	ldsfld	native int _clt_i::_one
+	ldsfld	native int _clt_i::odd
+	clt
+	brfalse fail
+
+	ldsfld	native int _clt_i::_one
+	ldsfld	native int _clt_i::even
+	clt
+	brtrue fail
+
+	ldsfld	native int _clt_i::zero
+	ldsfld	native int _clt_i::min
+	clt
+	brtrue fail
+
+	ldsfld	native int _clt_i::zero
+	ldsfld	native int _clt_i::_one
+	clt
+	brtrue fail
+
+	ldsfld	native int _clt_i::zero
+	ldsfld	native int _clt_i::zero
+	clt
+	brtrue fail
+
+	ldsfld	native int _clt_i::zero
+	ldsfld	native int _clt_i::one
+	clt
+	brfalse fail
+
+	ldsfld	native int _clt_i::zero
+	ldsfld	native int _clt_i::max
+	clt
+	brfalse fail
+
+	ldsfld	native int _clt_i::zero
+	ldsfld	native int _clt_i::odd
+	clt
+	brfalse fail
+
+	ldsfld	native int _clt_i::zero
+	ldsfld	native int _clt_i::even
+	clt
+	brtrue fail
+
+	ldsfld	native int _clt_i::one
+	ldsfld	native int _clt_i::min
+	clt
+	brtrue fail
+
+	ldsfld	native int _clt_i::one
+	ldsfld	native int _clt_i::_one
+	clt
+	brtrue fail
+
+	ldsfld	native int _clt_i::one
+	ldsfld	native int _clt_i::zero
+	clt
+	brtrue fail
+
+	ldsfld	native int _clt_i::one
+	ldsfld	native int _clt_i::one
+	clt
+	brtrue fail
+
+	ldsfld	native int _clt_i::one
+	ldsfld	native int _clt_i::max
+	clt
+	brfalse fail
+
+	ldsfld	native int _clt_i::one
+	ldsfld	native int _clt_i::odd
+	clt
+	brfalse fail
+
+	ldsfld	native int _clt_i::one
+	ldsfld	native int _clt_i::even
+	clt
+	brtrue fail
+
+	ldsfld	native int _clt_i::max
+	ldsfld	native int _clt_i::min
+	clt
+	brtrue fail
+
+	ldsfld	native int _clt_i::max
+	ldsfld	native int _clt_i::_one
+	clt
+	brtrue fail
+
+	ldsfld	native int _clt_i::max
+	ldsfld	native int _clt_i::zero
+	clt
+	brtrue fail
+
+	ldsfld	native int _clt_i::max
+	ldsfld	native int _clt_i::one
+	clt
+	brtrue fail
+
+	ldsfld	native int _clt_i::max
+	ldsfld	native int _clt_i::max
+	clt
+	brtrue fail
+
+	ldsfld	native int _clt_i::max
+	ldsfld	native int _clt_i::odd
+	clt
+	brtrue fail
+
+	ldsfld	native int _clt_i::max
+	ldsfld	native int _clt_i::even
+	clt
+	brtrue fail
+
+	ldsfld	native int _clt_i::odd
+	ldsfld	native int _clt_i::min
+	clt
+	brtrue fail
+
+	ldsfld	native int _clt_i::odd
+	ldsfld	native int _clt_i::_one
+	clt
+	brtrue fail
+
+	ldsfld	native int _clt_i::odd
+	ldsfld	native int _clt_i::zero
+	clt
+	brtrue fail
+
+	ldsfld	native int _clt_i::odd
+	ldsfld	native int _clt_i::one
+	clt
+	brtrue fail
+
+	ldsfld	native int _clt_i::odd
+	ldsfld	native int _clt_i::max
+	clt
+	brfalse fail
+
+	ldsfld	native int _clt_i::odd
+	ldsfld	native int _clt_i::odd
+	clt
+	brtrue fail
+
+	ldsfld	native int _clt_i::odd
+	ldsfld	native int _clt_i::even
+	clt
+	brtrue fail
+
+	ldsfld	native int _clt_i::even
+	ldsfld	native int _clt_i::min
+	clt
+	brtrue fail
+
+	ldsfld	native int _clt_i::even
+	ldsfld	native int _clt_i::_one
+	clt
+	brfalse fail
+
+	ldsfld	native int _clt_i::even
+	ldsfld	native int _clt_i::zero
+	clt
+	brfalse fail
+
+	ldsfld	native int _clt_i::even
+	ldsfld	native int _clt_i::one
+	clt
+	brfalse fail
+
+	ldsfld	native int _clt_i::even
+	ldsfld	native int _clt_i::max
+	clt
+	brfalse fail
+
+	ldsfld	native int _clt_i::even
+	ldsfld	native int _clt_i::odd
+	clt
+	brfalse fail
+
+	ldsfld	native int _clt_i::even
+	ldsfld	native int _clt_i::even
+	clt
+	brtrue fail
+
+pass:
+	ldc.i4 0x0000
+	ret
+fail:
+	ldc.i4 0x0001
+	ret
+}
+}

--- a/Tests/ILCompiler.IntegrationTests/il_bvt/clt_u.il
+++ b/Tests/ILCompiler.IntegrationTests/il_bvt/clt_u.il
@@ -1,0 +1,126 @@
+﻿.assembly extern System.Private.CoreLib as mscorlib
+{
+    .ver 0:0:0:0
+}
+.assembly TestAssembly
+{
+}
+.class public _clt_u {
+
+.field public static	native uint all
+.field public static	native uint none
+.field public static	native uint odd
+.field public static	native uint even
+
+.method public static	void initialize() {
+.maxstack	10
+	ldc.i4		0xFFFFFFFF
+	conv.u
+	stsfld	native uint _clt_u::all
+	ldc.i4		0x00000000
+	conv.u
+	stsfld	native uint _clt_u::none
+	ldc.i4		0x55555555
+	conv.u
+	stsfld	native uint _clt_u::odd
+	ldc.i4		0xAAAAAAAA
+	conv.u
+	stsfld	native uint _clt_u::even
+	ret
+}
+
+
+.method public static int32 Main() {
+.entrypoint
+.maxstack 10
+
+	call	void _clt_u::initialize()
+
+	ldsfld	native uint _clt_u::all
+	ldsfld	native uint _clt_u::all
+	clt.un
+	brtrue fail
+
+	ldsfld	native uint _clt_u::all
+	ldsfld	native uint _clt_u::none
+	clt.un
+	brtrue fail
+
+	ldsfld	native uint _clt_u::all
+	ldsfld	native uint _clt_u::odd
+	clt.un
+	brtrue fail
+
+	ldsfld	native uint _clt_u::all
+	ldsfld	native uint _clt_u::even
+	clt.un
+	brtrue fail
+
+	ldsfld	native uint _clt_u::none
+	ldsfld	native uint _clt_u::all
+	clt.un
+	brfalse fail
+
+	ldsfld	native uint _clt_u::none
+	ldsfld	native uint _clt_u::none
+	clt.un
+	brtrue fail
+
+	ldsfld	native uint _clt_u::none
+	ldsfld	native uint _clt_u::odd
+	clt.un
+	brfalse fail
+
+	ldsfld	native uint _clt_u::none
+	ldsfld	native uint _clt_u::even
+	clt.un
+	brfalse fail
+
+	ldsfld	native uint _clt_u::odd
+	ldsfld	native uint _clt_u::all
+	clt.un
+	brfalse fail
+
+	ldsfld	native uint _clt_u::odd
+	ldsfld	native uint _clt_u::none
+	clt.un
+	brtrue fail
+
+	ldsfld	native uint _clt_u::odd
+	ldsfld	native uint _clt_u::odd
+	clt.un
+	brtrue fail
+
+	ldsfld	native uint _clt_u::odd
+	ldsfld	native uint _clt_u::even
+	clt.un
+	brfalse fail
+
+	ldsfld	native uint _clt_u::even
+	ldsfld	native uint _clt_u::all
+	clt.un
+	brfalse fail
+
+	ldsfld	native uint _clt_u::even
+	ldsfld	native uint _clt_u::none
+	clt.un
+	brtrue fail
+
+	ldsfld	native uint _clt_u::even
+	ldsfld	native uint _clt_u::odd
+	clt.un
+	brtrue fail
+
+	ldsfld	native uint _clt_u::even
+	ldsfld	native uint _clt_u::even
+	clt.un
+	brtrue fail
+
+pass:
+	ldc.i4 0x0000
+	ret
+fail:
+	ldc.i4 0x0001
+	ret
+}
+}


### PR DESCRIPTION
Add tests for cgt and clt to cover changes.

This fixes remaining issues with #581