### PR TITLE
Group static fields for a type together

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/SymbolConstantCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/SymbolConstantCodeGenerator.cs
@@ -9,7 +9,14 @@ namespace ILCompiler.Compiler.CodeGenerators
         {
             var mangledFieldName = entry.Value;
 
-            context.InstructionsBuilder.Ld(HL, mangledFieldName);
+            if (entry.Offset != 0)
+            {
+                context.InstructionsBuilder.Ld(HL, $"{mangledFieldName} + {entry.Offset}");
+            }
+            else
+            {
+                context.InstructionsBuilder.Ld(HL, mangledFieldName);
+            }
             context.InstructionsBuilder.Push(HL);
         }
     }

--- a/ILCompiler/Compiler/DependencyAnalysis/ILScanner.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/ILScanner.cs
@@ -242,7 +242,8 @@ namespace ILCompiler.Compiler.DependencyAnalysis
                     throw new InvalidProgramException();
                 }
 
-                _dependencies.Add(_context.NodeFactory.StaticsNode(fieldDesc));
+                var metadataType = fieldDesc.OwningType as MetadataType;
+                _dependencies.Add(_context.NodeFactory.StaticsNode(metadataType!));
 
                 if (!_context.PreinitializationManager.IsPreinitialized(fieldDesc.OwningType))
                 {

--- a/ILCompiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -8,7 +8,7 @@ namespace ILCompiler.Compiler.DependencyAnalysis
 {
     public class NodeFactory
     {
-        private readonly IDictionary<string, StaticsNode> _staticNodesByFullName = new Dictionary<string, StaticsNode>();
+        private readonly IDictionary<TypeDesc, StaticsNode> _staticNodes = new Dictionary<TypeDesc, StaticsNode>();
         private readonly IDictionary<MethodDesc, Z80MethodCodeNode> _methodNodesByFullName = new Dictionary<MethodDesc, Z80MethodCodeNode>();
         private readonly IDictionary<string, UnboxingStubNode> _unboxingStubsByFullName = new Dictionary<string, UnboxingStubNode>();
 
@@ -56,12 +56,12 @@ namespace ILCompiler.Compiler.DependencyAnalysis
             return necessaryTypeSymbolNode;
         }
 
-        public StaticsNode StaticsNode(FieldDesc field)
+        public StaticsNode StaticsNode(MetadataType type)
         {
-            if (!_staticNodesByFullName.TryGetValue(field.ToString(), out var staticNode))
+            if (!_staticNodes.TryGetValue(type, out var staticNode))
             {
-                staticNode = new StaticsNode(field, _preinitializationManager, _nameMangler);
-                _staticNodesByFullName[field.ToString()] = staticNode;
+                staticNode = new StaticsNode(type, _preinitializationManager, _nameMangler);
+                _staticNodes[type] = staticNode;
             }
 
             return staticNode;

--- a/ILCompiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -8,16 +8,16 @@ namespace ILCompiler.Compiler.DependencyAnalysis
 {
     public class NodeFactory
     {
-        private readonly IDictionary<TypeDesc, StaticsNode> _staticNodes = new Dictionary<TypeDesc, StaticsNode>();
-        private readonly IDictionary<MethodDesc, Z80MethodCodeNode> _methodNodesByFullName = new Dictionary<MethodDesc, Z80MethodCodeNode>();
-        private readonly IDictionary<string, UnboxingStubNode> _unboxingStubsByFullName = new Dictionary<string, UnboxingStubNode>();
+        private readonly Dictionary<TypeDesc, StaticsNode> _staticNodes = [];
+        private readonly Dictionary<MethodDesc, Z80MethodCodeNode> _methodNodesByFullName = [];
+        private readonly Dictionary<string, UnboxingStubNode> _unboxingStubsByFullName = [];
 
-        private readonly IDictionary<string, VirtualMethodUseNode> _virtualMethodNodesByFullName = new Dictionary<string, VirtualMethodUseNode>();
-        private readonly IDictionary<string, ConstructedEETypeNode> _constructedEETypeNodesByFullName = new Dictionary<string, ConstructedEETypeNode>();
-        private readonly IDictionary<TypeDesc, VTableSliceNode> _vTableNodes = new Dictionary<TypeDesc, VTableSliceNode>();
-        private readonly IDictionary<TypeDesc, EETypeNode> _necessaryTypeSymbolNodes = new Dictionary<TypeDesc, EETypeNode>();
-        private readonly IDictionary<string, FrozenStringNode> _frozenStringNodes = new Dictionary<string, FrozenStringNode>();
-        private readonly IDictionary<FieldDesc, FieldRvaDataNode> _fieldRvaDataNodes = new Dictionary<FieldDesc, FieldRvaDataNode>();
+        private readonly Dictionary<string, VirtualMethodUseNode> _virtualMethodNodesByFullName = [];
+        private readonly Dictionary<string, ConstructedEETypeNode> _constructedEETypeNodesByFullName = [];
+        private readonly Dictionary<TypeDesc, VTableSliceNode> _vTableNodes = [];
+        private readonly Dictionary<TypeDesc, EETypeNode> _necessaryTypeSymbolNodes = [];
+        private readonly Dictionary<string, FrozenStringNode> _frozenStringNodes = [];
+        private readonly Dictionary<FieldDesc, FieldRvaDataNode> _fieldRvaDataNodes = [];
 
         private readonly PreinitializationManager _preinitializationManager;
         private readonly INameMangler _nameMangler;

--- a/ILCompiler/Compiler/DependencyAnalysis/StaticsNode.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/StaticsNode.cs
@@ -8,16 +8,16 @@ namespace ILCompiler.Compiler.DependencyAnalysis
 {
     public class StaticsNode : DependencyNode
     {
-        public FieldDesc Field { get; private set; }
+        private readonly MetadataType _type;
 
-        public override string Name => Field.ToString();
+        public override string Name => $"StaticsNode_{_type.ToString()}";
 
         private readonly PreinitializationManager _preinitializationManager;
         private readonly INameMangler _nameMangler;
 
-        public StaticsNode(FieldDesc field, PreinitializationManager preinitializationManager, INameMangler nameMangler)
+        public StaticsNode(MetadataType type, PreinitializationManager preinitializationManager, INameMangler nameMangler)
         {
-            Field = field;
+            _type = type;
             _preinitializationManager = preinitializationManager;
             _nameMangler = nameMangler;
         }
@@ -26,32 +26,48 @@ namespace ILCompiler.Compiler.DependencyAnalysis
         {
             var instructionsBuilder = new InstructionsBuilder();
 
-            var field = Field;
+            instructionsBuilder.Comment($"Bytes for static fields for type {_type.ToString()}");
 
-            if (_preinitializationManager.IsPreinitialized(field.OwningType))
+            instructionsBuilder.Label(_nameMangler.GetMangledTypeName(_type) + "_" + "statics");
+
+
+            if (_preinitializationManager.IsPreinitialized(_type))
             {
-                var preinitializationInfo = _preinitializationManager.GetPreinitializationInfo(field.OwningType);
-                var value = preinitializationInfo.GetFieldValue(field);
+                var preinitializationInfo = _preinitializationManager.GetPreinitializationInfo(_type);
 
-                // Need to mangle full field name here
-                instructionsBuilder.Label(_nameMangler.GetMangledFieldName(field));
-
-                var bytes = value.GetRawData();
-                foreach (var b in bytes)
+                int byteCount = 0;
+                foreach (var field in _type.GetFields())
                 {
-                    instructionsBuilder.Db(b);
+                    if (!field.IsStatic || field.IsLiteral)
+                        continue;
+
+                    instructionsBuilder.Comment($"Field {field.Name} offset: {field.Offset.AsInt}");
+
+                    int padding = field.Offset.AsInt - byteCount;
+                    instructionsBuilder.Dc((ushort)padding, 0);
+
+                    var value = preinitializationInfo.GetFieldValue(field);
+                    var bytes = value.GetRawData();
+                    foreach (var b in bytes)
+                    {
+                        instructionsBuilder.Db(b);
+                        byteCount++;
+                    }
                 }
             }
             else
             {
-                var fieldSize = field.FieldType.GetElementSize().AsInt;
-                instructionsBuilder.Comment($"Reserving {fieldSize} bytes for static field {field.ToString()}");
+                var staticsSize = _type.StaticFieldSize.AsInt;
 
-                // Need to mangle full field name here
-                instructionsBuilder.Label(_nameMangler.GetMangledFieldName(field));
+                foreach (var field in _type.GetFields())
+                {
+                    if (!field.IsStatic || field.IsLiteral)
+                        continue;
 
-                // Emit fieldSize bytes with value 0
-                instructionsBuilder.Dc((ushort)fieldSize, 0);
+                    instructionsBuilder.Comment($"Field {field.Name} offset: {field.Offset.AsInt}");
+                }
+
+                instructionsBuilder.Dc((ushort)staticsSize, 0);
             }
 
             return instructionsBuilder.Instructions;

--- a/ILCompiler/Compiler/EvaluationStack/ConstantEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/ConstantEntry.cs
@@ -31,13 +31,16 @@
 
     public class SymbolConstantEntry : ConstantEntry<string>
     {
-        public SymbolConstantEntry(String name) : base(VarType.Ptr, name, 2)
+        public int Offset { get; set; } = 0;
+
+        public SymbolConstantEntry(String name, int offset = 0) : base(VarType.Ptr, name, 2)
         {
+            Offset = offset;
         }
 
         public override SymbolConstantEntry Duplicate()
         {
-            return new SymbolConstantEntry(Value);
+            return new SymbolConstantEntry(Value, Offset);
         }
 
         public override void Accept(IStackEntryVisitor visitor)

--- a/ILCompiler/Compiler/Importer/AddressOfFieldImporter.cs
+++ b/ILCompiler/Compiler/Importer/AddressOfFieldImporter.cs
@@ -17,9 +17,8 @@ namespace ILCompiler.Compiler.Importer
 
             if (isLoadStatic)
             {
-                var mangledFieldName = context.NameMangler.GetMangledFieldName(fieldDesc);
-
-                StackEntry obj = new SymbolConstantEntry(mangledFieldName);
+                var staticsBase = context.NameMangler.GetMangledTypeName(fieldDesc.OwningType) + "_statics";
+                StackEntry obj = new SymbolConstantEntry(staticsBase, fieldDesc.Offset.AsInt);
                 if (!context.PreinitializationManager.IsPreinitialized(fieldDesc.OwningType))
                 {
                     obj = InitClassHelper.ImportInitClass(fieldDesc.OwningType, context, importer, obj);

--- a/ILCompiler/Compiler/Importer/LoadFieldImporter.cs
+++ b/ILCompiler/Compiler/Importer/LoadFieldImporter.cs
@@ -1,6 +1,6 @@
-﻿using ILCompiler.TypeSystem.Common;
-using ILCompiler.Compiler.EvaluationStack;
+﻿using ILCompiler.Compiler.EvaluationStack;
 using ILCompiler.Interfaces;
+using ILCompiler.TypeSystem.Common;
 using ILCompiler.TypeSystem.IL;
 
 namespace ILCompiler.Compiler.Importer
@@ -20,14 +20,13 @@ namespace ILCompiler.Compiler.Importer
             StackEntry obj;
             if (isLoadStatic)
             {
-                var mangledFieldName = context.NameMangler.GetMangledFieldName(runtimeDeterminedType);
-                obj = new SymbolConstantEntry(mangledFieldName);
+                var staticsBase = context.NameMangler.GetMangledTypeName(runtimeDeterminedType.OwningType) + "_statics";
+                obj = new SymbolConstantEntry(staticsBase);
 
                 if (!context.PreinitializationManager.IsPreinitialized(runtimeDeterminedType.OwningType))
                 {
                     obj = InitClassHelper.ImportInitClass(runtimeDeterminedType.OwningType, context, importer, obj);
                 }
-                fieldOffset = 0;
             }
             else
             {

--- a/ILCompiler/Compiler/Importer/StoreFieldImporter.cs
+++ b/ILCompiler/Compiler/Importer/StoreFieldImporter.cs
@@ -1,6 +1,6 @@
-﻿using ILCompiler.TypeSystem.Common;
-using ILCompiler.Compiler.EvaluationStack;
+﻿using ILCompiler.Compiler.EvaluationStack;
 using ILCompiler.Interfaces;
+using ILCompiler.TypeSystem.Common;
 using ILCompiler.TypeSystem.IL;
 
 namespace ILCompiler.Compiler.Importer
@@ -20,8 +20,8 @@ namespace ILCompiler.Compiler.Importer
             StackEntry addr;
             if (isStoreStatic)
             {
-                var mangledFieldName = context.NameMangler.GetMangledFieldName(field);
-                addr = new SymbolConstantEntry(mangledFieldName);
+                var staticsBase = context.NameMangler.GetMangledTypeName(field.OwningType) + "_statics";
+                addr = new SymbolConstantEntry(staticsBase);
 
                 if (!context.PreinitializationManager.IsPreinitialized(field.OwningType))
                 {
@@ -34,7 +34,7 @@ namespace ILCompiler.Compiler.Importer
             }
 
             var fieldSize = field.FieldType.GetElementSize().AsInt;
-            var fieldOffset = isStoreStatic ? 0 : field.Offset.AsInt;
+            var fieldOffset = field.Offset.AsInt;
 
             var node = new StoreIndEntry(addr, value, field.FieldType.VarType, (uint)fieldOffset, fieldSize);
 

--- a/ILCompiler/Compiler/Morpher.cs
+++ b/ILCompiler/Compiler/Morpher.cs
@@ -163,6 +163,13 @@ namespace ILCompiler.Compiler
                 offset = 0;
             }
 
+            if (tree.Op1 is CommaEntry ce && ce.Op2 is SymbolConstantEntry sce2)
+            {
+                // Move offset into SymbolConstantEntry
+                sce2.Offset += (int)tree.Offset;
+                offset = 0;
+            }
+
             return new IndirectEntry(MorphTree(tree.Op1), tree.Type, tree.ExactSize, offset);
         }
 
@@ -173,6 +180,13 @@ namespace ILCompiler.Compiler
             {
                 // Move offset into SymbolConstantEntry
                 sce.Offset += (int)fieldOffset;
+                fieldOffset = 0;
+            }
+
+            if (sie.Op1 is CommaEntry ce && ce.Op2 is SymbolConstantEntry sce2)
+            {
+                // Move offset into SymbolConstantEntry
+                sce2.Offset += (int)fieldOffset;
                 fieldOffset = 0;
             }
 

--- a/ILCompiler/Compiler/Morpher.cs
+++ b/ILCompiler/Compiler/Morpher.cs
@@ -63,7 +63,7 @@ namespace ILCompiler.Compiler
                     break;
 
                 case IndirectEntry ie:
-                    tree = new IndirectEntry(MorphTree(ie.Op1), ie.Type, ie.ExactSize, ie.Offset);
+                    tree = MorphIndirectEntry(ie);
                     break;
 
                 case IntrinsicEntry ie:
@@ -151,6 +151,18 @@ namespace ILCompiler.Compiler
             addr = MorphTree(addr);
 
             return addr;
+        }
+
+        private StackEntry MorphIndirectEntry(IndirectEntry tree)
+        {
+            if (tree.Op1 is SymbolConstantEntry sce)
+            {
+                // Move offset into SymbolConstantEntry
+                sce.Offset += (int)tree.Offset;
+                return new IndirectEntry(sce, tree.Type, tree.ExactSize, 0);
+            }
+
+            return new IndirectEntry(MorphTree(tree.Op1), tree.Type, tree.ExactSize, tree.Offset);
         }
 
         private BinaryOperator MorphBinaryOperator(BinaryOperator bo)

--- a/ILCompiler/Compiler/Morpher.cs
+++ b/ILCompiler/Compiler/Morpher.cs
@@ -99,7 +99,7 @@ namespace ILCompiler.Compiler
                     break;
 
                 case StoreIndEntry sie:
-                    tree = new StoreIndEntry(MorphTree(sie.Addr), MorphTree(sie.Op1), sie.Type, sie.FieldOffset, sie.ExactSize);
+                    tree = MorphStoreIndEntry(sie);
                     break;
 
                 case StoreLocalVariableEntry slve:
@@ -155,14 +155,28 @@ namespace ILCompiler.Compiler
 
         private StackEntry MorphIndirectEntry(IndirectEntry tree)
         {
+            var offset = tree.Offset;
             if (tree.Op1 is SymbolConstantEntry sce)
             {
                 // Move offset into SymbolConstantEntry
                 sce.Offset += (int)tree.Offset;
-                return new IndirectEntry(sce, tree.Type, tree.ExactSize, 0);
+                offset = 0;
             }
 
-            return new IndirectEntry(MorphTree(tree.Op1), tree.Type, tree.ExactSize, tree.Offset);
+            return new IndirectEntry(MorphTree(tree.Op1), tree.Type, tree.ExactSize, offset);
+        }
+
+        private StackEntry MorphStoreIndEntry(StoreIndEntry sie)
+        {
+            var fieldOffset = sie.FieldOffset;
+            if (sie.Addr is SymbolConstantEntry sce)
+            {
+                // Move offset into SymbolConstantEntry
+                sce.Offset += (int)fieldOffset;
+                fieldOffset = 0;
+            }
+
+            return new StoreIndEntry(MorphTree(sie.Addr), MorphTree(sie.Op1), sie.Type, fieldOffset, sie.ExactSize);
         }
 
         private BinaryOperator MorphBinaryOperator(BinaryOperator bo)

--- a/ILCompiler/Compiler/Morpher.cs
+++ b/ILCompiler/Compiler/Morpher.cs
@@ -153,7 +153,7 @@ namespace ILCompiler.Compiler
             return addr;
         }
 
-        private StackEntry MorphIndirectEntry(IndirectEntry tree)
+        private IndirectEntry MorphIndirectEntry(IndirectEntry tree)
         {
             var offset = tree.Offset;
             if (tree.Op1 is SymbolConstantEntry sce)
@@ -173,7 +173,7 @@ namespace ILCompiler.Compiler
             return new IndirectEntry(MorphTree(tree.Op1), tree.Type, tree.ExactSize, offset);
         }
 
-        private StackEntry MorphStoreIndEntry(StoreIndEntry sie)
+        private StoreIndEntry MorphStoreIndEntry(StoreIndEntry sie)
         {
             var fieldOffset = sie.FieldOffset;
             if (sie.Addr is SymbolConstantEntry sce)

--- a/ILCompiler/TypeSystem/Common/FieldDesc.cs
+++ b/ILCompiler/TypeSystem/Common/FieldDesc.cs
@@ -26,7 +26,7 @@
                 {
                     if (IsStatic)
                     {
-                        // TODO: ComputeStaticFieldLayout
+                        OwningType.ComputeStaticFieldLayout();
                     }
                     else
                     {

--- a/ILCompiler/TypeSystem/Common/FieldLayoutAlgorithm.cs
+++ b/ILCompiler/TypeSystem/Common/FieldLayoutAlgorithm.cs
@@ -9,6 +9,14 @@
 
         public FieldAndOffset[] Offsets { get; set; }
     }
+
+    public struct ComputedStaticFieldLayout
+    {
+        public LayoutInt Size { get; set; }
+
+        public FieldAndOffset[] Offsets { get; set; }
+    }
+
     public readonly struct FieldAndOffset
     {
         public static readonly LayoutInt InvalidOffset = new(int.MaxValue);

--- a/ILCompiler/TypeSystem/Common/TypeSystemContext.cs
+++ b/ILCompiler/TypeSystem/Common/TypeSystemContext.cs
@@ -1,5 +1,4 @@
 ﻿using ILCompiler.Compiler;
-using ILCompiler.Interfaces;
 using ILCompiler.TypeSystem.Canon;
 using ILCompiler.TypeSystem.RuntimeDetermined;
 


### PR DESCRIPTION
Groups static fields for a type together as a pre-cursor to progressing shared generics in #531 - which will need to access static fields via static base - a pointer to the group of static fields for a type - and offset.

Added some morphing to push field offset from Indirect nodes into Symbol Constant nodes.

Results from jitdiff:

Total bytes of diff: -144
        diff is an improvement.

Top file improvements by size (bytes).
             -24 : Samples\CalcPi\bin\Trs80\Release\net9.0\CalcPi.dasm
             -24 : Samples\Wumpus\bin\Trs80\Debug\net9.0\Wumpus.dasm
             -24 : Samples\Wumpus\bin\Trs80\Release\net9.0\Wumpus.dasm
             -24 : Samples\CalcPi\bin\Trs80\Debug\net9.0\CalcPi.dasm
              -8 : Samples\QSort\bin\Trs80\Release\net9.0\QSort.dasm

10 total files with size differences.

Top method improvements by size (bytes):
             -24 : Samples\CalcPi\bin\Trs80\Release\net9.0\CalcPi.dasm - System.Void CalculatePi.CalculatePi::DisplayDigitsOfPi(System.Int32)
             -24 : Samples\CalcPi\bin\Trs80\Debug\net9.0\CalcPi.dasm - System.Void CalculatePi.CalculatePi::DisplayDigitsOfPi(System.Int32)
              -8 : Samples\Wumpus\bin\Trs80\Release\net9.0\Wumpus.dasm - System.Void Wumpus.Game::Shoot(Wumpus.Game)
              -8 : Samples\Wumpus\bin\Trs80\Release\net9.0\Wumpus.dasm - System.Void Wumpus.CaveBuilder::.ctor(Wumpus.CaveBuilder)
              -8 : Samples\Wumpus\bin\Trs80\Release\net9.0\Wumpus.dasm - System.Void Wumpus.Room::.ctor(Wumpus.Room,System.Int32)

14 total methods with size differences.