### PR TITLE
EqualityComparer<T>.Default improvements

### DIFF
--- a/CSharp-80.sln
+++ b/CSharp-80.sln
@@ -207,6 +207,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GenericConstrainedCall", "T
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Linq.Tests", "Tests\CoreLib\System.Linq.Tests\System.Linq.Tests.csproj", "{271614EC-F2F0-12C7-C5A8-A6FD9D88985D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Collections.Tests", "Tests\CoreLib\System.Collections.Tests\System.Collections.Tests.csproj", "{2A3F21F8-AECB-178B-70EC-FF459814810F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -521,6 +523,10 @@ Global
 		{271614EC-F2F0-12C7-C5A8-A6FD9D88985D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{271614EC-F2F0-12C7-C5A8-A6FD9D88985D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{271614EC-F2F0-12C7-C5A8-A6FD9D88985D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2A3F21F8-AECB-178B-70EC-FF459814810F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2A3F21F8-AECB-178B-70EC-FF459814810F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2A3F21F8-AECB-178B-70EC-FF459814810F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2A3F21F8-AECB-178B-70EC-FF459814810F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -609,6 +615,7 @@ Global
 		{1966FCB9-03C0-A419-0C0A-EC1319A5E25B} = {2076ADF1-E63E-4A71-AF00-DCD6570B5ECF}
 		{5D0B35F5-C8BE-BDA7-E493-2BB0AEF0A834} = {35C20505-0FCB-4D27-AFC5-A0B1071C268F}
 		{271614EC-F2F0-12C7-C5A8-A6FD9D88985D} = {2076ADF1-E63E-4A71-AF00-DCD6570B5ECF}
+		{2A3F21F8-AECB-178B-70EC-FF459814810F} = {2076ADF1-E63E-4A71-AF00-DCD6570B5ECF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8386495B-97A2-4105-9FFF-71902F2E61B8}

--- a/ILCompiler/IL/RTILProvider.cs
+++ b/ILCompiler/IL/RTILProvider.cs
@@ -44,6 +44,14 @@ namespace ILCompiler.IL
                         }
                     }
                     break;
+                case "EqualityComparer`1":
+                    {
+                        if (declaringType.Namespace == "System.Collections.Generic")
+                        {
+                            return ComparerIntrinsics.EmitEqualityComparer(method);
+                        }
+                    }
+                    break;
             }
 
             return null;

--- a/ILCompiler/IL/Stubs/ComparerIntrinsics.cs
+++ b/ILCompiler/IL/Stubs/ComparerIntrinsics.cs
@@ -1,11 +1,58 @@
 ﻿using ILCompiler.TypeSystem.Canon;
 using ILCompiler.TypeSystem.Common;
+using ILCompiler.TypeSystem.IL;
 using System.Diagnostics;
 
 namespace ILCompiler.IL.Stubs
 {
     internal static class ComparerIntrinsics
     {
+        public static MethodIL? EmitEqualityComparer(MethodDesc method)
+        {
+            return EmitComparerAndEqualityComparerCreateCommon(method, "EqualityComparer", "IEquatable`1");
+        }
+
+        private static MethodIL? EmitComparerAndEqualityComparerCreateCommon(MethodDesc methodBeingGenerated, string flavor, string interfaceName)
+        {
+            var owningType = methodBeingGenerated.OwningType;
+            var comparedType = owningType.Instantiation![0];
+
+            if (comparedType.IsCanonicalSubtype(CanonicalFormKind.Any))
+                throw new NotImplementedException("No support for using type loader to load proper EqualityComparer");
+
+            var comparerType = GetComparerForType(comparedType, flavor, interfaceName);
+
+            var body = new MethodIL();
+
+            var comparerTypeCtor = comparerType.GetKnownMethod(".ctor");
+
+            body.Instructions.Add(new Instruction(ILOpcode.newobj, 0, comparerTypeCtor));
+            body.Instructions.Add(new Instruction(ILOpcode.ret, 1));
+
+            return body;
+        }
+
+        private static TypeDesc GetComparerForType(TypeDesc type, string flavor, string interfaceName)
+        {
+            var context = type.Context;
+
+            if (context.IsCanonicalDefinitionType(type, CanonicalFormKind.Any) || (type.IsRuntimeDeterminedSubtype && !type.HasInstantiation))
+            {
+                // Can't determine the exact type for the comparer at compile time.
+                throw new NotImplementedException("Runtime determined comparer types not supported");
+            }
+
+            bool? implementsInterfaceOfSelf = ImplementsInterfaceOfSelf(type, interfaceName);
+            if (implementsInterfaceOfSelf is null)
+            {
+                throw new ArgumentException($"Type {type.FullName} does not implement {interfaceName}");
+            }
+
+            var comparerTypeName = (bool)implementsInterfaceOfSelf ? $"Generic{flavor}`1" : $"Object{flavor}`1";
+            return context.SystemModule!.GetKnownType("System.Collections.Generic", comparerTypeName).MakeInstantiatedType(type);
+        }
+
+
         public static bool? ImplementsIEquatable(TypeDesc type) => ImplementsInterfaceOfSelf(type, "IEquatable`1");
 
         private static bool? ImplementsInterfaceOfSelf(TypeDesc type, string interfaceName)

--- a/ILCompiler/TypeSystem/Common/InstantiatedType.cs
+++ b/ILCompiler/TypeSystem/Common/InstantiatedType.cs
@@ -133,6 +133,8 @@ namespace ILCompiler.TypeSystem.Common
 
         public override string Name => _typeDef.Name;
 
+        public override string Namespace => _typeDef.Namespace;
+
         public override bool IsValueType => _typeDef.IsValueType;
 
         public override bool IsInterface => _typeDef.IsInterface;

--- a/ILCompiler/TypeSystem/Common/InstantiatedType.cs
+++ b/ILCompiler/TypeSystem/Common/InstantiatedType.cs
@@ -137,6 +137,16 @@ namespace ILCompiler.TypeSystem.Common
 
         public override bool IsInterface => _typeDef.IsInterface;
 
+        public override bool HasStaticConstructor => _typeDef.HasStaticConstructor;
+
+        public override MethodDesc? GetStaticConstructor()
+        {
+            var typicalCctor = _typeDef.GetStaticConstructor();
+            if (typicalCctor == null)
+                return null;
+            return _typeDef.Context.GetMethodForInstantiatedType(typicalCctor, this);
+        }
+
         private MetadataType? _baseType;
 
         private MetadataType? InitializeBaseType()

--- a/ILCompiler/TypeSystem/Common/MethodForInstantiatedType.cs
+++ b/ILCompiler/TypeSystem/Common/MethodForInstantiatedType.cs
@@ -79,6 +79,7 @@ namespace ILCompiler.TypeSystem.Common
         public override bool IsVirtual => _typicalMethodDef.IsVirtual;
         public override bool IsAbstract => _typicalMethodDef.IsAbstract;
 
+        public override bool IsIntrinsic => _typicalMethodDef.IsIntrinsic;
         public override MethodDesc CreateUserMethod(string name) => throw new NotImplementedException();
 
         public override MethodDesc GetTypicalMethodDefinition() => _typicalMethodDef;

--- a/System.Private.CoreLib/System/Collections/Generic/EqualityComparer.cs
+++ b/System.Private.CoreLib/System/Collections/Generic/EqualityComparer.cs
@@ -4,16 +4,15 @@ namespace System.Collections.Generic
 {
     public abstract class EqualityComparer<T> : IEqualityComparer, IEqualityComparer<T>
     {
-        public static EqualityComparer<T> Default
+        // TODO: Use Intrinsic to pick appropraite comparer here
+        [Intrinsic]
+        private static EqualityComparer<T> Create()
         {
-            [Intrinsic]
-            get
-            {
-                // TODO: Use Intrinsic to pick appropriate comparer here
-                return new ObjectEqualityComparer<T>();
-            }
+            Console.WriteLine("Creating ObjectEqualityComparer");
+            return new ObjectEqualityComparer<T>();
         }
 
+        public static EqualityComparer<T> Default { get; } = Create();
         public abstract bool Equals(T? x, T? y);
         public abstract int GetHashCode(T obj);
 

--- a/System.Private.CoreLib/System/Collections/Generic/EqualityComparer.cs
+++ b/System.Private.CoreLib/System/Collections/Generic/EqualityComparer.cs
@@ -4,7 +4,7 @@ namespace System.Collections.Generic
 {
     public abstract class EqualityComparer<T> : IEqualityComparer, IEqualityComparer<T>
     {
-        // TODO: Use Intrinsic to pick appropraite comparer here
+        // TODO: Use Intrinsic to pick appropriate comparer here
         [Intrinsic]
         private static EqualityComparer<T> Create()
         {

--- a/System.Private.CoreLib/System/Collections/Generic/EqualityComparer.cs
+++ b/System.Private.CoreLib/System/Collections/Generic/EqualityComparer.cs
@@ -4,12 +4,10 @@ namespace System.Collections.Generic
 {
     public abstract class EqualityComparer<T> : IEqualityComparer, IEqualityComparer<T>
     {
-        // TODO: Use Intrinsic to pick appropriate comparer here
         [Intrinsic]
         private static EqualityComparer<T> Create()
         {
-            Console.WriteLine("Creating ObjectEqualityComparer");
-            return new ObjectEqualityComparer<T>();
+            throw new Exception();
         }
 
         public static EqualityComparer<T> Default { get; } = Create();
@@ -32,6 +30,32 @@ namespace System.Collections.Generic
     }
 
     public sealed class ObjectEqualityComparer<T> : EqualityComparer<T>
+    {
+        public override bool Equals(T x, T y)
+        {
+            if (x is not null)
+            {
+                if (y is not null) return x.Equals(y);
+                return false;
+            }
+            if (y is not null) return false;
+            return true;
+        }
+
+        public override bool Equals(object? obj) => throw new NotImplementedException();
+
+        public override int GetHashCode(T obj)
+        {
+            if (obj is not null)
+                return obj.GetHashCode();
+
+            return 0;
+        }
+
+        public override int GetHashCode() => throw new NotImplementedException();
+    }
+
+    public sealed class GenericEqualityComparer<T> : EqualityComparer<T> where T : IEquatable<T>
     {
         public override bool Equals(T x, T y)
         {

--- a/Tests/CoreLib/System.Collections.Tests/Assert.cs
+++ b/Tests/CoreLib/System.Collections.Tests/Assert.cs
@@ -1,0 +1,75 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace System.Collections.Tests
+{
+    internal static class Assert
+    {
+        public static void AreEnumerablesEqual<T>(IEnumerable<T> expected, IEnumerable<T> actual)
+        {
+            Assert.AreEqual(expected.Count(), actual.Count());
+
+            var expectedEnumerator = expected.GetEnumerator();
+            var actualEnumerator = actual.GetEnumerator();
+            while (expectedEnumerator.MoveNext() && actualEnumerator.MoveNext())
+            {
+                Assert.AreEqual(expectedEnumerator.Current, actualEnumerator.Current);
+            }
+        }
+
+        public static void AreEqual(RuntimeTypeHandle expected, RuntimeTypeHandle actual)
+        {
+            if (!expected.Equals(actual))
+            {
+                Environment.Exit(1);
+            }
+        }
+
+        public static void AreEqual<T>(T expected, T actual)
+        {
+            if (expected is null)
+            {
+                if (actual is not null)
+                {
+                    Environment.Exit(1);
+                }
+            }
+            else if (!expected.Equals(actual))
+            {
+                Environment.Exit(1);
+            }
+        }
+
+        public static void AreNotEqual(RuntimeTypeHandle expected, RuntimeTypeHandle actual)
+        {
+            if (expected.Equals(actual))
+            {
+                Environment.Exit(1);
+            }
+        }
+
+        public static void IsFalse(bool condition)
+        {
+            if (condition)
+            {
+                Environment.Exit(1);
+            }
+        }
+
+        public static void IsTrue(bool condition)
+        {
+            if (!condition)
+            {
+                Environment.Exit(1);
+            }
+        }
+
+        public static void IsNotNull(object obj)
+        {
+            if (obj == null)
+            {
+                Environment.Exit(1);
+            }
+        }
+    }
+}

--- a/Tests/CoreLib/System.Collections.Tests/EqualityComparerTests.cs
+++ b/Tests/CoreLib/System.Collections.Tests/EqualityComparerTests.cs
@@ -1,0 +1,74 @@
+﻿using System.Collections.Generic;
+
+namespace System.Collections.Tests
+{
+    static class EqualityComparerTests
+    {
+        public class DefaultType { }
+
+        public static void Default_ForType_CreatesNoMoreThanOneComparerInstance()
+        {
+            _ = EqualityComparer<DefaultType>.Default;
+            var afterComparerCreation = GC.GetTotalMemory();
+            for (int i = 0; i < 10; i++)
+            {
+                _ = EqualityComparer<DefaultType>.Default;
+            }
+            var afterAllComparerRequests = GC.GetTotalMemory();
+            Assert.AreEqual(afterComparerCreation, afterAllComparerRequests);
+        }
+
+        public static void EqualsTests()
+        {
+            EqualsTest<byte>(3, 3, true);
+            EqualsTest<byte>(3, 4, false);
+            EqualsTest<byte>(0, 255, false);
+            EqualsTest<byte>(0, 128, false);
+            EqualsTest<byte>(255, 255, true);
+
+            EqualsTest<Int32>(3, 3, true);
+            EqualsTest<Int32>(3, 5, false);
+            EqualsTest<Int32>(int.MinValue + 1, 1, false);
+            EqualsTest<Int32>(int.MinValue, int.MinValue, true);
+
+            Equatable one = new Equatable(1);
+
+            EqualsTest<Equatable>(one, one, true);
+            EqualsTest<Equatable>(one, new Equatable(1), true);
+            EqualsTest<Equatable>(new Equatable(int.MinValue + 1), new Equatable(1), false);
+            EqualsTest<Equatable>(new Equatable(-1), new Equatable(int.MaxValue), false);
+
+            var obj = new object();
+
+            EqualsTest<object>(obj, obj, true);
+            EqualsTest<object>(obj, new object(), false);
+            EqualsTest<object>(obj, null, false);
+        }
+
+        private static void EqualsTest<T>(T? left, T? right, bool expected)
+        {
+            var comparer = EqualityComparer<T>.Default;
+
+            // Commutative tests
+            Assert.AreEqual(expected, comparer.Equals(left, right));
+            Assert.AreEqual(expected, comparer.Equals(right, left));
+
+            // Reflexive tests
+            Assert.IsTrue(comparer.Equals(left, left));
+            Assert.IsTrue(comparer.Equals(right, right));
+
+            if (default(T) is null)
+            {
+                T? nil = default;
+
+                Assert.IsTrue(comparer.Equals(nil, nil));
+
+                Assert.AreEqual(left is null, comparer.Equals(left, nil));
+                Assert.AreEqual(left is null, comparer.Equals(nil, left));
+
+                Assert.AreEqual(right is null, comparer.Equals(right, nil));
+                Assert.AreEqual(right is null, comparer.Equals(nil, right));
+            }
+        }
+    }
+}

--- a/Tests/CoreLib/System.Collections.Tests/System.Collections.Tests.csproj
+++ b/Tests/CoreLib/System.Collections.Tests/System.Collections.Tests.csproj
@@ -1,0 +1,35 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+	 <Nullable>enable</Nullable>
+
+    <RuntimeMetadataVersion>v4.0.30319</RuntimeMetadataVersion>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+        
+    <!--Disable .NET Core SDK libs-->
+    <NoStdLib>true</NoStdLib>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+	  <!-- Prevent .NET Core 3+ from generating exe -->
+	  <UseAppHost>false</UseAppHost>
+
+	  <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="System\**" />
+    <EmbeddedResource Remove="System\**" />
+    <None Remove="System\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\System.Private.CoreLib\System.Private.CoreLib.csproj" />
+    <ProjectReference Include="..\..\..\ILCompiler\ILCompiler.csproj" />
+  </ItemGroup>
+  
+</Project>

--- a/Tests/CoreLib/System.Collections.Tests/SystemCollectionsTests.cs
+++ b/Tests/CoreLib/System.Collections.Tests/SystemCollectionsTests.cs
@@ -1,0 +1,13 @@
+﻿namespace System.Collections.Tests
+{
+    public static class SystemCollectionsTests
+    {
+        public static int Main()
+        {
+            EqualityComparerTests.Default_ForType_CreatesNoMoreThanOneComparerInstance();
+            EqualityComparerTests.EqualsTests();
+
+            return 0;
+        }
+    }
+}

--- a/Tests/CoreLib/System.Collections.Tests/TestingTypes.cs
+++ b/Tests/CoreLib/System.Collections.Tests/TestingTypes.cs
@@ -1,0 +1,19 @@
+﻿namespace System.Collections.Tests
+{
+    public class Equatable : IEquatable<Equatable>
+    {
+        public Equatable(int value)
+        {
+            Value = value;
+        }
+
+        public int Value { get; }
+
+        public bool Equals(Equatable? other)
+        {
+            return other != null && Value == other.Value;
+        }
+
+        public override int GetHashCode() => Value;
+    }
+}


### PR DESCRIPTION
Ensure a comparer is created at most once.
Add GenericEqualityComparer<T>
Implement EqualityComparer<T>.Create as intrinsic to pick appropriate comparer to use.

Contributes to #555 