### PR TITLE
Fix binary operator optimisation for multiply by native int of 1

### DIFF
--- a/ILCompiler/Compiler/Importer/BinaryOperationImporter.cs
+++ b/ILCompiler/Compiler/Importer/BinaryOperationImporter.cs
@@ -40,6 +40,12 @@ namespace ILCompiler.Compiler.Importer
             if ((op2.IsIntegralConstant(0) && (binaryOp == Operation.Add || binaryOp == Operation.Sub)) ||
                 op2.IsIntegralConstant(1) && (binaryOp == Operation.Mul || binaryOp == Operation.Div))
             {
+                // If the second operand is a native int then need to still ensure op1 is cast to be a native int
+                if (op2.Type == VarType.Ptr)
+                {
+                    op1 = CodeFolder.FoldExpression(new CastEntry(op1, VarType.Ptr));
+                }
+
                 importer.PushExpression(op1);
                 return true;
             }

--- a/Tests/Regression/Regression/RegressionTests.cs
+++ b/Tests/Regression/Regression/RegressionTests.cs
@@ -1,4 +1,6 @@
-﻿namespace Regression
+﻿using Internal.Runtime.CompilerServices;
+
+namespace Regression
 {
     public static class Regression
     {
@@ -17,7 +19,15 @@
 
             Assert.AreEqual(10, Bug545Method<int>().Length);
 
+            Bug617();
+
             return 0;
+        }
+
+        public unsafe static void Bug617()
+        {
+            byte value = 42;
+            Unsafe.Add<byte>(ref value, 0);
         }
 
         public unsafe static nuint Bug206(int count)


### PR DESCRIPTION
Importer needs to add cast if 1 is a native int/ptr.

Resolves #617 