### PR TITLE
Support multidimensional arrays via NewObj

### DIFF
--- a/ILCompiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -389,6 +389,9 @@ namespace ILCompiler.Compiler.DependencyAnalysis
             else if (type.IsArray)
             {
                 objectSize = 2 * pointerSize; // EETypePtr + Length
+                if (type.IsMdArray)
+                    objectSize +=
+                        1 * 2 /* sizeof(nint) */ * ((ArrayType)type).Rank; // Only use upper bounds on md arrays
             }
 
             if (type.IsString)

--- a/ILCompiler/Compiler/DependencyAnalysis/ILScanner.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/ILScanner.cs
@@ -295,7 +295,8 @@ namespace ILCompiler.Compiler.DependencyAnalysis
 
             if (instruction.Opcode == ILOpcode.newobj)
             {
-                CreateConstructedEETypeNodeDependencies(instruction);
+                if (CreateConstructedEETypeNodeDependencies(instruction))
+                    return;
             }
 
             var methodDesc = (MethodDesc)instruction.Operand;
@@ -492,7 +493,7 @@ namespace ILCompiler.Compiler.DependencyAnalysis
             return directCall;
         }
 
-        private void CreateConstructedEETypeNodeDependencies(Instruction instruction)
+        private bool CreateConstructedEETypeNodeDependencies(Instruction instruction)
         {
             var ctor = (MethodDesc)instruction.Operand;
             var owningType = ctor.OwningType;
@@ -515,14 +516,16 @@ namespace ILCompiler.Compiler.DependencyAnalysis
 
                 if (owningType.IsMdArray)
                 {
-                    // TODO: Add dependency for newing up multi-dimensional arrays
-                    throw new NotImplementedException();
+                    _dependencies.Add(GetHelperEntryPoint("ArrayHelpers", "NewObjArray"));
+                    return true;
                 }
                 else
                 {
                     // TODO: Add dependency on helper for NewObject
                 }
             }
+
+            return false;
         }
 
         private IMethodNode GetHelperEntryPoint(string typeName, string methodName)

--- a/ILCompiler/Compiler/Importer/NewarrImporter.cs
+++ b/ILCompiler/Compiler/Importer/NewarrImporter.cs
@@ -1,6 +1,7 @@
-﻿using ILCompiler.TypeSystem.Common;
-using ILCompiler.Compiler.EvaluationStack;
+﻿using ILCompiler.Compiler.EvaluationStack;
+using ILCompiler.IL;
 using ILCompiler.Interfaces;
+using ILCompiler.TypeSystem.Common;
 using ILCompiler.TypeSystem.IL;
 using System.Diagnostics;
 
@@ -32,8 +33,10 @@ namespace ILCompiler.Compiler.Importer
                 eeTypeNode = new NativeIntConstantEntry(mangledEETypeName);
             }
 
-            var args = new List<StackEntry>() { numElements, eeTypeNode };
-            var node = new CallEntry("NewArray", args, VarType.Ref, 2);
+            var runtimeHelperMethod = context.Method.Context.GetHelperEntryPoint("System.Runtime", "RuntimeImports", "NewArray");
+
+            var args = new List<StackEntry>() { eeTypeNode, numElements };
+            var node = new CallEntry("NewArray", args, VarType.Ref, 2, runtimeHelperMethod.IsVirtual, runtimeHelperMethod);
             importer.PushExpression(node);
 
             return true;

--- a/ILCompiler/Compiler/TypeExtensions.cs
+++ b/ILCompiler/Compiler/TypeExtensions.cs
@@ -123,7 +123,7 @@ namespace ILCompiler.Compiler
             if (type is ArrayType arrayType)
             {
                 var elementType = arrayType.ElementType;
-                return elementType.IsMdArray || elementType.IsFunctionPointer || elementType.IsPointer;
+                return type.IsMdArray || elementType.IsFunctionPointer || elementType.IsPointer;
             }
 
             return false;

--- a/ILCompiler/Runtime/NewArray.asm
+++ b/ILCompiler/Runtime/NewArray.asm
@@ -1,29 +1,19 @@
 ; This routine allocates space for 1-dimensional arrays in the heap
 ;
-; Uses: HL, DE
+; Uses: HL, DE, BC, AF, HL'
 
-; On entry on stack: EETypePtr, element count
-
-NewArrayRuntimeImport:
-	POP BC	; Ret Addr
-	POP DE	; EE Type Ptr
-
-	PUSH HL	; Element Count
-	PUSH HL	; Ignored
-	PUSH DE	; EE Type Ptr
-	PUSH BC ; Ret Addr
+; On entry on stack: EETypePtr, ElementCount in DEHL
 
 NewArray:
 	; Save return address
-	POP HL
-	EXX
-
-	; EETypePtr
-	POP HL
-
-	; Element Count
-	POP DE
 	POP AF
+	EX AF, AF'
+
+	; Get Element count into DE
+	EX DE, HL
+
+	; Get EETypePtr
+	POP HL
 
 	; Save EETypePtr & Element Count
 	PUSH DE ; DE = Element Count
@@ -33,7 +23,6 @@ NewArray:
 	LD C, (HL)
 	INC HL
 	LD B, (HL)
-
 
 	; HL = EETypePtr
 	; BC = Element Size
@@ -80,7 +69,7 @@ NEWARR_NOMUL16:
 	CALL NEWOBJECT
 
 	POP HL	; ptr to new object
-	POP DE
+	POP DE	; element count
 	PUSH HL
 
 	; Skip past the EETypePtr
@@ -92,5 +81,6 @@ NEWARR_NOMUL16:
 	INC HL
 	LD (HL), D
 
-	EXX
-	JP (HL)
+	EX AF, AF'
+	PUSH AF
+	RET

--- a/ILCompiler/TypeSystem/Common/ArrayType.cs
+++ b/ILCompiler/TypeSystem/Common/ArrayType.cs
@@ -15,6 +15,7 @@ namespace ILCompiler.TypeSystem.Common
 
         public TypeDesc ElementType => this.ParameterType;
 
+        public override DefType BaseType => Context.GetWellKnownType(WellKnownType.Array);
 
         public override bool IsArray => true;
         public override bool IsSzArray => _rank < 0;

--- a/ILCompiler/TypeSystem/Common/TypeDesc.cs
+++ b/ILCompiler/TypeSystem/Common/TypeDesc.cs
@@ -105,12 +105,12 @@ namespace ILCompiler.TypeSystem.Common
                     else
                     {
                         // TODO: multi-dimensional arrays, and arrays of pointers or function pointers
-                        throw new NotImplementedException();
+                        return this.BaseType!.RuntimeInterfaces;
                     }
                 }
                 else
                 {
-                    throw new NotImplementedException();
+                    return Array.Empty<DefType>();
                 }
             }
         }

--- a/System.Private.CoreLib/Internal/Runtime/CompilerHelpers/ArrayHelpers.cs
+++ b/System.Private.CoreLib/Internal/Runtime/CompilerHelpers/ArrayHelpers.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Internal.Runtime.CompilerHelpers
+{
+    internal static class ArrayHelpers
+    {
+        public static unsafe Array NewObjArray(EEType* pEEType, int nDimensions, int* pDimensions)
+        {
+            return Array.NewMultiDimArray(pEEType, pDimensions, nDimensions);
+        }
+    }
+}

--- a/System.Private.CoreLib/System/Linq/ArrayBuilder.cs
+++ b/System.Private.CoreLib/System/Linq/ArrayBuilder.cs
@@ -43,8 +43,7 @@ namespace System.Collections.Generic
         {   
             if (_count == 0)
             {
-                // TODO: Use Array.Empty<T>
-                return new T[0];
+                return Array.Empty<T>();
             }
 
             T[] result = _array;

--- a/System.Private.CoreLib/System/Runtime/RuntimeImports.cs
+++ b/System.Private.CoreLib/System/Runtime/RuntimeImports.cs
@@ -10,7 +10,7 @@ namespace System.Runtime
         internal static unsafe extern string NewString(EEType* pEEType, int length);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RuntimeImport("NewArrayRuntimeImport")]
+        [RuntimeImport("NewArray")]
         internal static unsafe extern Array NewArray(EEType* pEEType, int length);
     }
 }

--- a/System.Private.CoreLib/System/Runtime/RuntimeImports.cs
+++ b/System.Private.CoreLib/System/Runtime/RuntimeImports.cs
@@ -8,5 +8,9 @@ namespace System.Runtime
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport("NewString")]
         internal static unsafe extern string NewString(EEType* pEEType, int length);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        [RuntimeImport("NewArrayRuntimeImport")]
+        internal static unsafe extern Array NewArray(EEType* pEEType, int length);
     }
 }


### PR DESCRIPTION
For multidimensional arrays the data size is the product of the dimensions multiplied by the element size, e.g. for dimensions of 3,4,5 then data size is 3 * 4 * 5 = 60 * element size. The base size is increased to hold the dimensions. Native ints are used for the dimensions and only upper bounds are stored.

Contributes to #55

Fix bug in IsArrayTypeWithoutGenericInterfaces