### PR TITLE
Handle Main method with args

### DIFF
--- a/ILCompiler/Compiler/Z80AssemblyWriter.cs
+++ b/ILCompiler/Compiler/Z80AssemblyWriter.cs
@@ -134,12 +134,25 @@ namespace ILCompiler.Compiler
 
             instructionsBuilder.Label("START");
 
+            LoadMainArguments(instructionsBuilder, entryMethod);
+
             instructionsBuilder.Call(_nameMangler.GetMangledMethodName(entryMethod));
 
             instructionsBuilder.Label("EH_ENDIP");
             instructionsBuilder.Jp("EXITRETCODE");
 
             _out.Write(instructionsBuilder.ToString());
+        }
+
+        private static void LoadMainArguments(InstructionsBuilder instructionsBuilder, MethodDesc entryMethod)
+        {
+            // If Main method has string[] args then need to push reference on the stack here
+            if (entryMethod.Parameters.Count > 0)
+            {
+                // Push a null reference for the args array
+                instructionsBuilder.Ld(HL, 0);
+                instructionsBuilder.Push(HL);
+            }
         }
 
         private void RelocateStack(InstructionsBuilder instructionsBuilder)


### PR DESCRIPTION
No parsing of any real args for now - just supplies a null string[] as the actual arg to prevent the program from hanging on exit.

Fixes #630 