### PR TITLE
Extend mini Xunit asserts to handle equality on IEnumerables

### DIFF
--- a/ILCompiler/TypeSystem/Common/VirtualMethodAlgorithm.cs
+++ b/ILCompiler/TypeSystem/Common/VirtualMethodAlgorithm.cs
@@ -151,9 +151,15 @@
                         foundOnCurrentType = FindSlotDefiningMethodForVirtualMethod(foundOnCurrentType);
                     }
 
-                    if (baseType != null && foundOnCurrentType == null)
+                    if (baseType == null)
+                        return foundOnCurrentType;
+
+                    if (foundOnCurrentType == null && ResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod, baseType) == null)
                     {
-                        throw new NotImplementedException("Unable to resolve explicit interface method to virtual method on type");
+                        if (!IsInterfaceImplementedOnType(baseType, interfaceType))
+                        {
+                            throw new NotImplementedException("Unable to resolve explicit interface method to virtual method on type");
+                        }
                     }
 
                     return foundOnCurrentType;

--- a/System.Private.CoreLib/System/Array.cs
+++ b/System.Private.CoreLib/System/Array.cs
@@ -311,11 +311,6 @@ namespace System
 
             return new SZGenericArrayEnumerator<T>(@this, length);
         }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            throw new NotImplementedException();
-        }
     }
 
     internal sealed class SZGenericArrayEnumerator<T> : IEnumerator<T>

--- a/Tests/Common/Assert.cs
+++ b/Tests/Common/Assert.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Xunit
 {
@@ -15,20 +14,14 @@ namespace Xunit
             }
         }
 
-        public static void EqualEnumerable<T>(IEnumerable<T> expected, IEnumerable<T> actual)
-        {
-            Assert.Equal(expected.Count(), actual.Count());
-
-            var expectedEnumerator = expected.GetEnumerator();
-            var actualEnumerator = actual.GetEnumerator();
-            while (expectedEnumerator.MoveNext() && actualEnumerator.MoveNext())
-            {
-                Assert.Equal(expectedEnumerator.Current, actualEnumerator.Current);
-            }
-        }
-
         public static void Equal<T>(T expected, T actual)
         {
+            if (expected is IEnumerable expectedEnumerable && actual is IEnumerable actualEnumerable)
+            {
+                SequenceEqual(expectedEnumerable, actualEnumerable);
+                return;
+            }
+
             var comparer = EqualityComparerHelpers.GetComparerForReferenceTypesOnly<T>();
 
             bool result;
@@ -45,6 +38,20 @@ namespace Xunit
             {
                 Assert.HandleFail("Assert.Equal", "");
             }
+        }
+
+        private static void SequenceEqual(IEnumerable expected, IEnumerable actual)
+        {
+            var expectedEnumerator = expected.GetEnumerator();
+            var actualEnumerator = actual.GetEnumerator();
+
+            while (expectedEnumerator.MoveNext())
+            {
+                Assert.True(actualEnumerator.MoveNext());
+                Assert.Equal(expectedEnumerator.Current, actualEnumerator.Current);
+            }
+
+            Assert.False(actualEnumerator.MoveNext());
         }
 
         public static void NotEqual<T>(T notExpected, T actual)

--- a/Tests/CoreLib/System.Linq.Tests/ToArrayTests.cs
+++ b/Tests/CoreLib/System.Linq.Tests/ToArrayTests.cs
@@ -11,7 +11,7 @@ namespace System.Linq.Tests
             int[] resultArray = sourceArray.ToArray();
 
             Assert.True(sourceArray != resultArray);
-            Assert.EqualEnumerable(sourceArray, resultArray);
+            Assert.Equal(sourceArray, resultArray);
         }
     }
 }

--- a/Tests/CoreLib/System.Linq.Tests/ToListTests.cs
+++ b/Tests/CoreLib/System.Linq.Tests/ToListTests.cs
@@ -11,7 +11,7 @@ namespace System.Linq.Tests
             List<int> resultList = sourceList.ToList();
 
             Assert.True(sourceList != resultList);
-            Assert.EqualEnumerable(sourceList, resultList);
+            Assert.Equal(sourceList, resultList);
         }
     }
 }


### PR DESCRIPTION
Fix bug in ResolveInterfaceMethodToVirtualMethodOnType which was preventing removal of IEnumerable.GetEnumerator dummy implementation in Array<T> 
Change Linq tests to use new assert

Last piece for #615