### PR TITLE
Fix test names as VS groups tests if they have dots in the name.

### DIFF
--- a/Tests/CodeGen/CodeGenTestsRunner/CodeGenTestsRunner.cs
+++ b/Tests/CodeGen/CodeGenTestsRunner/CodeGenTestsRunner.cs
@@ -33,7 +33,11 @@ namespace CodeGenTests
                         var temp = Path.Combine(binConfigTargetPath, $"{codeGenTestName}.cim");
                         var testAssemblyPath = Path.Combine(codeGenTestPath, temp);
 
-                        yield return new TestCaseData(testAssemblyPath).SetName(Path.GetFileNameWithoutExtension(codeGenTestName));
+                        // Visual Studio doesn't like .'s in test names so replace with a character that looks like a dot but isn't
+                        var testName = Path.GetFileNameWithoutExtension(codeGenTestName);
+                        testName = testName.Replace('.', '\u2024');
+
+                        yield return new TestCaseData(testAssemblyPath).SetName(testName);
                     }
                 }
             }

--- a/Tests/CoreLib/CoreLibTestsRunner/CoreLibTestsRunner.cs
+++ b/Tests/CoreLib/CoreLibTestsRunner/CoreLibTestsRunner.cs
@@ -35,6 +35,9 @@ namespace CoreLibTests
                             var temp = Path.Combine(binConfigTargetPath, $"{coreLibTestName}.cim");
                             var testAssemblyPath = Path.Combine(coreLibTestPath, temp);
 
+                            // Visual Studio doesn't like .'s in test names so replace with a character that looks like a dot but isn't
+                            coreLibTestName = coreLibTestName.Replace('.', '\u2024');
+
                             yield return new TestCaseData(testAssemblyPath).SetName(coreLibTestName);
                         }
                     }

--- a/Tests/Directed/DirectedTestsRunner/DirectedTestsRunner.cs
+++ b/Tests/Directed/DirectedTestsRunner/DirectedTestsRunner.cs
@@ -33,7 +33,11 @@ namespace DirectedTests
                         var temp = Path.Combine(binConfigTargetPath, $"{directedTestName}.cim");
                         var testAssemblyPath = Path.Combine(directedTestPath, temp);
 
-                        yield return new TestCaseData(testAssemblyPath).SetName(Path.GetFileNameWithoutExtension(directedTestName));
+                        // Visual Studio doesn't like .'s in test names so replace with a character that looks like a dot but isn't
+                        var testName = Path.GetFileNameWithoutExtension(directedTestName);
+                        testName = testName.Replace('.', '\u2024');
+
+                        yield return new TestCaseData(testAssemblyPath).SetName(testName);
                     }
                 }
             }

--- a/Tests/Generics/GenericsTestsRunner/GenericsTestsRunner.cs
+++ b/Tests/Generics/GenericsTestsRunner/GenericsTestsRunner.cs
@@ -32,7 +32,11 @@ namespace GenericsTests
                         var temp = Path.Combine(binConfigTargetPath, $"{genericsTestName}.cim");
                         var testAssemblyPath = Path.Combine(genericsTestPath, temp);
 
-                        yield return new TestCaseData(testAssemblyPath).SetName(Path.GetFileNameWithoutExtension(genericsTestName));
+                        // Visual Studio doesn't like .'s in test names so replace with a character that looks like a dot but isn't
+                        var testName = Path.GetFileNameWithoutExtension(genericsTestName);
+                        testName = testName.Replace('.', '\u2024');
+
+                        yield return new TestCaseData(testAssemblyPath).SetName(testName);
                     }
                 }
             }

--- a/Tests/ILCompiler.IntegrationTests/ILBvtTests.cs
+++ b/Tests/ILCompiler.IntegrationTests/ILBvtTests.cs
@@ -42,7 +42,11 @@ namespace CSharp80.Tests.BVT
                     var targetFilePath = Path.Combine(@".\il_bvt", Path.GetFileName(file));
                     File.Copy(file, targetFilePath, true);
 
-                    yield return new TestCaseData(targetFilePath).SetName(Path.GetFileNameWithoutExtension(targetFilePath));
+                    // Visual Studio doesn't like .'s in test names so replace with a character that looks like a dot but isn't
+                    var testName = Path.GetFileNameWithoutExtension(targetFilePath);
+                    testName = testName.Replace('.', '\u2024');
+
+                    yield return new TestCaseData(targetFilePath).SetName(testName);
                 }
             }
         }

--- a/Tests/Methodical/MethodicalTestsRunner/MethodicalTestsRunner.cs
+++ b/Tests/Methodical/MethodicalTestsRunner/MethodicalTestsRunner.cs
@@ -61,7 +61,11 @@ namespace MethodicalTests
                             var temp = Path.Combine(binConfigTargetPath, $"{methodicalTestName}{CimExtension}");
                             var testAssemblyPath = Path.Combine(methodicalTestPath, temp);
 
-                            yield return new TestCaseData(testAssemblyPath).SetName(methodicalTestName);
+                            // Visual Studio doesn't like .'s in test names so replace with a character that looks like a dot but isn't
+                            var testName = Path.GetFileNameWithoutExtension(methodicalTestName);
+                            testName = testName.Replace('.', '\u2024');
+
+                            yield return new TestCaseData(testAssemblyPath).SetName(testName);
                         }
                         else
                         {
@@ -72,6 +76,9 @@ namespace MethodicalTests
                                 var testAssemblyPath = Path.Combine(methodicalTestPath, temp);
 
                                 var testName = $"{methodicalTestName} ({Path.GetFileNameWithoutExtension(ilFile)})";
+
+                                // Visual Studio doesn't like .'s in test names so replace with a character that looks like a dot but isn't
+                                testName = testName.Replace('.', '\u2024');
 
                                 yield return new TestCaseData(testAssemblyPath).SetName(testName);
                             }

--- a/Tests/Performance/CodeQuality/Benchmarks/BenchmarkTestsRunner/BenchmarkTestsRunner.cs
+++ b/Tests/Performance/CodeQuality/Benchmarks/BenchmarkTestsRunner/BenchmarkTestsRunner.cs
@@ -61,7 +61,11 @@ namespace BenchmarkTests
                             var temp = Path.Combine(binConfigTargetPath, $"{methodicalTestName}{CimExtension}");
                             var testAssemblyPath = Path.Combine(methodicalTestPath, temp);
 
-                            yield return new TestCaseData(testAssemblyPath).SetName(methodicalTestName);
+                            // Visual Studio doesn't like .'s in test names so replace with a character that looks like a dot but isn't
+                            var testName = Path.GetFileNameWithoutExtension(methodicalTestName);
+                            testName = testName.Replace('.', '\u2024');
+
+                            yield return new TestCaseData(testAssemblyPath).SetName(testName);
                         }
                         else
                         {
@@ -72,6 +76,9 @@ namespace BenchmarkTests
                                 var testAssemblyPath = Path.Combine(methodicalTestPath, temp);
 
                                 var testName = $"{methodicalTestName} ({Path.GetFileNameWithoutExtension(ilFile)})";
+
+                                // Visual Studio doesn't like .'s in test names so replace with a character that looks like a dot but isn't
+                                testName = testName.Replace('.', '\u2024');
 
                                 yield return new TestCaseData(testAssemblyPath).SetName(testName);
                             }

--- a/Tests/Regression/RegressionTestsRunner/RegressionTestsRunner.cs
+++ b/Tests/Regression/RegressionTestsRunner/RegressionTestsRunner.cs
@@ -32,7 +32,11 @@ namespace RegressionTests
                         var temp = Path.Combine(binConfigTargetPath, $"{regressionTestName}.cim");
                         var testAssemblyPath = Path.Combine(regressionTestPath, temp);
 
-                        yield return new TestCaseData(testAssemblyPath).SetName(Path.GetFileNameWithoutExtension(regressionTestName));
+                        // Visual Studio doesn't like .'s in test names so replace with a character that looks like a dot but isn't
+                        var testName = Path.GetFileNameWithoutExtension(regressionTestName);
+                        testName = testName.Replace('.', '\u2024');
+
+                        yield return new TestCaseData(testAssemblyPath).SetName(testName);
                     }
                 }
             }


### PR DESCRIPTION
Instead of this grouping

![image](https://github.com/user-attachments/assets/cc3a3671-dff0-4580-9fe9-39ffb12e239c)

this PR results in this:

![image](https://github.com/user-attachments/assets/f85b804c-1736-412c-ab04-67fa121678d9)
