### PR TITLE
Handle concurrent tests by making update of benchmark file atomic

### DIFF
--- a/Tests/ILCompiler.Tests.Common/BenchmarkWriter.cs
+++ b/Tests/ILCompiler.Tests.Common/BenchmarkWriter.cs
@@ -61,12 +61,15 @@ namespace ILCompiler.Tests.Common
                 using (var reader = new StreamReader(stream, leaveOpen: true))
                 {
                     var currentJson = reader.ReadToEnd();
-                    benchmarks = JsonSerializer.Deserialize<List<BenchmarkData>>(currentJson, serializeOptions);
-                }
+                    if (currentJson.Length > 0)
+                    {
+                        benchmarks = JsonSerializer.Deserialize<List<BenchmarkData>>(currentJson, serializeOptions);
 
-                if (benchmarks == null)
-                {
-                    throw new NullReferenceException($"Deserialization of benchmark file {_benchmarkResultsPath} failed");
+                        if (benchmarks == null)
+                        {
+                            throw new NullReferenceException($"Deserialization of benchmark file {_benchmarkResultsPath} failed");
+                        }
+                    }
                 }
 
                 benchmarks.Add(new BenchmarkData() { Name = testName, Unit = "T-States", Value = (int)tStates });


### PR DESCRIPTION
Update of benchmark file could result in errors when running multiple tests at same time.
Improve code to make access to benchmark file atomic across the read and write and wrap in simple retry policy.

Previously running tests in release configuration could result in failing tests e.g.

dotnet test --configuration Release .\CSharp-80

This PR resolves this problem and all tests now pass.