### PR TITLE
Range checks for md arrays

### DIFF
--- a/CSharp-80.sln
+++ b/CSharp-80.sln
@@ -262,6 +262,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StructInstance", "Tests\Gen
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StructStatic", "Tests\Generics\Arrays\ConstructedTypes\MultiDim\StructStatic.csproj", "{B78CE740-C5E3-F5E8-193D-8D49FCE9C4E3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RangeCheck", "Tests\Methodical\MDArrays\RangeCheck\RangeCheck.csproj", "{90C14ECD-8045-79B5-0C92-53B04A47D9F8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -648,6 +650,10 @@ Global
 		{B78CE740-C5E3-F5E8-193D-8D49FCE9C4E3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B78CE740-C5E3-F5E8-193D-8D49FCE9C4E3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B78CE740-C5E3-F5E8-193D-8D49FCE9C4E3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{90C14ECD-8045-79B5-0C92-53B04A47D9F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{90C14ECD-8045-79B5-0C92-53B04A47D9F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{90C14ECD-8045-79B5-0C92-53B04A47D9F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{90C14ECD-8045-79B5-0C92-53B04A47D9F8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -759,6 +765,7 @@ Global
 		{8C39C81B-436C-972E-49CF-0CC44218DF74} = {5C9ADC0F-8239-4B4C-8D41-5A79CC7127C3}
 		{E6A7ABA6-594F-ADC1-B9C6-F34E0E35BC75} = {5C9ADC0F-8239-4B4C-8D41-5A79CC7127C3}
 		{B78CE740-C5E3-F5E8-193D-8D49FCE9C4E3} = {5C9ADC0F-8239-4B4C-8D41-5A79CC7127C3}
+		{90C14ECD-8045-79B5-0C92-53B04A47D9F8} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8386495B-97A2-4105-9FFF-71902F2E61B8}

--- a/ILCompiler/TypeSystem/Common/ArrayType.cs
+++ b/ILCompiler/TypeSystem/Common/ArrayType.cs
@@ -236,8 +236,7 @@ namespace ILCompiler.TypeSystem.Common
 
         public override IList<MethodParameter> Parameters => Signature.Parameters;
 
-        private readonly IList<LocalVariableDefinition> _locals = [];
-        public override IList<LocalVariableDefinition> Locals => _locals;
+        public override IList<LocalVariableDefinition> Locals => _methodIL?.Locals ?? [];
 
         private MethodIL? _methodIL;
         public override MethodIL? MethodIL
@@ -246,7 +245,7 @@ namespace ILCompiler.TypeSystem.Common
             {
                 if (_methodIL == null)
                 {
-                    _methodIL = ArrayMethodILEmitter.EmitIL(this, _locals);
+                    _methodIL = ArrayMethodILEmitter.EmitIL(this);
                 }
                 return _methodIL;
             }

--- a/ILCompiler/TypeSystem/Common/ParameterDefinition.cs
+++ b/ILCompiler/TypeSystem/Common/ParameterDefinition.cs
@@ -1,6 +1,6 @@
 ﻿namespace ILCompiler.TypeSystem.Common
 {
-    internal class ParameterDefinition
+    public class ParameterDefinition
     {
         public readonly TypeDesc Type;
         public readonly string Name;

--- a/ILCompiler/TypeSystem/Common/TypeSystemContext.cs
+++ b/ILCompiler/TypeSystem/Common/TypeSystemContext.cs
@@ -1,11 +1,18 @@
 ﻿using ILCompiler.Compiler;
+using ILCompiler.Interfaces;
 using ILCompiler.TypeSystem.Canon;
 using ILCompiler.TypeSystem.RuntimeDetermined;
 
 namespace ILCompiler.TypeSystem.Common
 {
     public class TypeSystemContext
-    {        
+    {   
+        public IConfiguration Configuration { get; init; }
+        public TypeSystemContext(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
         public TargetDetails Target { get; } = new TargetDetails(TargetArchitecture.Z80);
 
         private readonly Dictionary<string, ArrayType> _arrayTypes = new Dictionary<string, ArrayType>();

--- a/ILCompiler/TypeSystem/IL/Instruction.cs
+++ b/ILCompiler/TypeSystem/IL/Instruction.cs
@@ -3,10 +3,10 @@
     public class Instruction
     {
         public virtual ILOpcode Opcode { get; }
-        public virtual uint Offset { get; }
+        public virtual uint Offset { get; set; }
         public virtual int GetSize() => 1;
 
-        private readonly object? _operand = null;
+        private object? _operand = null;
         public virtual object Operand
         {
             get
@@ -17,12 +17,26 @@
                 }
                 return _operand;
             }
+            set
+            {
+                if (value is null)
+                {
+                    throw new ArgumentNullException(nameof(value), "Operand cannot be null");
+                }
+                _operand = value;
+            }
         }
 
         public Instruction(ILOpcode opcode, uint offset, object? operand = null)
         {
             Opcode = opcode;
             Offset = offset;
+            _operand = operand;
+        }
+
+        public Instruction(ILOpcode opcode, object? operand = null)
+        {
+            Opcode = opcode;
             _operand = operand;
         }
     }

--- a/ILCompiler/TypeSystem/IL/MethodIL.cs
+++ b/ILCompiler/TypeSystem/IL/MethodIL.cs
@@ -4,12 +4,14 @@ namespace ILCompiler.TypeSystem.IL
 {
     public class MethodIL
     {
-        public virtual IList<Instruction> Instructions { get; } = new List<Instruction>();
+        public virtual IList<Instruction> Instructions { get; set; } = new List<Instruction>();
 
         public virtual ILExceptionRegion[] GetExceptionRegions() => [];
         public virtual bool IsInitLocals { get; }
 
         public virtual int LocalsCount { get; set; }
+
+        public List<LocalVariableDefinition> Locals { get; set; } = new List<LocalVariableDefinition>();
 
         public virtual MethodIL GetMethodILDefinition()
         {

--- a/ILCompiler/TypeSystem/IL/Stubs/ILEmitter.cs
+++ b/ILCompiler/TypeSystem/IL/Stubs/ILEmitter.cs
@@ -1,0 +1,106 @@
+﻿using ILCompiler.TypeSystem.Common;
+
+namespace ILCompiler.TypeSystem.IL.Stubs
+{
+    public class ILCodeStream
+    {
+        internal readonly List<Instruction> instructions = [];
+        private readonly List<(Instruction, ILCodeLabel)> _instructionsNeedingPatching = [];
+
+        public void Emit(ILOpcode opcode, object? operand = null)
+        {
+            instructions.Add(new Instruction(opcode, operand));
+        }
+
+        public void Emit(ILOpcode opcode, ILCodeLabel label)
+        {
+            var instruction = new Instruction(opcode);
+            instructions.Add(instruction);
+            _instructionsNeedingPatching.Add((instruction, label));
+        }
+
+        public void EmitLdArg(ParameterDefinition parameter) => Emit(ILOpcode.ldarg, parameter);
+        public void EmitLdFlda(FieldDesc field) => Emit(ILOpcode.ldflda, field);
+        public void EmitLdcI4(int value) => Emit(ILOpcode.ldc_i4, value);
+        public void EmitStLoc(LocalVariableDefinition localVariable) => Emit(ILOpcode.stloc, localVariable);
+        public void EmitLdLoc(LocalVariableDefinition localVariable) => Emit(ILOpcode.ldloc, localVariable);
+
+        public void EmitLabel(ILCodeLabel label)
+        {
+            label.Place(this, instructions.Count);
+        }
+
+        public void PatchLabels()
+        {
+            foreach (var (instruction, label) in _instructionsNeedingPatching)
+            {
+                var targetInstruction = instructions[label.Offset];
+
+                instruction.Operand = targetInstruction;
+            }   
+        }
+    }
+
+    public class ILCodeLabel
+    {
+        private ILCodeStream? _codeStream;
+        private int _offsetWithinCodeStream;
+
+        public int Offset => _codeStream == null ? -1 : _offsetWithinCodeStream;
+
+        internal void Place(ILCodeStream codeStream, int offsetWithinCodeStream)
+        {
+            _codeStream = codeStream;
+            _offsetWithinCodeStream = offsetWithinCodeStream;
+        }
+    }
+
+    internal class ILEmitter
+    {
+        private readonly List<ILCodeStream> _codeStreams = [];
+        private readonly List<LocalVariableDefinition> _locals = [];
+
+        public ILCodeStream NewCodeStream()
+        {
+            var codeStream = new ILCodeStream();
+            _codeStreams.Add(codeStream);
+            return codeStream;
+        }
+
+        public LocalVariableDefinition NewLocal(TypeDesc type, string name)
+        {
+            var local = new LocalVariableDefinition(type, name, _locals.Count);
+            _locals.Add(local);
+            return local;
+        }
+
+        public static ILCodeLabel NewCodeLabel() => new();
+
+        public MethodIL Link()
+        {
+            var allInstructions = new List<Instruction>();
+            uint offset = 0;
+            foreach (var codeStream in _codeStreams)
+            {
+                foreach (var instruction in codeStream.instructions)
+                {
+                    instruction.Offset = offset++;
+                    allInstructions.Add(instruction);
+                }
+            }
+
+            foreach (var codeStream in _codeStreams)
+            {
+                codeStream.PatchLabels();
+            }
+
+            var methodIL = new MethodIL()
+            {
+                Instructions = allInstructions,
+                Locals = _locals,
+                LocalsCount = _locals.Count,
+            };
+            return methodIL;
+        }
+    }
+}

--- a/Tests/ILCompiler.UnitTests/BasicBlockAnalyserTests.cs
+++ b/Tests/ILCompiler.UnitTests/BasicBlockAnalyserTests.cs
@@ -24,10 +24,18 @@ namespace ILCompiler.Tests
             return module.Create(methodDef);
         }
 
+        private DnlibModule CreateModule()
+        {
+            return new DnlibModule(
+                new TypeSystemContext(new Configuration()), 
+                new Compiler.CorLibModuleProvider(), 
+                new RTILProvider());
+        }
+
         [Test]
         public void FindBasicBlocks_WithNoBranches_CreatesBasicBlockWithAlwaysJumpKind()
         {
-            var module = new DnlibModule(new TypeSystemContext(), new Compiler.CorLibModuleProvider(), new RTILProvider());
+            var module = CreateModule();
             var method = BuildMethod(new List<Instruction>()
             {
                 new Instruction(OpCodes.Ldc_I4_0),
@@ -45,7 +53,7 @@ namespace ILCompiler.Tests
         [Test]
         public void FindBasicBlocks_WithOnlyReturn_CreatesBasicBlockWithReturnJumpKind()
         {
-            var module = new DnlibModule(new TypeSystemContext(), new Compiler.CorLibModuleProvider(), new RTILProvider());
+            var module = CreateModule();
             var method = BuildMethod(new List<Instruction>()
             {
                 new Instruction(OpCodes.Ret),
@@ -62,7 +70,7 @@ namespace ILCompiler.Tests
         [Test]
         public void FindBasicBlocks_WithSwitch_CreatesBasicBlockWithSwitchJumpKind()
         {
-            var module = new DnlibModule(new TypeSystemContext(), new Compiler.CorLibModuleProvider(), new RTILProvider());
+            var module = CreateModule();
             var method = BuildMethod(new List<Instruction>()
             {
                 new Instruction(OpCodes.Switch, System.Array.Empty<Instruction>()),
@@ -86,7 +94,7 @@ namespace ILCompiler.Tests
             code.Add(OpCodes.Brfalse.ToInstruction(branchTarget));
             code.Add(OpCodes.Nop.ToInstruction());
             code.Add(branchTarget);
-            var module = new DnlibModule(new TypeSystemContext(), new Compiler.CorLibModuleProvider(), new RTILProvider());
+            var module = CreateModule();
             var method = BuildMethod(code, module);
             var basicBlockAnalyser = new BasicBlockAnalyser(method);
             var offsetToIndexMap = new Dictionary<int, int>();
@@ -100,7 +108,7 @@ namespace ILCompiler.Tests
         [Test]
         public void FindBasicBlocks_WithNoBranches_IdentifiesSingleBasicBlock()
         {
-            var module = new DnlibModule(new TypeSystemContext(), new Compiler.CorLibModuleProvider(), new RTILProvider());
+            var module = CreateModule();
             var method = BuildMethod(new List<Instruction>()
             {
                 new Instruction(OpCodes.Ldc_I4_0),
@@ -125,7 +133,7 @@ namespace ILCompiler.Tests
             code.Add(OpCodes.Brfalse.ToInstruction(branchTarget));
             code.Add(OpCodes.Nop.ToInstruction());
             code.Add(branchTarget);
-            var module = new DnlibModule(new TypeSystemContext(), new Compiler.CorLibModuleProvider(), new RTILProvider());
+            var module = CreateModule();
             var method = BuildMethod(code, module);
             var basicBlockAnalyser = new BasicBlockAnalyser(method);
             var offsetToIndexMap = new Dictionary<int, int>();
@@ -147,7 +155,7 @@ namespace ILCompiler.Tests
             var instructionAfterBranch = OpCodes.Nop.ToInstruction();
             code.Add(instructionAfterBranch);
             code.Add(branchTarget);
-            var module = new DnlibModule(new TypeSystemContext(), new Compiler.CorLibModuleProvider(), new RTILProvider());
+            var module = CreateModule();
             var method = BuildMethod(code, module);
             var basicBlockAnalyser = new BasicBlockAnalyser(method);
             var offsetToIndexMap = new Dictionary<int, int>();
@@ -167,7 +175,7 @@ namespace ILCompiler.Tests
             code.Add(OpCodes.Nop.ToInstruction());
             code.Add(branchTarget);
             code.Add(OpCodes.Br.ToInstruction(branchTarget));
-            var module = new DnlibModule(new TypeSystemContext(), new Compiler.CorLibModuleProvider(), new RTILProvider());
+            var module = CreateModule();
             var method = BuildMethod(code, module);
             var basicBlockAnalyser = new BasicBlockAnalyser(method);
             var offsetToIndexMap = new Dictionary<int, int>();

--- a/Tests/ILCompiler.UnitTests/BasicBlockAnalyserTests.cs
+++ b/Tests/ILCompiler.UnitTests/BasicBlockAnalyserTests.cs
@@ -24,7 +24,7 @@ namespace ILCompiler.Tests
             return module.Create(methodDef);
         }
 
-        private DnlibModule CreateModule()
+        private static DnlibModule CreateModule()
         {
             return new DnlibModule(
                 new TypeSystemContext(new Configuration()), 

--- a/Tests/ILCompiler.UnitTests/CanonicalizationTests.cs
+++ b/Tests/ILCompiler.UnitTests/CanonicalizationTests.cs
@@ -41,7 +41,8 @@ namespace ILCompiler.UnitTests
             string inputFilePath = Path.Combine(SolutionPath, $@".\Tests\CoreTestAssembly\bin\{buildConfigurationName}\net9.0\CoreTestAssembly.dll");
             _testModule = ModuleDefMD.Load(inputFilePath, options);
 
-            var typeSystemContext = new TypeSystemContext();
+            var configuration = new Configuration();
+            var typeSystemContext = new TypeSystemContext(configuration);
             typeSystemContext.GenericsMode = SharedGenericsMode.CanonicalReferenceTypes;
             var corLibModuleProvider = new CorLibModuleProvider();
             corLibModuleProvider.CorLibModule = corlibModule;

--- a/Tests/ILCompiler.UnitTests/InstanceFieldLayoutTests.cs
+++ b/Tests/ILCompiler.UnitTests/InstanceFieldLayoutTests.cs
@@ -36,7 +36,7 @@ namespace ILCompiler.UnitTests
             _testModule = ModuleDefMD.Load(inputFilePath, options);
         }
 
-        private DnlibModule CreateModule()
+        private static DnlibModule CreateModule()
         {
             return new DnlibModule(
                 new TypeSystemContext(new Configuration()),

--- a/Tests/ILCompiler.UnitTests/InstanceFieldLayoutTests.cs
+++ b/Tests/ILCompiler.UnitTests/InstanceFieldLayoutTests.cs
@@ -36,6 +36,14 @@ namespace ILCompiler.UnitTests
             _testModule = ModuleDefMD.Load(inputFilePath, options);
         }
 
+        private DnlibModule CreateModule()
+        {
+            return new DnlibModule(
+                new TypeSystemContext(new Configuration()),
+                new Compiler.CorLibModuleProvider(),
+                new RTILProvider());
+        }
+
         [Test]
         public void TestSequentialTypeLayout_WithFixedSizeBuffer()
         {
@@ -43,7 +51,7 @@ namespace ILCompiler.UnitTests
 
             var target = new TargetDetails(TargetArchitecture.Z80);
 
-            var module = new DnlibModule(new TypeSystemContext(), new Compiler.CorLibModuleProvider(), new RTILProvider());
+            var module = CreateModule();
             var typeDesc = module.Create(typeDef);
             var newMetaDataFieldLayoutAlgorithm = new MetadataFieldLayoutAlgorithm(target);
             var computedFieldLayout = newMetaDataFieldLayoutAlgorithm.ComputeInstanceLayout(typeDesc as DefType);
@@ -95,7 +103,7 @@ namespace ILCompiler.UnitTests
             var target = new TargetDetails(TargetArchitecture.Z80);
             var metadataFieldLayoutAlgorithm = new MetadataFieldLayoutAlgorithm(target);
 
-            var module = new DnlibModule(new TypeSystemContext(), new Compiler.CorLibModuleProvider(), new RTILProvider());
+            var module = CreateModule();
             var typeDesc = module.Create(typeDef);
             var computedFieldLayout = metadataFieldLayoutAlgorithm.ComputeInstanceLayout(typeDesc as DefType);
 
@@ -158,7 +166,7 @@ namespace ILCompiler.UnitTests
             var target = new TargetDetails(TargetArchitecture.Z80);
             var metadataFieldLayoutAlgorithm = new MetadataFieldLayoutAlgorithm(target);
 
-            var module = new DnlibModule(new TypeSystemContext(), new Compiler.CorLibModuleProvider(), new RTILProvider());
+            var module = CreateModule();
             var typeDesc = module.Create(typeDef);
             var computedFieldLayout = metadataFieldLayoutAlgorithm.ComputeInstanceLayout(typeDesc as DefType);
 
@@ -201,7 +209,7 @@ namespace ILCompiler.UnitTests
             var target = new TargetDetails(TargetArchitecture.Z80);
             var metadataFieldLayoutAlgorithm = new MetadataFieldLayoutAlgorithm(target);
 
-            var module = new DnlibModule(new TypeSystemContext(), new Compiler.CorLibModuleProvider(), new RTILProvider());
+            var module = CreateModule();
             var typeDesc = module.Create(typeDef);
             var computedFieldLayout = metadataFieldLayoutAlgorithm.ComputeInstanceLayout(typeDesc as DefType);
 
@@ -259,7 +267,7 @@ namespace ILCompiler.UnitTests
             var target = new TargetDetails(TargetArchitecture.Z80);
             var metadataFieldLayoutAlgorithm = new MetadataFieldLayoutAlgorithm(target);
 
-            var module = new DnlibModule(new TypeSystemContext(), new Compiler.CorLibModuleProvider(), new RTILProvider());
+            var module = CreateModule();
             var typeDesc = module.Create(typeDef);
             var computedFieldLayout = metadataFieldLayoutAlgorithm.ComputeInstanceLayout(typeDesc as DefType);
 

--- a/Tests/ILCompiler.UnitTests/RuntimeDeterminedTypesTests.cs
+++ b/Tests/ILCompiler.UnitTests/RuntimeDeterminedTypesTests.cs
@@ -42,7 +42,7 @@ namespace ILCompiler.UnitTests
             string inputFilePath = Path.Combine(SolutionPath, $@".\Tests\CoreTestAssembly\bin\{buildConfigurationName}\net9.0\CoreTestAssembly.dll");
             _testModule = ModuleDefMD.Load(inputFilePath, options);
 
-            _typeSystemContext = new TypeSystemContext();
+            _typeSystemContext = new TypeSystemContext(new Configuration());
             _typeSystemContext.GenericsMode = SharedGenericsMode.CanonicalReferenceTypes;
             var corLibModuleProvider = new CorLibModuleProvider();
             corLibModuleProvider.CorLibModule = corlibModule;

--- a/Tests/Methodical/MDArrays/RangeCheck/RangeCheck.cs
+++ b/Tests/Methodical/MDArrays/RangeCheck/RangeCheck.cs
@@ -1,0 +1,43 @@
+﻿using System;
+
+namespace RangeCheck
+{
+    public static class Test
+    {
+        public static int Main()
+        {
+            int result = IndexOutOfRangeException_Test_FirstDimension(); if (result != 0) return result;
+            result = IndexOutOfRangeException_Test_SecondDimension(); if (result != 0) return result;
+
+            return result;
+        }
+
+        private static int IndexOutOfRangeException_Test_FirstDimension()
+        {
+            int[,] array = new int[2, 3] { { 1, 2, 3 }, { 4, 5, 6 } };
+            try
+            {
+                int value = array[2, 0]; // This should throw an IndexOutOfRangeException
+                return 1; // If we reach here, the test failed
+            }
+            catch (IndexOutOfRangeException)
+            {
+                return 0; // Test passed
+            }
+        }
+
+        private static int IndexOutOfRangeException_Test_SecondDimension()
+        {
+            int[,] array = new int[2, 3] { { 1, 2, 3 }, { 4, 5, 6 } };
+            try
+            {
+                int value = array[0, 3]; // This should throw an IndexOutOfRangeException
+                return 1; // If we reach here, the test failed
+            }
+            catch (IndexOutOfRangeException)
+            {
+                return 0; // Test passed
+            }
+        }
+    }
+}

--- a/Tests/Methodical/MDArrays/RangeCheck/RangeCheck.cs
+++ b/Tests/Methodical/MDArrays/RangeCheck/RangeCheck.cs
@@ -6,13 +6,15 @@ namespace RangeCheck
     {
         public static int Main()
         {
-            int result = IndexOutOfRangeException_Test_FirstDimension(); if (result != 0) return result;
-            result = IndexOutOfRangeException_Test_SecondDimension(); if (result != 0) return result;
+            int result = ReadBeyondEndOfFirstDimension_Test(); if (result != 0) return result;
+            result = ReadBeyondEndOfSecondDimension_Test(); if (result != 0) return result;
+            result = WriteBeyondEndOfFirstDimension_Test(); if (result != 0) return result;
+            result = WriteBeyondEndOfSecondDimension_Test(); if (result != 0) return result;
 
             return result;
         }
 
-        private static int IndexOutOfRangeException_Test_FirstDimension()
+        private static int ReadBeyondEndOfFirstDimension_Test()
         {
             int[,] array = new int[2, 3] { { 1, 2, 3 }, { 4, 5, 6 } };
             try
@@ -26,12 +28,40 @@ namespace RangeCheck
             }
         }
 
-        private static int IndexOutOfRangeException_Test_SecondDimension()
+        private static int ReadBeyondEndOfSecondDimension_Test()
         {
             int[,] array = new int[2, 3] { { 1, 2, 3 }, { 4, 5, 6 } };
             try
             {
                 int value = array[0, 3]; // This should throw an IndexOutOfRangeException
+                return 1; // If we reach here, the test failed
+            }
+            catch (IndexOutOfRangeException)
+            {
+                return 0; // Test passed
+            }
+        }
+
+        private static int WriteBeyondEndOfFirstDimension_Test()
+        {
+            int[,] array = new int[2, 3] { { 1, 2, 3 }, { 4, 5, 6 } };
+            try
+            {
+                array[2, 0] = 10; // This should throw an IndexOutOfRangeException
+                return 1; // If we reach here, the test failed
+            }
+            catch (IndexOutOfRangeException)
+            {
+                return 0; // Test passed
+            }
+        }
+
+        private static int WriteBeyondEndOfSecondDimension_Test()
+        {
+            int[,] array = new int[2, 3] { { 1, 2, 3 }, { 4, 5, 6 } };
+            try
+            {
+                array[0, 3] = 10; // This should throw an IndexOutOfRangeException
                 return 1; // If we reach here, the test failed
             }
             catch (IndexOutOfRangeException)

--- a/Tests/Methodical/MDArrays/RangeCheck/RangeCheck.csproj
+++ b/Tests/Methodical/MDArrays/RangeCheck/RangeCheck.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+	 <Nullable>enable</Nullable>
+
+    <RuntimeMetadataVersion>v4.0.30319</RuntimeMetadataVersion>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+        
+    <!--Disable .NET Core SDK libs-->
+    <NoStdLib>true</NoStdLib>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+	  <!-- Prevent .NET Core 3+ from generating exe -->
+	  <UseAppHost>false</UseAppHost>
+
+	  <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\System.Private.CoreLib\System.Private.CoreLib.csproj" />
+    <ProjectReference Include="..\..\..\..\ILCompiler\ILCompiler.csproj" />
+  </ItemGroup>
+  
+</Project>


### PR DESCRIPTION
Adds support for range checks on multi-dimensional arrays
Added ILEmitter to make generation of IL for array methods easier.
Simple test to check IndexOutOfRangeException thrown when reading/writing array elements beyond end of dimension

Contributes to #55 