### PR TITLE
Add ArrayLengthEntry node

### DIFF
--- a/ILCompiler/Compiler/EvaluationStack/ArrayLengthEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/ArrayLengthEntry.cs
@@ -1,0 +1,32 @@
+﻿using ILCompiler.Compiler.LinearIR;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ILCompiler.Compiler.EvaluationStack
+{
+    public class ArrayLengthEntry : StackEntry
+    {
+        public StackEntry ArrayReference { get; set; }
+        public ArrayLengthEntry(StackEntry arrayReference) : base(VarType.Ptr, 2)
+        {
+            ArrayReference = arrayReference;
+        }
+
+        public override StackEntry Duplicate()
+        {
+            return new ArrayLengthEntry(ArrayReference);
+        }
+
+        public override void Accept(IStackEntryVisitor visitor) => visitor.Visit(this);
+
+        public override bool TryGetUse(StackEntry operand, [NotNullWhen(true)] out Edge<StackEntry>? edge)
+        {
+            if (operand == ArrayReference)
+            {
+                edge = new Edge<StackEntry>(() => ArrayReference, x => ArrayReference = x);
+                return true;
+            }
+            return base.TryGetUse(operand, out edge);
+        }
+
+    }
+}

--- a/ILCompiler/Compiler/EvaluationStack/GenericStackEntryAdapter.cs
+++ b/ILCompiler/Compiler/EvaluationStack/GenericStackEntryAdapter.cs
@@ -37,5 +37,6 @@
         public void Visit(NullCheckEntry entry) => _genericStackEntryVisitor.Visit<NullCheckEntry>(entry);
         public void Visit(CatchArgumentEntry entry) => _genericStackEntryVisitor.Visit<CatchArgumentEntry>(entry);
         public void Visit(TokenEntry entry) => _genericStackEntryVisitor.Visit<TokenEntry>(entry);
+        public void Visit(ArrayLengthEntry entry) => _genericStackEntryVisitor.Visit<ArrayLengthEntry>(entry);
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/IStackEntryVisitor.cs
+++ b/ILCompiler/Compiler/EvaluationStack/IStackEntryVisitor.cs
@@ -36,5 +36,6 @@
         public void Visit(NullCheckEntry entry);
         public void Visit(CatchArgumentEntry entry);
         public void Visit(TokenEntry entry);
+        public void Visit(ArrayLengthEntry entry);
     }
 }

--- a/ILCompiler/Compiler/Flowgraph.cs
+++ b/ILCompiler/Compiler/Flowgraph.cs
@@ -220,6 +220,12 @@ namespace ILCompiler.Compiler
             SetNext(entry);
         }
 
+        public void Visit(ArrayLengthEntry entry)
+        {
+            entry.ArrayReference.Accept(this);
+            SetNext(entry);
+        }
+
         private void SetNext(StackEntry entry)
         {
             if (Current != null)

--- a/ILCompiler/Compiler/Importer/LoadLengthImporter.cs
+++ b/ILCompiler/Compiler/Importer/LoadLengthImporter.cs
@@ -11,9 +11,7 @@ namespace ILCompiler.Compiler.Importer
             if (instruction.Opcode != ILOpcode.ldlen) return false;
 
             var addr = importer.PopExpression();
-            var arraySizeOffset = new NativeIntConstantEntry(2);
-            addr = new BinaryOperator(Operation.Add, isComparison: false, addr, arraySizeOffset, VarType.Ptr);
-            var node = new IndirectEntry(addr, VarType.Ptr, 2);
+            var node = new ArrayLengthEntry(addr);
             importer.PushExpression(node);
             return true;
         }

--- a/ILCompiler/Compiler/LIRDumper.cs
+++ b/ILCompiler/Compiler/LIRDumper.cs
@@ -161,6 +161,12 @@ namespace ILCompiler.Compiler
             _sb.AppendLine($"       cast {entry.Type}");
         }
 
+        public void Visit(ArrayLengthEntry entry)
+        {
+            _sb.AppendLine($"       ┌──▌  t{entry.ArrayReference.TreeID}");
+            _sb.AppendLine($"       arrayLength {entry.Type}");
+        }
+
         public void Visit(NullCheckEntry entry)
         {
             _sb.AppendLine($"       nullcheck {entry.Op1.TreeID}");

--- a/ILCompiler/Compiler/LinearIR/Range.cs
+++ b/ILCompiler/Compiler/LinearIR/Range.cs
@@ -119,6 +119,16 @@ namespace ILCompiler.Compiler.LinearIR
             FinishInsertionAfter(insertionPoint, node1, node2);
         }
 
+        public void InsertAfter(StackEntry insertionPoint, StackEntry node1, StackEntry node2, StackEntry node3)
+        {
+            node1.Next = node2;
+            node2.Prev = node1;
+            node2.Next = node3;
+            node3.Prev = node2;
+
+            FinishInsertionAfter(insertionPoint, node1, node3);
+        }
+
         private void FinishInsertionAfter(StackEntry insertionPoint, StackEntry first, StackEntry last)
         {
             if (insertionPoint == null)

--- a/ILCompiler/Compiler/Lowerings/ArrayLengthLowering.cs
+++ b/ILCompiler/Compiler/Lowerings/ArrayLengthLowering.cs
@@ -1,0 +1,33 @@
+﻿using ILCompiler.Compiler.EvaluationStack;
+using ILCompiler.Compiler.LinearIR;
+
+namespace ILCompiler.Compiler.Lowerings
+{
+    internal class ArrayLengthLowering : ILowering<ArrayLengthEntry>
+    {
+        public StackEntry? Lower(ArrayLengthEntry entry, BasicBlock block, LocalVariableTable locals)
+        {
+            var blockRange = block;
+            if (!blockRange.TryGetUse(entry, out Use? use))
+            {
+                return null;
+            }
+
+            // Create the expression "*(array_address + length_offset)"
+            var arraySizeOffset = new NativeIntConstantEntry(2);
+            var addr = new BinaryOperator(Operation.Add, isComparison: false, entry.ArrayReference, arraySizeOffset, VarType.Ptr);
+            var node = new IndirectEntry(addr, VarType.Ptr, 2);
+
+            // Insert new nodes after existing ArrayLengthEntry
+            blockRange.InsertAfter(entry.ArrayReference, arraySizeOffset, addr, node);
+
+            // Remove the original ArrayLengthEntry
+            blockRange.Remove(entry);
+
+            // Replace the use of the original ArrayLengthEntry with the new node
+            use.ReplaceWith(node);
+
+            return node;
+        }
+    }
+}

--- a/ILCompiler/Compiler/Lowerings/ServiceCollectionExtensions.cs
+++ b/ILCompiler/Compiler/Lowerings/ServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ namespace ILCompiler.Compiler.Lowerings
             services.AddSingleton<ILowering<JumpTrueEntry>, JumpTrueLowering>();
             services.AddSingleton<ILowering<StoreLocalVariableEntry>, StoreLocalVariableLowering>();
             services.AddSingleton<ILowering<IndirectEntry>, IndirectLowering>();
+            services.AddSingleton<ILowering<ArrayLengthEntry>, ArrayLengthLowering>();
             return services;
         }
     }

--- a/ILCompiler/Compiler/Morpher.cs
+++ b/ILCompiler/Compiler/Morpher.cs
@@ -125,6 +125,10 @@ namespace ILCompiler.Compiler
                 case NullCheckEntry nullCheckEntry:
                     tree = new NullCheckEntry(MorphTree(nullCheckEntry.Op1));
                     break;
+
+                case ArrayLengthEntry arrayLengthEntry:
+                    tree = new ArrayLengthEntry(MorphTree(arrayLengthEntry.ArrayReference));
+                    break;
             }
             return tree;
         }

--- a/ILCompiler/Compiler/TreeDumper.cs
+++ b/ILCompiler/Compiler/TreeDumper.cs
@@ -171,6 +171,14 @@ namespace ILCompiler.Compiler
             _indent--;
         }
 
+        public void Visit(ArrayLengthEntry entry)
+        {
+            Print($"ARRAYLENGTH {entry.Type}");
+            _indent++;
+            entry.ArrayReference.Accept(this);
+            _indent--;
+        }
+
         public void Visit(NullCheckEntry entry)
         {
             Print($"NULLCHECK");


### PR DESCRIPTION
Add lowering for this node to convert to indirection

No overall functional changes but sets up for introducing a new phase after SSA to convert ArrayLengthEntry to constant node when array length can be determined from SSA info.

Initial work for #611 