### PR TITLE
Add Array methods

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/CodeGeneratorContext.cs
+++ b/ILCompiler/Compiler/CodeGenerators/CodeGeneratorContext.cs
@@ -9,7 +9,6 @@ namespace ILCompiler.Compiler.CodeGenerators
     {
         public InstructionsBuilder InstructionsBuilder { get; } = new();
         public LocalVariableTable LocalVariableTable { get; }
-        public int ParamsCount => _method.ParamsCount;
         public int LocalsCount => _method.LocalsCount;
         public MethodDesc Method => _method.Method;
 

--- a/ILCompiler/Compiler/CodeGenerators/ReturnCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/ReturnCodeGenerator.cs
@@ -109,21 +109,20 @@ namespace ILCompiler.Compiler.CodeGenerators
 
             context.InstructionsBuilder.Pop(BC);      // Store return address in BC
 
-            if (context.ParamsCount > 0)
+            // Calculate size of parameters
+            var totalParametersSize = 0;
+            foreach (var local in context.LocalVariableTable)
             {
-                // Calculate size of parameters
-                var totalParametersSize = 0;
-                foreach (var local in context.LocalVariableTable)
+                if (local.IsParameter)
                 {
-                    if (local.IsParameter)
-                    {
-                        totalParametersSize += local.ExactSize;
-                    }
+                    totalParametersSize += local.ExactSize;
                 }
+            }
 
+            if (totalParametersSize > 0)
+            {
                 // Remove parameters from stack
                 CodeGeneratorHelper.AddSPFromHL(context.InstructionsBuilder, (short)(totalParametersSize));
-
             }
 
             if (hasReturnValue && !entry.ReturnBufferArgIndex.HasValue)

--- a/ILCompiler/Compiler/DependencyAnalysis/ILScanner.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/ILScanner.cs
@@ -497,18 +497,31 @@ namespace ILCompiler.Compiler.DependencyAnalysis
             var ctor = (MethodDesc)instruction.Operand;
             var owningType = ctor.OwningType;
 
-            if (owningType is ArrayType)
-            {
-                // TODO: Will need to review this when changing NewArray assembly routine to take EEType instead of size
-                throw new NotImplementedException();
-            }
-            else if (owningType.IsValueType)
+            if (owningType.IsValueType)
             {
                 // No dependency required 
             }
             else if (owningType.FullName != "System.String")
             {
-                _dependencies.Add(_context.NodeFactory.ConstructedEETypeNode(owningType));
+                if (owningType.IsRuntimeDeterminedSubtype)
+                {
+                    // TODO: Handle runtime determined subtypes
+                    throw new NotImplementedException();
+                }
+                else
+                {
+                    _dependencies.Add(_context.NodeFactory.ConstructedEETypeNode(owningType));
+                }
+
+                if (owningType.IsMdArray)
+                {
+                    // TODO: Add dependency for newing up multi-dimensional arrays
+                    throw new NotImplementedException();
+                }
+                else
+                {
+                    // TODO: Add dependency on helper for NewObject
+                }
             }
         }
 

--- a/ILCompiler/Compiler/DependencyAnalysis/Z80MethodCodeNode.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/Z80MethodCodeNode.cs
@@ -18,7 +18,6 @@ namespace ILCompiler.Compiler.DependencyAnalysis
         public Z80MethodCodeNode(MethodDesc method, Factory<IMethodCompiler> methodCompilerFactory, DnlibModule module)
         {
             Method = method;
-            ParamsCount = method.Signature.Length;
 
             _methodCompilerFactory = methodCompilerFactory;
             _module = module;

--- a/ILCompiler/Compiler/MethodCompiler.cs
+++ b/ILCompiler/Compiler/MethodCompiler.cs
@@ -75,13 +75,13 @@ namespace ILCompiler.Compiler
             if (!method.Signature.ReturnType.IsVoid)
             {
                 var returnType = method.Signature.ReturnType;
-                InitReturnBufferArg(returnType, !method.Signature.IsStatic);
+                InitReturnBufferArg(returnType, method.HasThis, ref paramterCount);
             }
 
             return paramterCount;
         }
 
-        private void InitReturnBufferArg(TypeDesc returnType, bool hasThis)
+        private void InitReturnBufferArg(TypeDesc returnType, bool hasThis, ref int parameterCount)
         {
             if (returnType.IsValueType && !returnType.IsPrimitive && !returnType.IsEnum)
             {
@@ -98,8 +98,7 @@ namespace ILCompiler.Compiler
                 // Ensure return buffer parameter goes after the this parameter if present
                 _returnBufferArgIndex = hasThis ? 1 : 0;
                 _locals.Insert(_returnBufferArgIndex.Value, returnBuffer);
-
-                _parameterCount++;
+                parameterCount++;
             }
         }
 

--- a/ILCompiler/Compiler/MethodCompiler.cs
+++ b/ILCompiler/Compiler/MethodCompiler.cs
@@ -25,8 +25,24 @@ namespace ILCompiler.Compiler
             _phaseFactory = phaseFactory;
         }
 
-        private void SetupLocalVariableTable(MethodDesc method)
+        private int SetupLocalVariableTable(MethodDesc method)
         {
+            int paramterCount = 0;
+
+            if (method.HasThis)
+            {
+                var local = new LocalVariableDescriptor()
+                {
+                    IsParameter = true,
+                    IsTemp = false,
+                    Name = "",
+                    ExactSize = 2,
+                    Type = VarType.Ref,
+                };
+                _locals.Add(local);
+                paramterCount++;
+            }
+
             // Setup local variable table - includes parameters as well as locals in method
             for (int parameterIndex = 0; parameterIndex < method.Signature.Length; parameterIndex++)
             {
@@ -40,6 +56,7 @@ namespace ILCompiler.Compiler
                     Type = parameter.Type.VarType,
                 };
                 _locals.Add(local);
+                paramterCount++;
             }
 
             foreach (var local in method.Locals)
@@ -60,6 +77,8 @@ namespace ILCompiler.Compiler
                 var returnType = method.Signature.ReturnType;
                 InitReturnBufferArg(returnType, !method.Signature.IsStatic);
             }
+
+            return paramterCount;
         }
 
         private void InitReturnBufferArg(TypeDesc returnType, bool hasThis)
@@ -105,9 +124,7 @@ namespace ILCompiler.Compiler
                 return;
             }
 
-            _parameterCount = method.Signature.Length;
-
-            SetupLocalVariableTable(method);
+            _parameterCount = SetupLocalVariableTable(method);
 
             var ilImporter = _phaseFactory.Create<IILImporter>();
 

--- a/ILCompiler/Compiler/MethodCompiler.cs
+++ b/ILCompiler/Compiler/MethodCompiler.cs
@@ -12,7 +12,6 @@ namespace ILCompiler.Compiler
         private readonly ILogger<MethodCompiler> _logger;
         private readonly IPhaseFactory _phaseFactory;
 
-        private int _parameterCount;
         private int? _returnBufferArgIndex;
 
         private readonly LocalVariableTable _locals;
@@ -123,12 +122,12 @@ namespace ILCompiler.Compiler
                 return;
             }
 
-            _parameterCount = SetupLocalVariableTable(method);
+            var parameterCount = SetupLocalVariableTable(method);
 
             var ilImporter = _phaseFactory.Create<IILImporter>();
 
             // Main phases of the compiler live here
-            var basicBlocks = ilImporter.Import(_parameterCount, _returnBufferArgIndex, method, _locals, methodCodeNodeNeedingCode.EhClauses);
+            var basicBlocks = ilImporter.Import(parameterCount, _returnBufferArgIndex, method, _locals, methodCodeNodeNeedingCode.EhClauses);
 
             if (_configuration.DumpFlowGraphs)
             {

--- a/ILCompiler/TypeSystem/Canon/CanonTypes.cs
+++ b/ILCompiler/TypeSystem/Canon/CanonTypes.cs
@@ -27,6 +27,8 @@ namespace ILCompiler.TypeSystem.Canon
         public override ClassLayoutMetadata GetClassLayout() => default;
 
         public override VarType VarType => VarType.Ref;
+
+        public override DefType? ContainingType => null;
     }
 
     internal sealed class CanonType(TypeSystemContext context) : CanonBaseType(context)

--- a/ILCompiler/TypeSystem/Common/ArrayType.cs
+++ b/ILCompiler/TypeSystem/Common/ArrayType.cs
@@ -1,5 +1,6 @@
 ﻿using ILCompiler.Compiler;
 using ILCompiler.TypeSystem.Canon;
+using ILCompiler.TypeSystem.IL;
 
 namespace ILCompiler.TypeSystem.Common
 {
@@ -46,5 +47,165 @@ namespace ILCompiler.TypeSystem.Common
         }
 
         public override TypeFlags Category => _rank == -1 ? TypeFlags.SzArray : TypeFlags.Array;
+
+        private MethodDesc[]? _methods;
+        public override IEnumerable<MethodDesc> GetMethods()
+        {
+            if (_methods == null)
+            {
+                InitializeMethods();
+            }
+            return _methods!;
+        }
+
+        private void InitializeMethods()
+        {
+            int numberOfConstructors;
+            if (IsSzArray)
+            {
+                numberOfConstructors = 1;
+
+                // Jagged arrays have constructors for each depth
+                var elemType = ElementType;
+                while (elemType.IsSzArray)
+                {
+                    elemType = ((ArrayType)elemType).ElementType;
+                    numberOfConstructors++;
+                }
+            }
+            else
+            {
+                // Multidimensional arrays have two constructors
+                // One with and one without the lower bounds
+                numberOfConstructors = 2;
+            }
+
+            MethodDesc[] methods = new MethodDesc[(int)ArrayMethodKind.Ctor + numberOfConstructors];
+            for (int i = 0; i < methods.Length; i++)
+            {
+                methods[i] = new ArrayMethod(this, (ArrayMethodKind)i);
+            }
+
+            _methods = methods;
+        }
+
+        public MethodDesc GetArrayMethod(ArrayMethodKind kind)
+        {
+            if (_methods == null)
+            {
+                InitializeMethods();
+            }
+            return _methods![(int)kind];
+        }
+    }
+
+    public enum ArrayMethodKind
+    {
+        Get,
+        Set,
+        Address,
+        AddressWithHiddenArg,
+        Ctor
+    }
+
+    public class ArrayMethod : MethodDesc
+    {
+        private readonly ArrayType _owningType;
+        private readonly ArrayMethodKind _kind;
+
+        public ArrayMethod(ArrayType owningType, ArrayMethodKind kind)
+        {
+            _owningType = owningType;
+            _kind = kind;
+        }
+
+        public override TypeSystemContext Context => _owningType.Context;
+
+        public override TypeDesc OwningType => _owningType;
+
+        public override MethodSignature Signature
+        {
+            get
+            {
+                switch (_kind)
+                {
+                    case ArrayMethodKind.Get:
+                    case ArrayMethodKind.Set:
+                    case ArrayMethodKind.Address:
+                    case ArrayMethodKind.AddressWithHiddenArg:
+                        throw new NotImplementedException();
+
+                    default:
+                        {
+                            int numberOfParameters;
+                            if (_owningType.IsSzArray)
+                            {
+                                numberOfParameters = 1 + (int)_kind - (int)ArrayMethodKind.Ctor;
+                            }
+                            else
+                            {
+                                numberOfParameters = (_kind == ArrayMethodKind.Ctor) ? _owningType.Rank : 2 * _owningType.Rank;
+                            }
+                            var parameters = new MethodParameter[numberOfParameters];
+                            for (int i = 0; i < numberOfParameters; i++)
+                            {
+                                parameters[i] = new MethodParameter(Context.GetWellKnownType(WellKnownType.Int32), String.Empty);
+                            }
+
+                            return new MethodSignature(MethodSignatureFlags.None, Context.GetWellKnownType(WellKnownType.Void), parameters);
+                        }
+                }
+                throw new NotImplementedException();
+            }
+        }
+
+        public override string Name
+        {
+            get
+            {
+                switch (_kind)
+                {
+                    case ArrayMethodKind.Get:
+                        return "Get";
+                    case ArrayMethodKind.Set:
+                        return "Set";
+                    case ArrayMethodKind.Address:
+                    case ArrayMethodKind.AddressWithHiddenArg:
+                        return "Address";
+                    default:
+                        return ".ctor";
+                }
+            }
+        }
+
+        public override bool HasCustomAttribute(string attributeNamespace, string attributeName) => false;
+
+        public override MethodDesc InstantiateSignature(Instantiation? typeInstantiation, Instantiation? methodInstantiation)
+        {
+            var owningType = OwningType;
+            var instantiatedOwningType = owningType.InstantiateSignature(typeInstantiation, methodInstantiation);
+
+            if (owningType != instantiatedOwningType)
+            {
+                return ((ArrayType)instantiatedOwningType).GetArrayMethod(_kind);
+            }
+
+            return this;
+        }
+
+        public override IEnumerable<MethodImplRecord> Overrides => throw new NotImplementedException();
+
+        public override Instantiation Instantiation => Instantiation.Empty;
+
+        public override IList<MethodParameter> Parameters => Signature.Parameters;
+
+        public override IList<LocalVariableDefinition> Locals => throw new NotImplementedException();
+
+        public override MethodIL? MethodIL => throw new NotImplementedException();
+
+        public override MethodDesc CreateUserMethod(string name)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/ILCompiler/TypeSystem/Common/DefType.cs
+++ b/ILCompiler/TypeSystem/Common/DefType.cs
@@ -156,5 +156,7 @@ namespace ILCompiler.TypeSystem.Common
                 return false;
             }
         }
+
+        public virtual DefType? ContainingType => null;
     }
 }

--- a/ILCompiler/TypeSystem/Common/InstantiatedType.cs
+++ b/ILCompiler/TypeSystem/Common/InstantiatedType.cs
@@ -214,5 +214,24 @@ namespace ILCompiler.TypeSystem.Common
 
             return false;
         }
+
+        public override MethodDesc? GetMethod(string name, MethodSignature? signature, Instantiation? substitution)
+        {
+            MethodDesc? typicalMethodDef = _typeDef.GetMethod(name, signature, substitution);
+            if (typicalMethodDef == null)
+                return null;
+            return _typeDef.Context.GetMethodForInstantiatedType(typicalMethodDef, this);
+        }
+
+
+        public override MethodDesc? GetMethodWithEquivalentSignature(string name, MethodSignature? signature, Instantiation? substitution)
+        {
+            MethodDesc? typicalMethodDef = _typeDef.GetMethodWithEquivalentSignature(name, signature, substitution);
+            if (typicalMethodDef == null)
+                return null;
+            return _typeDef.Context.GetMethodForInstantiatedType(typicalMethodDef, this);
+        }
+
+        public override DefType? ContainingType => _typeDef.ContainingType;
     }
 }

--- a/ILCompiler/TypeSystem/Common/InstantiatedType.cs
+++ b/ILCompiler/TypeSystem/Common/InstantiatedType.cs
@@ -215,18 +215,18 @@ namespace ILCompiler.TypeSystem.Common
             return false;
         }
 
-        public override MethodDesc? GetMethod(string name, MethodSignature? signature, Instantiation? substitution)
+        public override MethodDesc? GetMethod(string name, MethodSignature? signature, Instantiation? instantiation)
         {
-            MethodDesc? typicalMethodDef = _typeDef.GetMethod(name, signature, substitution);
+            MethodDesc? typicalMethodDef = _typeDef.GetMethod(name, signature, instantiation);
             if (typicalMethodDef == null)
                 return null;
             return _typeDef.Context.GetMethodForInstantiatedType(typicalMethodDef, this);
         }
 
 
-        public override MethodDesc? GetMethodWithEquivalentSignature(string name, MethodSignature? signature, Instantiation? substitution)
+        public override MethodDesc? GetMethodWithEquivalentSignature(string name, MethodSignature? signature, Instantiation? instantiation)
         {
-            MethodDesc? typicalMethodDef = _typeDef.GetMethodWithEquivalentSignature(name, signature, substitution);
+            MethodDesc? typicalMethodDef = _typeDef.GetMethodWithEquivalentSignature(name, signature, instantiation);
             if (typicalMethodDef == null)
                 return null;
             return _typeDef.Context.GetMethodForInstantiatedType(typicalMethodDef, this);

--- a/ILCompiler/TypeSystem/Common/MetadataType.cs
+++ b/ILCompiler/TypeSystem/Common/MetadataType.cs
@@ -18,6 +18,8 @@ namespace ILCompiler.TypeSystem.Common
         public abstract MethodImplRecord[] FindMethodsImplWithMatchingDeclName(string name);
 
         public override bool IsCanonicalSubtype(CanonicalFormKind policy) => false;
+
+        public abstract override DefType? ContainingType { get; }
     }
 
     public struct ClassLayoutMetadata

--- a/ILCompiler/TypeSystem/Common/MethodDesc.cs
+++ b/ILCompiler/TypeSystem/Common/MethodDesc.cs
@@ -31,6 +31,9 @@ namespace ILCompiler.TypeSystem.Common
         public virtual bool HasReturnType => false;
 
         public virtual bool HasThis => false;
+        public virtual bool IsExplicitThis => false;
+
+        public bool IsConstructor => Name == ".ctor";
 
         public virtual string FullName => String.Empty;
 

--- a/ILCompiler/TypeSystem/Common/MethodForInstantiatedType.cs
+++ b/ILCompiler/TypeSystem/Common/MethodForInstantiatedType.cs
@@ -79,6 +79,9 @@ namespace ILCompiler.TypeSystem.Common
         public override bool IsVirtual => _typicalMethodDef.IsVirtual;
         public override bool IsAbstract => _typicalMethodDef.IsAbstract;
 
+        public override bool HasThis => _typicalMethodDef.HasThis;
+        public override bool IsExplicitThis => _typicalMethodDef.IsExplicitThis;
+
         public override bool IsIntrinsic => _typicalMethodDef.IsIntrinsic;
         public override MethodDesc CreateUserMethod(string name) => throw new NotImplementedException();
 

--- a/ILCompiler/TypeSystem/Common/MethodSignature.cs
+++ b/ILCompiler/TypeSystem/Common/MethodSignature.cs
@@ -15,7 +15,15 @@ namespace ILCompiler.TypeSystem.Common
         }
     }
 
-    public class MethodSignature : TypeSystemEntity, IEquatable<MethodSignature>
+    [Flags]
+    public enum MethodSignatureFlags
+    {
+        None =  0x0000,
+        Static = 0x0010,
+        ExplicitThis = 0x0020,
+    }
+
+    public sealed class MethodSignature : TypeSystemEntity, IEquatable<MethodSignature>
     {
         private readonly MethodParameter[] _parameters;
         public TypeDesc ReturnType { get; init; }
@@ -32,62 +40,57 @@ namespace ILCompiler.TypeSystem.Common
         public int Length => _parameters.Length;
 
         public MethodParameter[] Parameters => _parameters;
-        public MethodSignature(bool isStatic, TypeDesc returnType, MethodParameter[] parameters)
+
+        private readonly MethodSignatureFlags _flags;
+
+        public MethodSignature(MethodSignatureFlags flags, TypeDesc returnType, MethodParameter[] parameters)
         {
-            IsStatic = isStatic;
+            _flags = flags;
             ReturnType = returnType;
             _parameters = parameters;
         }
 
-        public bool IsStatic { get; }
+        public MethodSignatureFlags Flags => _flags;
+        public bool IsStatic => (_flags & MethodSignatureFlags.Static) != 0;
+        public bool ExplicitThis => (_flags & MethodSignatureFlags.ExplicitThis) != 0;
 
         public override TypeSystemContext Context => ReturnType.Context;
 
-        public bool Equals(MethodSignature? other)
+        private bool Equals(MethodSignature? other, bool allowEquivalence)
         {
-            if (this.ReturnType.ToString() != other?.ReturnType.ToString()) return false;
+            if (!TypeIsEqualHelper(this.ReturnType, other!.ReturnType, allowEquivalence))
+                return false;
+
             if (this.Length != other?.Length) return false;
+
 
             for (int parameterIndex = 0; parameterIndex < Length; parameterIndex++)
             {
-                if (Parameters[parameterIndex].Type.ToString() != other.Parameters[parameterIndex].Type.ToString()) return false;
+                if (!TypeIsEqualHelper(Parameters[parameterIndex].Type, other.Parameters[parameterIndex].Type, allowEquivalence)) return false;
             }
-
-            return true;
-        }
-
-        public bool EquivalentTo(MethodSignature otherSignature)
-        {
-            if (!TypeIsEqualHelper(ReturnType, otherSignature.ReturnType)) 
-                return false;
-
-            if (_parameters.Length != otherSignature._parameters.Length)
-                return false;
-
-            // For instance methods ignore first parameter as will be "this"
-            var startParameterIndex = IsStatic ? 0 : 1;
-            for (int i = startParameterIndex; i < _parameters.Length; i++)
-            {
-                if (!TypeIsEqualHelper(_parameters[i].Type, otherSignature._parameters[i].Type))
-                    return false;
-            }
-
             return true;
 
-            static bool TypeIsEqualHelper(TypeDesc type1, TypeDesc type2)
+            static bool TypeIsEqualHelper(TypeDesc type1, TypeDesc type2, bool allowEquivalence)
             {
-                if (type1 == type2) 
+                if (type1 == type2)
                     return true;
 
-                if (type1.IsEquivalentTo(type2))
+                if (allowEquivalence && type1.IsEquivalentTo(type2))
                 {
                     return true;
                 }
-
                 return false;
             }
         }
 
+        public bool Equals(MethodSignature? other) => Equals(other, allowEquivalence: false);
+
+        public override bool Equals(object? obj) => obj is MethodSignature signature && Equals(signature);
+
+        public bool EquivalentTo(MethodSignature otherSignature)
+        {
+            return Equals(otherSignature, allowEquivalence: true);
+        }
         public override string ToString() => ToString(includeReturnType: true);
 
         public string ToString(bool includeReturnType)
@@ -118,6 +121,29 @@ namespace ILCompiler.TypeSystem.Common
                 sb.Append(')');
             }
             return sb.ToString();
+        }
+
+        public MethodSignature ApplySubstitution(Instantiation? substitution)
+        {
+            if (substitution is null)
+                return this;
+
+            MethodParameter[] newParameters = new MethodParameter[Length];
+            var returnTypeNew = ReturnType.InstantiateSignature(substitution, default(Instantiation));
+
+            int parameterIndex = 0;
+            foreach (var parameter in Parameters)
+            {
+                var newParameter = parameter.Type.InstantiateSignature(substitution, default(Instantiation));
+                newParameters[parameterIndex++] = new MethodParameter(newParameter, parameter.Name);
+            }
+
+            return new MethodSignature(Flags, returnTypeNew, newParameters);
+        }
+
+        public override int GetHashCode()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/ILCompiler/TypeSystem/Common/MethodSignature.cs
+++ b/ILCompiler/TypeSystem/Common/MethodSignature.cs
@@ -61,7 +61,7 @@ namespace ILCompiler.TypeSystem.Common
             if (!TypeIsEqualHelper(this.ReturnType, other!.ReturnType, allowEquivalence))
                 return false;
 
-            if (this.Length != other?.Length) return false;
+            if (this.Length != other.Length) return false;
 
 
             for (int parameterIndex = 0; parameterIndex < Length; parameterIndex++)

--- a/ILCompiler/TypeSystem/Common/MethodSignatureBuilder.cs
+++ b/ILCompiler/TypeSystem/Common/MethodSignatureBuilder.cs
@@ -20,7 +20,7 @@
 
         public MethodSignature ToSignature()
         {
-            _template = new MethodSignature(_template.IsStatic, _returnType, _parameters);
+            _template = new MethodSignature(_template.Flags, _returnType, _parameters);
             return _template;
         }
 

--- a/ILCompiler/TypeSystem/Common/TypeDesc.cs
+++ b/ILCompiler/TypeSystem/Common/TypeDesc.cs
@@ -175,5 +175,32 @@ namespace ILCompiler.TypeSystem.Common
         public bool IsGenericDefinition => HasInstantiation && IsTypeDefinition;
 
         public bool IsTypeDefinition => GetTypeDefinition() == this;
+
+        public virtual MethodDesc? GetMethod(string name, MethodSignature? signature, Instantiation? substitution)
+        {
+            foreach (var method in GetMethods())
+            {
+                if (method.Name == name)
+                {
+                    if (signature == null || signature.Equals(method.Signature.ApplySubstitution(substitution)))
+                        return method;
+                }
+            }
+            return null;
+        }
+
+
+        public virtual MethodDesc? GetMethodWithEquivalentSignature(string name, MethodSignature? signature, Instantiation? substitution)
+        {
+            foreach (var method in GetMethods())
+            {
+                if (method.Name == name)
+                {
+                    if (signature == null || signature.EquivalentTo(method.Signature.ApplySubstitution(substitution)))
+                        return method;
+                }
+            }
+            return null;
+        }
     }
 }

--- a/ILCompiler/TypeSystem/Common/TypeDesc.cs
+++ b/ILCompiler/TypeSystem/Common/TypeDesc.cs
@@ -176,13 +176,13 @@ namespace ILCompiler.TypeSystem.Common
 
         public bool IsTypeDefinition => GetTypeDefinition() == this;
 
-        public virtual MethodDesc? GetMethod(string name, MethodSignature? signature, Instantiation? substitution)
+        public virtual MethodDesc? GetMethod(string name, MethodSignature? signature, Instantiation? instantiation)
         {
             foreach (var method in GetMethods())
             {
                 if (method.Name == name)
                 {
-                    if (signature == null || signature.Equals(method.Signature.ApplySubstitution(substitution)))
+                    if (signature == null || signature.Equals(method.Signature.ApplySubstitution(instantiation)))
                         return method;
                 }
             }
@@ -190,13 +190,13 @@ namespace ILCompiler.TypeSystem.Common
         }
 
 
-        public virtual MethodDesc? GetMethodWithEquivalentSignature(string name, MethodSignature? signature, Instantiation? substitution)
+        public virtual MethodDesc? GetMethodWithEquivalentSignature(string name, MethodSignature? signature, Instantiation? instantiation)
         {
             foreach (var method in GetMethods())
             {
                 if (method.Name == name)
                 {
-                    if (signature == null || signature.EquivalentTo(method.Signature.ApplySubstitution(substitution)))
+                    if (signature == null || signature.EquivalentTo(method.Signature.ApplySubstitution(instantiation)))
                         return method;
                 }
             }

--- a/ILCompiler/TypeSystem/Common/TypeNameFormatter.cs
+++ b/ILCompiler/TypeSystem/Common/TypeNameFormatter.cs
@@ -97,9 +97,25 @@ namespace ILCompiler.TypeSystem.Common
             }
             else
             {
-                AppendNameForNamespaceType(sb, type);
+                DefType? containingType = type.ContainingType;
+                if (containingType is not null)
+                {
+                    AppendNameForNestedType(sb, type, containingType);
+                }
+                else
+                {
+                    AppendNameForNamespaceType(sb, type);
+                }
             }
         }
+
+        protected void AppendNameForNestedType(StringBuilder sb, DefType nestedType, DefType containingType)
+        {
+            AppendName(sb, containingType);
+            sb.Append('+');
+            sb.Append(nestedType.Name);
+        }
+
 
         private void AppendNameForInstantiatedType(StringBuilder sb, DefType type)
         {

--- a/ILCompiler/TypeSystem/Common/TypeSystemHelper.cs
+++ b/ILCompiler/TypeSystem/Common/TypeSystemHelper.cs
@@ -26,6 +26,8 @@
 
         public static ArrayType MakeArrayType(this TypeDesc type) => type.Context.GetArrayType(type);
 
+        public static ArrayType MakeArrayType(this TypeDesc type, int rank) => type.Context.GetArrayType(type, rank);
+
         public static MethodDesc? FindMethodOnTypeWithMatchingTypicalMethod(this TypeDesc targetType, MethodDesc method)
         {
             if (!method.HasInstantiation && !method.OwningType.HasInstantiation)

--- a/ILCompiler/TypeSystem/Dnlib/DnlibMethod.cs
+++ b/ILCompiler/TypeSystem/Dnlib/DnlibMethod.cs
@@ -52,6 +52,7 @@ namespace ILCompiler.TypeSystem.Dnlib
         public override bool HasGenericParameters => _methodDef.HasGenericParameters;
         public override bool HasReturnType => _methodDef.HasReturnType;
         public override bool HasThis => _methodDef.HasThis;
+        public override bool IsExplicitThis => _methodDef.ExplicitThis;
 
 
         public override IList<LocalVariableDefinition> Locals

--- a/ILCompiler/TypeSystem/Dnlib/DnlibModule.cs
+++ b/ILCompiler/TypeSystem/Dnlib/DnlibModule.cs
@@ -242,12 +242,12 @@ namespace ILCompiler.TypeSystem.Dnlib
 
             MethodSignature? methodSig = Create(memberReference.MethodSig);
             TypeDesc? typeDescToInspect = parentTypeDesc;
-            Instantiation? substitution = null;
+            Instantiation? instantiation = null;
 
             // Try to resolve the name and signature in the current type or any of the base types
             do
             {
-                MethodDesc? method = typeDescToInspect.GetMethod(name, methodSig, substitution);
+                MethodDesc? method = typeDescToInspect.GetMethod(name, methodSig, instantiation);
                 if (method != null)
                 {
                     // Instance constructors are not inherited
@@ -261,17 +261,17 @@ namespace ILCompiler.TypeSystem.Dnlib
                 if (baseType != null)
                 {
                     // handle generic base types
-                    Instantiation? newSubstitution = typeDescToInspect.GetTypeDefinition().BaseType?.Instantiation;
-                    if (substitution is not null && newSubstitution is not null)
+                    Instantiation? newInstantiation = typeDescToInspect.GetTypeDefinition().BaseType?.Instantiation;
+                    if (instantiation is not null && newInstantiation is not null)
                     {
-                        TypeDesc[] newSubstitutionTypes = new TypeDesc[newSubstitution.Length];
-                        for (int i = 0; i < newSubstitution.Length; i++)
+                        TypeDesc[] newSubstitutionTypes = new TypeDesc[newInstantiation.Length];
+                        for (int i = 0; i < newInstantiation.Length; i++)
                         {
-                            newSubstitutionTypes[i] = newSubstitution[i].InstantiateSignature(substitution, default(Instantiation));
+                            newSubstitutionTypes[i] = newInstantiation[i].InstantiateSignature(instantiation, default(Instantiation));
                         }
-                        newSubstitution = new Instantiation(newSubstitutionTypes);
+                        newInstantiation = new Instantiation(newSubstitutionTypes);
                     }
-                    substitution = newSubstitution;
+                    instantiation = newInstantiation;
                 }
                 typeDescToInspect = baseType;
             } while (typeDescToInspect != null);

--- a/ILCompiler/TypeSystem/Dnlib/DnlibModule.cs
+++ b/ILCompiler/TypeSystem/Dnlib/DnlibModule.cs
@@ -257,26 +257,32 @@ namespace ILCompiler.TypeSystem.Dnlib
                     return method;
                 }
 
-                var baseType = typeDescToInspect.BaseType;
-                if (baseType != null)
-                {
-                    // handle generic base types
-                    Instantiation? newInstantiation = typeDescToInspect.GetTypeDefinition().BaseType?.Instantiation;
-                    if (instantiation is not null && newInstantiation is not null)
-                    {
-                        TypeDesc[] newSubstitutionTypes = new TypeDesc[newInstantiation.Length];
-                        for (int i = 0; i < newInstantiation.Length; i++)
-                        {
-                            newSubstitutionTypes[i] = newInstantiation[i].InstantiateSignature(instantiation, default(Instantiation));
-                        }
-                        newInstantiation = new Instantiation(newSubstitutionTypes);
-                    }
-                    instantiation = newInstantiation;
-                }
-                typeDescToInspect = baseType;
+                typeDescToInspect = GetBaseType(typeDescToInspect, ref instantiation);
             } while (typeDescToInspect != null);
 
-            throw new Exception($"Missing Method Failure {name}, {methodSig}");
+            throw new InvalidOperationException($"Missing Method Failure {name}, {methodSig}");
+        }
+
+        private static DefType? GetBaseType(TypeDesc typeDescToInspect, ref Instantiation? instantiation)
+        {
+            var baseType = typeDescToInspect.BaseType;
+            if (baseType != null)
+            {
+                // handle generic base types
+                Instantiation? newInstantiation = typeDescToInspect.GetTypeDefinition().BaseType?.Instantiation;
+                if (instantiation is not null && newInstantiation is not null)
+                {
+                    TypeDesc[] newSubstitutionTypes = new TypeDesc[newInstantiation.Length];
+                    for (int i = 0; i < newInstantiation.Length; i++)
+                    {
+                        newSubstitutionTypes[i] = newInstantiation[i].InstantiateSignature(instantiation, default(Instantiation));
+                    }
+                    newInstantiation = new Instantiation(newSubstitutionTypes);
+                }
+                instantiation = newInstantiation;
+            }
+
+            return baseType;
         }
 
         public MethodSignature CreateMethodSignature(MethodDef methodDef)

--- a/ILCompiler/TypeSystem/Dnlib/DnlibModule.cs
+++ b/ILCompiler/TypeSystem/Dnlib/DnlibModule.cs
@@ -51,6 +51,13 @@ namespace ILCompiler.TypeSystem.Dnlib
                 var elemTypeDesc = Create(elemTypeSig);
                 return elemTypeDesc.MakeArrayType();
             }
+            if (typeSig.IsArray)
+            {
+                var arraySig = typeSig.ToArraySig();
+                var elemTypeSig = typeSig.Next;
+                var elemTypeDesc = Create(elemTypeSig);
+                return elemTypeDesc.MakeArrayType((int)arraySig.Rank);
+            }
             if (typeSig.IsFunctionPointer)
             {
                 var fnPtrSig = (FnPtrSig)typeSig;
@@ -68,7 +75,7 @@ namespace ILCompiler.TypeSystem.Dnlib
             {
                 var parameterTypeSig = typeSig.Next;
                 var parameterType = Create(parameterTypeSig);
-                return new PointerType(parameterType);
+                return Context.GetPointerType(parameterType);
             }
 
             if (typeSig.IsPinned)
@@ -85,7 +92,7 @@ namespace ILCompiler.TypeSystem.Dnlib
 
             if (typeSig.IsGenericMethodParameter)
             {
-                TypeDesc genericMethodParameter = new SignatureMethodVariable(Context, (int)((GenericSig)typeSig).Number);
+                TypeDesc genericMethodParameter = Context.GetSignatureVariable((int)((GenericSig)typeSig).Number, method:true);
                 return genericMethodParameter;
             }
 
@@ -96,7 +103,7 @@ namespace ILCompiler.TypeSystem.Dnlib
 
             if (typeSig.IsGenericTypeParameter)
             {
-                TypeDesc genericTypeParameter = new SignatureTypeVariable(Context, (int)((GenericVar)typeSig).Number);
+                TypeDesc genericTypeParameter = Context.GetSignatureVariable((int)((GenericVar)typeSig).Number, method:false);
                 return genericTypeParameter;
             }
 
@@ -121,38 +128,29 @@ namespace ILCompiler.TypeSystem.Dnlib
             {
                 return ResolveMethodSpecification(methodSpec);
             }
-            else
+            else if (methodDefOrRef is MemberRef memberRef)
             {
-                var methodDef = methodDefOrRef.ResolveMethodDefThrow();
-
+                return ResolveMemberReference(memberRef);
+            }
+            else if (methodDefOrRef is MethodDef methodDef)
+            {
                 if (!_dnlibMethodsByFullName.TryGetValue(methodDef.FullName, out MethodDesc? methodDesc))
                 {
                     methodDesc = new DnlibMethod(methodDef, this, _ilProvider);
-                    _dnlibMethodsByFullName[methodDef.FullName] = methodDesc;
+                    _dnlibMethodsByFullName[methodDefOrRef.FullName] = methodDesc;
                 }
 
-                if (methodDefOrRef.DeclaringType?.NumberOfGenericParameters > 0)
+                if (methodDef.DeclaringType.TryGetGenericInstSig() != null)
                 {
-                    var genericInstSig = methodDefOrRef.DeclaringType.TryGetGenericInstSig();
-                    if (genericInstSig != null)
-                    {
-                        var genericParams = genericInstSig.GenericArguments;
-                        TypeDesc[] genericParameters = new TypeDesc[genericParams.Count];
-                        for (int i = 0; i < genericParams.Count; i++)
-                        {
-                            genericParameters[i] = Create(genericParams[i]);
-                        }
-                        var instantiation = new Instantiation(genericParameters);
-
-                        MetadataType typeDef = (MetadataType)Create(methodDef.DeclaringType);
-
-                        var instantiatedType = Context.GetInstantiatedType(typeDef, instantiation);
-                        methodDesc = Context.GetMethodForInstantiatedType(methodDesc, instantiatedType);
-                    }
+                    var typeSig = methodDef.DeclaringType.ToTypeSig();
+                    var instantiatedType = ResolveGenericInstanceType(typeSig);
+                    methodDesc = Context.GetMethodForInstantiatedType(methodDesc, instantiatedType);
                 }
 
                 return methodDesc;
             }
+
+            throw new NotImplementedException();
         }
 
         public TypeDesc Create(ITypeDefOrRef typeDefOrRef)
@@ -226,7 +224,59 @@ namespace ILCompiler.TypeSystem.Dnlib
                 parameters.Add(new MethodParameter(Create(parameter), parameter.GetName()));
             }
 
-            return new MethodSignature(!methodSig.HasThis, Create(methodSig.RetType), parameters.ToArray());
+            MethodSignatureFlags flags = 0;
+            if (!methodSig.HasThis)
+                flags |= MethodSignatureFlags.Static;
+
+            if (methodSig.ExplicitThis)
+                flags |= MethodSignatureFlags.ExplicitThis;
+
+            return new MethodSignature(flags, Create(methodSig.RetType), parameters.ToArray());
+        }
+
+        private MethodDesc ResolveMemberReference(MemberRef memberReference)
+        {
+            TypeDesc? parentTypeDesc = Create(memberReference.DeclaringType.ToTypeSig());
+
+            string name = memberReference.Name.String;
+
+            MethodSignature? methodSig = Create(memberReference.MethodSig);
+            TypeDesc? typeDescToInspect = parentTypeDesc;
+            Instantiation? substitution = null;
+
+            // Try to resolve the name and signature in the current type or any of the base types
+            do
+            {
+                MethodDesc? method = typeDescToInspect.GetMethod(name, methodSig, substitution);
+                if (method != null)
+                {
+                    // Instance constructors are not inherited
+                    if (typeDescToInspect != parentTypeDesc && method.IsConstructor)
+                        break;
+
+                    return method;
+                }
+
+                var baseType = typeDescToInspect.BaseType;
+                if (baseType != null)
+                {
+                    // handle generic base types
+                    Instantiation? newSubstitution = typeDescToInspect.GetTypeDefinition().BaseType?.Instantiation;
+                    if (substitution is not null && newSubstitution is not null)
+                    {
+                        TypeDesc[] newSubstitutionTypes = new TypeDesc[newSubstitution.Length];
+                        for (int i = 0; i < newSubstitution.Length; i++)
+                        {
+                            newSubstitutionTypes[i] = newSubstitution[i].InstantiateSignature(substitution, default(Instantiation));
+                        }
+                        newSubstitution = new Instantiation(newSubstitutionTypes);
+                    }
+                    substitution = newSubstitution;
+                }
+                typeDescToInspect = baseType;
+            } while (typeDescToInspect != null);
+
+            throw new Exception($"Missing Method Failure {name}, {methodSig}");
         }
 
         public MethodSignature CreateMethodSignature(MethodDef methodDef)
@@ -234,10 +284,19 @@ namespace ILCompiler.TypeSystem.Dnlib
             var parameters = new List<MethodParameter>();
             foreach (var parameter in methodDef.Parameters)
             {
-                parameters.Add(new MethodParameter(Create(parameter.Type), parameter.Name));
+                if (!parameter.IsHiddenThisParameter)
+                {
+                    parameters.Add(new MethodParameter(Create(parameter.Type), parameter.Name));
+                }
             }
 
-            return new MethodSignature(!methodDef.HasThis, Create(methodDef.ReturnType), parameters.ToArray());
+            MethodSignatureFlags flags = 0;
+            if (!methodDef.HasThis)
+                flags |= MethodSignatureFlags.Static;
+            if (methodDef.ExplicitThis)
+                flags |= MethodSignatureFlags.ExplicitThis;
+
+            return new MethodSignature(flags, Create(methodDef.ReturnType), parameters.ToArray());
         }
 
         public TypeSystemEntity CreateFromTypeOrMethodDef(ITypeOrMethodDef typeOrMethodDef)
@@ -274,8 +333,6 @@ namespace ILCompiler.TypeSystem.Dnlib
 
         private InstantiatedMethod ResolveMethodSpecification(MethodSpec methodSpec)
         {
-            var methodDef = Create(methodSpec.ResolveMethodDefThrow());
-
             var genericInstMethodSig = methodSpec.GenericInstMethodSig;
             var genericParams = genericInstMethodSig.GenericArguments;
             TypeDesc[] genericParameters = new TypeDesc[genericParams.Count];
@@ -284,6 +341,7 @@ namespace ILCompiler.TypeSystem.Dnlib
                 genericParameters[i] = Create(genericParams[i]);
             }
             var instantiation = new Instantiation(genericParameters);
+            var methodDef = Create(methodSpec.ResolveMethodDefThrow());
 
             return Context.GetInstantiatedMethod(methodDef, instantiation);
         }

--- a/ILCompiler/TypeSystem/Dnlib/DnlibType.cs
+++ b/ILCompiler/TypeSystem/Dnlib/DnlibType.cs
@@ -113,6 +113,23 @@ namespace ILCompiler.TypeSystem.Dnlib
             }
         }
 
+        public override MethodDesc? GetMethod(string name, MethodSignature? signature, Instantiation? instantiation)
+        {
+            foreach (var method  in _typeDef.Methods)
+            {
+                if (method.Name == name)
+                {
+                    var methodDesc = _module.Create(method);
+                    if (signature is null || signature.Equals(methodDesc.Signature.ApplySubstitution(instantiation)))
+                    {
+                        return methodDesc;
+                    }
+                }
+            }
+
+            return null;
+        }
+
         public override IEnumerable<FieldDesc> GetFields()
         {
             foreach (var field in _typeDef.Fields)
@@ -251,6 +268,17 @@ namespace ILCompiler.TypeSystem.Dnlib
                     ComputeGenericParameters();
                 }
                 return new Instantiation(_genericParameters!);
+            }
+        }
+
+        public override DefType? ContainingType
+        {
+            get
+            {
+                if (!_typeDef.IsNested)
+                    return null;
+
+                return (DefType)_module.Create(_typeDef.DeclaringType);
             }
         }
     }

--- a/ILCompiler/TypeSystem/RuntimeDetermined/RuntimeDeterminedType.cs
+++ b/ILCompiler/TypeSystem/RuntimeDetermined/RuntimeDeterminedType.cs
@@ -49,5 +49,13 @@ namespace ILCompiler.TypeSystem.RuntimeDetermined
         public override bool IsCanonicalSubtype(CanonicalFormKind policy) => false;
 
         public override bool IsRuntimeDeterminedSubtype => true;
+
+        public override MethodDesc? GetMethodWithEquivalentSignature(string name, MethodSignature? signature, Instantiation? substitution)
+        {
+            MethodDesc? method = CanonicalType.GetMethodWithEquivalentSignature(name, signature, substitution);
+            if (method == null)
+                return null;
+            return Context.GetMethodForRuntimeDeterminedType(method.GetTypicalMethodDefinition(), this);
+        }
     }
 }

--- a/ILCompiler/TypeSystem/RuntimeDetermined/RuntimeDeterminedType.cs
+++ b/ILCompiler/TypeSystem/RuntimeDetermined/RuntimeDeterminedType.cs
@@ -50,9 +50,9 @@ namespace ILCompiler.TypeSystem.RuntimeDetermined
 
         public override bool IsRuntimeDeterminedSubtype => true;
 
-        public override MethodDesc? GetMethodWithEquivalentSignature(string name, MethodSignature? signature, Instantiation? substitution)
+        public override MethodDesc? GetMethodWithEquivalentSignature(string name, MethodSignature? signature, Instantiation? instantiation)
         {
-            MethodDesc? method = CanonicalType.GetMethodWithEquivalentSignature(name, signature, substitution);
+            MethodDesc? method = CanonicalType.GetMethodWithEquivalentSignature(name, signature, instantiation);
             if (method == null)
                 return null;
             return Context.GetMethodForRuntimeDeterminedType(method.GetTypicalMethodDefinition(), this);


### PR DESCRIPTION
Array methods are special and aren't present in the IL and include ctors for multi dimensional arrays
This is initial work to enable further development for multi dimensional arrays - #55 

Required refactoring member resolution in DnlibModule to use GetMethod on TypeDesc to ultimately use ArrayType.GetMethod to find the special array methods.