### PR TITLE
Add Early Value Propagation phase

### DIFF
--- a/ILCompiler/Compiler/BasicBlock.cs
+++ b/ILCompiler/Compiler/BasicBlock.cs
@@ -28,7 +28,7 @@ namespace ILCompiler.Compiler
         public ISet<BasicBlock> Reach { get; } = new HashSet<BasicBlock>();
 
         // High level intermediate representation - main output of importation process
-        public IList<StackEntry> Statements { get; } = new List<StackEntry>();
+        public IList<Statement> Statements { get; } = new List<Statement>();
 
         public bool Marked { get; set; } = false;
 

--- a/ILCompiler/Compiler/CodeGenerators/CastCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/CastCodeGenerator.cs
@@ -123,6 +123,12 @@ namespace ILCompiler.Compiler.CodeGenerators
 
             var key = CreateKey(actualType, desiredType);
 
+            // If the types are the same, no cast is needed
+            if (actualType == desiredType)
+            {
+                return;
+            }
+
             if (_codeGeneratorActionsMap.TryGetValue(key, out Action<CodeGeneratorContext>? generateCastCode))
             {
                 generateCastCode(context);

--- a/ILCompiler/Compiler/EarlyValuePropagation.cs
+++ b/ILCompiler/Compiler/EarlyValuePropagation.cs
@@ -1,0 +1,144 @@
+﻿using ILCompiler.Compiler.EvaluationStack;
+using ILCompiler.Compiler.LinearIR;
+using ILCompiler.Interfaces;
+
+namespace ILCompiler.Compiler
+{
+    internal class EarlyValuePropagation : IEarlyValuePropagation
+    {
+        private readonly IFlowgraph _flowgraph;
+        public EarlyValuePropagation(IFlowgraph flowgraph)
+        {
+            _flowgraph = flowgraph;
+        }
+
+        public void Run(IList<BasicBlock> blocks, LocalVariableTable locals)
+        {
+            foreach (var block in blocks)
+            {
+                foreach (var statement in block.Statements)
+                {
+                    bool isRewritten = false;
+                    foreach (var tree in statement.TreeList)
+                    {
+                        var rewrittenTree = EarlyPropagationRewriteTree(block, tree, locals);
+                        if (rewrittenTree != null)
+                        {
+                            isRewritten = true;
+                        }
+                    }
+
+                    if (isRewritten)
+                    {
+                        // Update the evaluation order
+                        _flowgraph.SetStatementSequence(statement);
+                    }
+                }
+            }
+        }
+
+        private StackEntry? EarlyPropagationRewriteTree(BasicBlock block, StackEntry tree, LocalVariableTable locals)
+        {
+            if (tree is ArrayLengthEntry arrayLengthEntry)
+            {
+                if (arrayLengthEntry.ArrayReference is LocalVariableEntry localVariableEntry)
+                {
+                    var localNumber = localVariableEntry.LocalNumber;
+
+                    var localVariableDescriptor = locals[localNumber];
+                    if (localVariableDescriptor.InSsa)
+                    {
+                        var ssaNumber = localVariableEntry.SsaNumber;
+
+                        var actualValue = PropagationGetValue(localNumber, ssaNumber, locals);
+
+                        if (actualValue is not null)
+                        {
+                            int actualConstValue = actualValue.GetIntConstant();
+
+                            var actualValueClone = actualValue.Duplicate();
+
+                            // Replace tree with actualValueClone
+                            if (!block.TryGetUse(tree, out Use? use))
+                            {
+                                return null;
+                            }
+                            use.ReplaceWith(actualValueClone);
+
+                            return tree;
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private StackEntry? PropagationGetValue(int localNumber, int ssaNumber, LocalVariableTable locals)
+        {
+            return PropagationGetValueRecursive(localNumber, ssaNumber, 0, locals);
+        }
+
+        private StackEntry? PropagationGetValueRecursive(int localNumber, int ssaNumber, int walkDepth, LocalVariableTable locals)
+        {
+            // Bound the recursion
+            if (walkDepth > 5)
+            {
+                return null;
+            }
+
+            var local = locals[localNumber];
+            var ssaVariableDescriptor = local.GetPerSsaData(ssaNumber);
+
+            var ssaDefStore = ssaVariableDescriptor.DefNode;
+
+            StackEntry? value = null;
+
+            if (ssaDefStore is not null)
+            {
+                if (ssaDefStore is StoreLocalVariableEntry storeLocalVariableEntry && 
+                    storeLocalVariableEntry.LocalNumber == localNumber &&
+                    storeLocalVariableEntry.Op1 is LocalVariableEntry defValue)
+                {
+                    var defValueLocalNumber = defValue.LocalNumber;
+                    var defValueSsaNumber = defValue.SsaNumber;
+                    // Recurse to find the value
+                    value = PropagationGetValueRecursive(defValueLocalNumber, defValueSsaNumber, walkDepth + 1, locals);
+                }
+                else
+                {
+                    // This is the allocation of the array
+                    var storeLocalVariable = (StoreLocalVariableEntry)ssaDefStore;
+                    StackEntry? arrayLength = GetArrayLengthFromAllocation(storeLocalVariable.Op1);
+
+                    if (arrayLength is not null && arrayLength.IsIntCnsOrI())
+                    {
+                        value = arrayLength;
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        private static StackEntry? GetArrayLengthFromAllocation(StackEntry tree)
+        {
+            StackEntry? arrayLength = null;
+            // TODO: more precise check on method
+            if (tree is CallEntry call && call.TargetMethod == "NewArray")
+            {
+                // Get the array length parameter from the call
+                arrayLength = call.Arguments[1];
+            }
+
+            if (arrayLength is not null)
+            {
+                arrayLength = arrayLength is PutArgTypeEntry putArgTypeEntry
+                    ? putArgTypeEntry.Op1
+                    : arrayLength;
+            }
+
+            return arrayLength;
+        }
+    }
+}

--- a/ILCompiler/Compiler/EvaluationStack/ILocalVariable.cs
+++ b/ILCompiler/Compiler/EvaluationStack/ILocalVariable.cs
@@ -3,6 +3,6 @@
     public interface ILocalVariable
     {
         public int LocalNumber { get; }
-        public int SsaNumber { get; }
+        public int SsaNumber { get; set; }
     }
 }

--- a/ILCompiler/Compiler/EvaluationStack/LocalVariableAddressEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/LocalVariableAddressEntry.cs
@@ -3,7 +3,7 @@
     public class LocalVariableAddressEntry : StackEntry, ILocalVariable
     {
         public int LocalNumber { get; }
-        public int SsaNumber { get; }
+        public int SsaNumber { get; set;  }
 
         public LocalVariableAddressEntry(int localNumber) : base(VarType.Ptr, VarType.Ptr.GetTypeSize())
         {

--- a/ILCompiler/Compiler/EvaluationStack/PhiArg.cs
+++ b/ILCompiler/Compiler/EvaluationStack/PhiArg.cs
@@ -3,7 +3,7 @@
     public class PhiArg : StackEntry, ILocalVariable
     {
         public int LocalNumber { get; }
-        public int SsaNumber { get; }
+        public int SsaNumber { get; set; }
         public BasicBlock Block { get; }
 
         public PhiArg(VarType type, int localNumber, int ssaNumber, BasicBlock block) : base(type)

--- a/ILCompiler/Compiler/EvaluationStack/Statement.cs
+++ b/ILCompiler/Compiler/EvaluationStack/Statement.cs
@@ -1,0 +1,16 @@
+﻿namespace ILCompiler.Compiler.EvaluationStack
+{
+    public class Statement
+    {
+        public StackEntry RootNode { get; init; }
+
+        public List<StackEntry> TreeList { get; set; } = [];
+
+        public Statement(StackEntry rootNode)
+        {
+            RootNode = rootNode;
+        }
+
+        public bool IsPhiDefinition => RootNode is StoreLocalVariableEntry store && store.Op1 is PhiNode;
+    }
+}

--- a/ILCompiler/Compiler/ILImporter.cs
+++ b/ILCompiler/Compiler/ILImporter.cs
@@ -151,21 +151,21 @@ namespace ILCompiler.Compiler
                 ImportSpillAppendTree(entry);
             }
             else
-            {
-                _currentBasicBlock?.Statements.Add(entry);
+            {                
+                _currentBasicBlock?.Statements.Add(new Statement(entry));
             }
         }
 
         private StackEntry? ImportExtractLastStmt()
         {
-            StackEntry? lastStmt = null;
+            Statement? lastStmt = null;
             if (_currentBasicBlock?.Statements.Count > 0)
             {
                 var lastStatementIndex = _currentBasicBlock.Statements.Count - 1;
                 lastStmt = _currentBasicBlock.Statements[lastStatementIndex];
                 _currentBasicBlock.Statements.RemoveAt(lastStatementIndex);
             }
-            return lastStmt;
+            return lastStmt?.RootNode;
         }
 
         private void ImportBasicBlock(IDictionary<int, int> offsetToIndexMap, BasicBlock block)
@@ -306,7 +306,7 @@ namespace ILCompiler.Compiler
                     var targetMethod = _nameMangler.GetMangledMethodName(staticConstructorMethod);
                     var staticInitCall = new CallEntry(targetMethod, new List<StackEntry>(), VarType.Void, 0);
 
-                    _basicBlocks[0].Statements.Add(staticInitCall);
+                    _basicBlocks[0].Statements.Add(new Statement(staticInitCall));
                 }
             }
 

--- a/ILCompiler/Compiler/LinearIR/Range.cs
+++ b/ILCompiler/Compiler/LinearIR/Range.cs
@@ -80,6 +80,11 @@ namespace ILCompiler.Compiler.LinearIR
             FinishInsertionBefore(insertion, range.FirstNode, range.LastNode);
         }
 
+        public void InsertAtEnd(Range range)
+        {
+            InsertAfter(LastNode, range);
+        }
+
         private void FinishInsertionBefore(StackEntry insertionPoint, StackEntry first, StackEntry last)
         {
             if (insertionPoint == null)
@@ -129,7 +134,13 @@ namespace ILCompiler.Compiler.LinearIR
             FinishInsertionAfter(insertionPoint, node1, node3);
         }
 
-        private void FinishInsertionAfter(StackEntry insertionPoint, StackEntry first, StackEntry last)
+        public void InsertAfter(StackEntry? insertion, Range range)
+        {
+            Debug.Assert(!range.IsEmpty);
+            FinishInsertionAfter(insertion, range.FirstNode!, range.LastNode!);
+        }
+
+        private void FinishInsertionAfter(StackEntry? insertionPoint, StackEntry first, StackEntry last)
         {
             if (insertionPoint == null)
             {
@@ -172,5 +183,7 @@ namespace ILCompiler.Compiler.LinearIR
         }
 
         IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+
+        public bool IsEmpty => FirstNode == null || LastNode == null;
     }
 }

--- a/ILCompiler/Compiler/MethodCompiler.cs
+++ b/ILCompiler/Compiler/MethodCompiler.cs
@@ -166,6 +166,10 @@ namespace ILCompiler.Compiler
             var ssaBuilder = _phaseFactory.Create<ISsaBuilder>();
             ssaBuilder.Build(basicBlocks, _locals, _configuration.DumpSsa);
 
+            // Early Value Propagation
+            var earlyValuePropagation = _phaseFactory.Create<IEarlyValuePropagation>();
+            earlyValuePropagation.Run(basicBlocks, _locals);
+
             // Rationalize
             // LIR valid from here on - nodes are fully linked across statements
             var rationalizer = _phaseFactory.Create<IRationalizer>();

--- a/ILCompiler/Compiler/MethodCompiler.cs
+++ b/ILCompiler/Compiler/MethodCompiler.cs
@@ -166,6 +166,11 @@ namespace ILCompiler.Compiler
             var ssaBuilder = _phaseFactory.Create<ISsaBuilder>();
             ssaBuilder.Build(basicBlocks, _locals, _configuration.DumpSsa);
 
+            // Rationalize
+            // LIR valid from here on - nodes are fully linked across statements
+            var rationalizer = _phaseFactory.Create<IRationalizer>();
+            rationalizer.Rationalize(basicBlocks);
+
             if (_configuration.DumpIRTrees)
             {
                 // Dump LIR here
@@ -173,10 +178,6 @@ namespace ILCompiler.Compiler
                 var lirDump = lirDumper.Dump(basicBlocks);
                 _logger.LogInformation("{lirDump}", lirDump);
             }
-
-            // Rationalize
-            var rationalizer = _phaseFactory.Create<IRationalizer>();
-            rationalizer.Rationalize(basicBlocks);
 
             // Lower
             var lowering = _phaseFactory.Create<ILowering>();

--- a/ILCompiler/Compiler/Morpher.cs
+++ b/ILCompiler/Compiler/Morpher.cs
@@ -20,10 +20,10 @@ namespace ILCompiler.Compiler
 
         private void MorphStatements(BasicBlock block)
         {
-            var morphedStatements = new List<StackEntry>();
+            var morphedStatements = new List<Statement>();
             foreach (var statement in block.Statements)
             {
-                morphedStatements.Add(MorphTree(statement));
+                morphedStatements.Add(MorphStatement(statement));
             }
 
             block.Statements.Clear();
@@ -32,6 +32,8 @@ namespace ILCompiler.Compiler
                 block.Statements.Add(morphedStatement);
             }
         }
+
+        private Statement MorphStatement(Statement statement) => new Statement(MorphTree(statement.RootNode));
 
         private StackEntry MorphTree(StackEntry tree)
         {

--- a/ILCompiler/Compiler/Rationalizer.cs
+++ b/ILCompiler/Compiler/Rationalizer.cs
@@ -10,6 +10,15 @@ namespace ILCompiler.Compiler
         {
             foreach (var block in blocks)
             {
+                // Link IR in statements together
+                foreach (var statement in block.Statements)
+                {
+                    var firstNode = statement.TreeList[0];
+                    var lastNode = statement.TreeList[^1];
+
+                    block.InsertAtEnd(new LinearIR.Range(firstNode, lastNode));
+                }
+               
                 if (block.Statements.Count > 0)
                 {
                     RemovePhiNodes(block);

--- a/ILCompiler/Compiler/Ssa/Liveness.cs
+++ b/ILCompiler/Compiler/Ssa/Liveness.cs
@@ -66,7 +66,6 @@ namespace ILCompiler.Compiler
             }
         }
 
-
         private static void PerBlockLocalVarLiveness(IList<BasicBlock> blocks, ILogger<SsaBuilder> logger)
         {
             foreach (var block in blocks)
@@ -75,11 +74,17 @@ namespace ILCompiler.Compiler
                 var defSet = VariableSet.Empty;
 
                 // Enumerate nodes in each statement in evaluation order
-                var currentNode = block.FirstNode;
-                while (currentNode != null)
+
+                foreach (var statement in block.Statements)
                 {
-                    PerNodeLocalVarLiveness(currentNode, useSet, defSet);
-                    currentNode = currentNode.Next;
+                    // Filter out phi definitions
+                    if (statement.IsPhiDefinition)
+                        continue;
+
+                    foreach (var node in statement.TreeList)
+                    {
+                        PerNodeLocalVarLiveness(node, useSet, defSet);
+                    }
                 }
 
                 block.VarDef = defSet;

--- a/ILCompiler/Compiler/Ssa/LocalSsaVariableDescriptor.cs
+++ b/ILCompiler/Compiler/Ssa/LocalSsaVariableDescriptor.cs
@@ -1,4 +1,6 @@
-﻿namespace ILCompiler.Compiler.Ssa
+﻿using ILCompiler.Compiler.EvaluationStack;
+
+namespace ILCompiler.Compiler.Ssa
 {
     public class LocalSsaVariableDescriptor
     {
@@ -9,9 +11,17 @@
 
         public int NumberOfUses { get; private set; } = 0;
 
+        public StackEntry? DefNode { get; private set; }
+
         public LocalSsaVariableDescriptor(BasicBlock block)
         {
             Block = block;
+        }
+
+        public LocalSsaVariableDescriptor(BasicBlock block, StackEntry defNode)
+        {
+            Block = block;
+            DefNode = defNode;
         }
 
         public void AddUse(BasicBlock block)

--- a/ILCompiler/Compiler/Ssa/SsaRenameState.cs
+++ b/ILCompiler/Compiler/Ssa/SsaRenameState.cs
@@ -40,8 +40,9 @@ namespace ILCompiler.Compiler.Ssa
             }
             else
             {
-                var top = stack.Peek();
+                var top = stack.Pop();
                 top.SsaNumber = ssaNumber;
+                stack.Push(top);
             }
 
             DumpStack(lclNumber);

--- a/ILCompiler/Compiler/SsaBuilder.cs
+++ b/ILCompiler/Compiler/SsaBuilder.cs
@@ -114,7 +114,8 @@ namespace ILCompiler.Compiler
             for (int localVariableNumber = 0; localVariableNumber < locals.Count; localVariableNumber++)
             {
                 var localVariableDescriptor = locals[localVariableNumber];
-                if (localVariableDescriptor.IsParameter || localVariableDescriptor.MustInit) 
+                if (localVariableDescriptor.IsParameter || localVariableDescriptor.MustInit || 
+                    localVariableDescriptor.Type.IsGC())
                 {
                     var ssaNumber = localVariableDescriptor.PerSsaData.AllocSsaNumber(() => new LocalSsaVariableDescriptor(tree.Block));
                     ssaRenameStack.Push(tree.Block, localVariableNumber, ssaNumber);
@@ -196,18 +197,15 @@ namespace ILCompiler.Compiler
 
         private static bool HasPhiNode(BasicBlock block, int localNumber)
         {
-            var node = block.FirstNode;
-            while (node != null)
+            foreach (var statement in block.Statements)
             {
-                if (node is PhiNode phi)
+                if (statement.RootNode is StoreLocalVariableEntry store && store.Op1 is PhiNode phi)
                 {
-                    var store = phi.Next as StoreLocalVariableEntry;
                     if (store?.LocalNumber == localNumber)
                     {
                         return true;
                     }
                 }
-                node = node.Next;
             }
 
             return false;
@@ -223,18 +221,15 @@ namespace ILCompiler.Compiler
             var store = new StoreLocalVariableEntry(localNumber, false, phiNode);
 
             // Create the statement and chain together in linear order e.g. PhiNode followed by StoreLocalVariableEntry
+            var statement = new Statement(store)
+            {
+                TreeList = new List<StackEntry> { phiNode, store }
+            };
             phiNode.Next = store;
             store.Prev = phiNode;
 
             // Add new store/phi statement to start of block
-            store.Next = block.FirstNode;
-            if (block.FirstNode != null)
-            {
-                block.FirstNode.Prev = store;
-            }
-
-            block.FirstNode = phiNode;
-            block.Statements.Insert(0, store);
+            block.Statements.Insert(0, statement);
 
             if (_dumpSsa)
             {

--- a/ILCompiler/Compiler/TreeDumper.cs
+++ b/ILCompiler/Compiler/TreeDumper.cs
@@ -31,7 +31,7 @@ namespace ILCompiler.Compiler
                     _sb.AppendLine($"STMT{stmtId}");
                     _indent++;
 
-                    statement.Accept(this);
+                    statement.RootNode.Accept(this);
                     stmtId++;
                 }
             }

--- a/ILCompiler/Compiler/TypeList.cs
+++ b/ILCompiler/Compiler/TypeList.cs
@@ -23,7 +23,7 @@
         ByRef,
         Struct,     // Custom Value Types
 
-        Ptr,        // Unmanaged pointers, NativeInt, NativeUInt
+        Ptr,        // Unmanaged pointers, Native sized Integers
     }
 
     public static class VarTypeExtensions
@@ -56,6 +56,11 @@
         public static bool IsInt(this VarType type)
         {
             return type >= VarType.Byte && type <= VarType.UInt;
+        }
+
+        public static bool IsGC(this VarType type)
+        {
+            return type == VarType.Ref || type == VarType.ByRef;
         }
 
         public static bool GenActualTypeIsI(this VarType type)

--- a/ILCompiler/Interfaces/IEarlyValuePropagation.cs
+++ b/ILCompiler/Interfaces/IEarlyValuePropagation.cs
@@ -1,0 +1,9 @@
+﻿using ILCompiler.Compiler;
+
+namespace ILCompiler.Interfaces
+{
+    internal interface IEarlyValuePropagation : IPhase
+    {
+        void Run(IList<BasicBlock> blocks, LocalVariableTable locals);
+    }
+}

--- a/ILCompiler/Interfaces/IFlowgraph.cs
+++ b/ILCompiler/Interfaces/IFlowgraph.cs
@@ -1,9 +1,11 @@
 ﻿using ILCompiler.Compiler;
+using ILCompiler.Compiler.EvaluationStack;
 
 namespace ILCompiler.Interfaces
 {
     public interface IFlowgraph : IPhase
     {
         void SetBlockOrder(IList<BasicBlock> blocks);
+        void SetStatementSequence(Statement statement);
     }
 }

--- a/ILCompiler/IoC/ServiceProviderFactory.cs
+++ b/ILCompiler/IoC/ServiceProviderFactory.cs
@@ -52,6 +52,8 @@ namespace ILCompiler.IoC
 
             services.AddTransient<IRationalizer, Rationalizer>();
 
+            services.AddTransient<IEarlyValuePropagation, EarlyValuePropagation>();
+
             services.AddTransient<IFlowgraph, Flowgraph>();
 
             services.AddTransient<ISsaBuilder, SsaBuilder>();


### PR DESCRIPTION
Use SSA use-def chains to propagate constant size array to ldlen and rewrite as constant load.
Refactor basic block to use explicit representation of statements to facilitate fixing up evaluation order at a statement level.
Fix number of bugs/missing functionality in SSA