### PR TITLE
Extend InitializeArray intrinsic implementation to work with multi-dmensional arrays

### DIFF
--- a/Tests/Methodical/MDArrays/MDArrays.cs
+++ b/Tests/Methodical/MDArrays/MDArrays.cs
@@ -4,8 +4,28 @@
     {
         public static int Main()
         {
-            int result = Simple_MDArray_Test();
+            int result = Simple_MDArray_Test(); if (result != 0) return result;
+            result = InitializeArray_Test(); if (result != 0) return result;
+
             return result;
+        }
+
+        private static int InitializeArray_Test()
+        {
+            var array = new int[2, 3] { { 1, 2, 3 }, { 4, 5, 6 } };
+            int value = 1;
+            for (int x = 0; x < array.GetLength(0); x++)
+            {
+                for (int y = 0; y < array.GetLength(1); y++)
+                {
+                    if (array[x, y] != value++)
+                    {
+                        return 1;
+                    }
+                }
+            }
+
+            return 0;
         }
 
         private static int Simple_MDArray_Test()


### PR DESCRIPTION
Existing code modified to get the BaseSize from the arrays EEType to determine where to copy the initialization data to.
Add simple test for initialization of md arrays.

Contributes to #55

Although this works it is sub-optimal as requires code at runtime to get the base size, a better solution will be to recognise a sequence of il such as (ldc, newarr or newobj, dup, ldtoken, call InitializeArray) and generate call to memcpy to replace the ldtoken/InitializeArray - doing this is possible as the full type of the array will be available from the newarr/newobj instruction and so can be used to determine the base size at compile time.