### PR TITLE
Extend inliner for args and locals

### DIFF
--- a/ILCompiler/Compiler/Importer/ImportContext.cs
+++ b/ILCompiler/Compiler/Importer/ImportContext.cs
@@ -22,8 +22,10 @@ namespace ILCompiler.Compiler.Importer
         public required DnlibModule Module { get; init; }
         public TypeDesc? Constrained { get; set; } = null;
 
-        public bool Inlining { get; set; } = false;
+        public InlineInfo? InlineInfo { get; set; } = null;
 
+        public bool Inlining => InlineInfo is not null;
+        
         public StackEntry GetGenericContext()
         {
             if (Method.AcquiresInstMethodTableFromThis())

--- a/ILCompiler/Compiler/Importer/LoadArgImporter.cs
+++ b/ILCompiler/Compiler/Importer/LoadArgImporter.cs
@@ -29,11 +29,20 @@ namespace ILCompiler.Compiler.Importer
                     return false;
             }
 
-            var lclNum = MapIlArgNum(index, importer.ReturnBufferArgIndex);
+            if (context.Inlining)
+            {
+                // Need to get arg from inline info.
+                var node = importer.InlineFetchArgument(index);
+                importer.PushExpression(node);
+            }
+            else
+            {
+                var lclNum = MapIlArgNum(index, importer.ReturnBufferArgIndex);
 
-            var argument = importer.LocalVariableTable[lclNum];
-            var node = new LocalVariableEntry(lclNum, argument.Type, argument.ExactSize);
-            importer.PushExpression(node);
+                var argument = importer.LocalVariableTable[lclNum];
+                var node = new LocalVariableEntry(lclNum, argument.Type, argument.ExactSize);
+                importer.PushExpression(node);
+            }
 
             return true;
         }

--- a/ILCompiler/Compiler/Importer/LoadVarImporter.cs
+++ b/ILCompiler/Compiler/Importer/LoadVarImporter.cs
@@ -31,6 +31,12 @@ namespace ILCompiler.Compiler.Importer
 
             var localNumber = importer.ParameterCount + index;
             var localVariable = importer.LocalVariableTable[localNumber];
+
+            if (context.Inlining)
+            {
+                localNumber = importer.InlineFetchLocal(index);
+            }
+
             var node = new LocalVariableEntry(localNumber, localVariable.Type, localVariable.ExactSize);
             importer.PushExpression(node);
 

--- a/ILCompiler/Compiler/Importer/StoreArgImporter.cs
+++ b/ILCompiler/Compiler/Importer/StoreArgImporter.cs
@@ -13,10 +13,19 @@ namespace ILCompiler.Compiler.Importer
             {
                 case ILOpcode.starg:
                 case ILOpcode.starg_s:
-                    var value = importer.PopExpression();
                     var parameter = (ParameterDefinition)instruction.Operand;
-                    var node = new StoreLocalVariableEntry(parameter.Index, true, value);
-                    importer.ImportAppendTree(node);
+                    int localNumber = parameter.Index;
+
+                    if (context.Inlining)
+                    {
+                        var node = importer.InlineFetchArgument(parameter.Index);
+                        localNumber = ((LocalVariableEntry)node).LocalNumber;
+                    }
+
+                    var value = importer.PopExpression();
+                    var store = new StoreLocalVariableEntry(localNumber, true, value);
+                    importer.ImportAppendTree(store);
+
                     return true;
 
                 default:

--- a/ILCompiler/Compiler/Importer/StoreVarImporter.cs
+++ b/ILCompiler/Compiler/Importer/StoreVarImporter.cs
@@ -28,10 +28,15 @@ namespace ILCompiler.Compiler.Importer
                     return false;
             }
 
+            var localNumber = importer.ParameterCount + index;
+
+            if (context.Inlining)
+            {
+                localNumber = importer.InlineFetchLocal(index);
+            }
+
             var value = importer.PopExpression();
 
-            var localNumber = importer.ParameterCount + index;
-            var localVariable = importer.LocalVariableTable[localNumber];
             var node = new StoreLocalVariableEntry(localNumber, false, value);
             importer.ImportAppendTree(node, true);
 

--- a/ILCompiler/Compiler/Inliner.cs
+++ b/ILCompiler/Compiler/Inliner.cs
@@ -149,7 +149,7 @@ namespace ILCompiler.Compiler
             return inlineInfo;
         }
 
-        private bool InsertInlineeBlocks(IList<BasicBlock> blocks, InlineMethod method, InlineInfo inlineInfo)
+        private static bool InsertInlineeBlocks(IList<BasicBlock> blocks, InlineMethod method, InlineInfo inlineInfo)
         {
             if (blocks.Count == 1)
             {
@@ -171,7 +171,7 @@ namespace ILCompiler.Compiler
             return false;
         }
 
-        private void PrependStatements(InlineMethod method, InlineInfo inlineInfo, ref int afterStatementIndex)
+        private static void PrependStatements(InlineMethod method, InlineInfo inlineInfo, ref int afterStatementIndex)
         {
             for (int argumentIndex = 0; argumentIndex < method.Call.Arguments.Count;  argumentIndex++)
             {
@@ -179,7 +179,7 @@ namespace ILCompiler.Compiler
             }
         }
 
-        private void InsertInlineeArgument(InlineMethod method, ref int afterStatementIndex, int argumentIndex, StackEntry argument, InlineInfo inlineInfo)
+        private static void InsertInlineeArgument(InlineMethod method, ref int afterStatementIndex, int argumentIndex, StackEntry argument, InlineInfo inlineInfo)
         {
             var tempNumber = inlineInfo.InlineArgumentInfos[argumentIndex].TempNumber;
 

--- a/ILCompiler/Compiler/Inliner.cs
+++ b/ILCompiler/Compiler/Inliner.cs
@@ -10,23 +10,39 @@ namespace ILCompiler.Compiler
         public required Statement Statement { get; set; }
         public required int StatementIndex { get; set; }
         public required BasicBlock Block { get; set; }
+        public required LocalVariableTable Locals { get; set; }
     }
 
-    public class Inliner : IInliner
+    public record InlineArgumentInfo
     {
-        private readonly IConfiguration _configuration;
-        private readonly ILogger<MethodCompiler> _logger;
-        private readonly IPhaseFactory _phaseFactory;
+        public required StackEntry Argument {  get; set; }
+        public int TempNumber { get; set; }
+        public bool HasTemp { get; set; }
+    }
+
+    public record LocalVariableInfo
+    {
+        public int TempNumber { get; set; }
+        public bool HasTemp { get; set; }
+
+        public VarType Type { get; set; }
+    }
+
+    public record InlineInfo
+    {
+        public InlineArgumentInfo[] InlineArgumentInfos { get; set; } = [];
+        public LocalVariableInfo[] LocalVariableInfos { get; set; } = [];
+        public required LocalVariableTable InlineLocalVariableTable { get; set; }
+    }
+
+    public class Inliner(ILogger<MethodCompiler> logger, IConfiguration configuration, IPhaseFactory phaseFactory) : IInliner
+    {
+        private readonly IConfiguration _configuration = configuration;
+        private readonly ILogger<MethodCompiler> _logger = logger;
+        private readonly IPhaseFactory _phaseFactory = phaseFactory;
         private string? _inputFilePath;
 
-        public Inliner(ILogger<MethodCompiler> logger, IConfiguration configuration, IPhaseFactory phaseFactory)
-        {
-            _configuration = configuration;
-            _logger = logger;
-            _phaseFactory = phaseFactory;
-        }
-
-        public void Inline(IList<BasicBlock> blocks, string inputFilePath)
+        public void Inline(IList<BasicBlock> blocks, LocalVariableTable locals, string inputFilePath)
         {
             _inputFilePath = inputFilePath;
 
@@ -51,6 +67,7 @@ namespace ILCompiler.Compiler
                                 Statement = statement,
                                 StatementIndex = statementIndex,
                                 Block = block,
+                                Locals = locals,
                             };
                             callInlined = MorphCallInline(inlineMethod);
                         }
@@ -73,39 +90,104 @@ namespace ILCompiler.Compiler
                 throw new InvalidOperationException("Method is null");
             }
 
-            // No support for inlining methods with return type and/or parameters yet
-            if (!method.Call.Method.HasReturnType && method.Call.Method.Parameters.Count != 0)
+            // No support for inlining methods with return types
+            if (method.Call.Method.HasReturnType)
             {
                 return false;
             }
 
+            InlineInfo inlineInfo = InitVars(method);
+
+            var startVars = method.Locals.Count;
+
             var compiler = new MethodCompiler(_logger, _configuration, _phaseFactory);
-            var basicBlocks = compiler.CompileInlineeMethod(method.Call.Method, _inputFilePath!);
+            var basicBlocks = compiler.CompileInlineeMethod(method.Call.Method, _inputFilePath!, inlineInfo);
 
             if (basicBlocks != null)
             {
-                return InsertInlineeBlocks(basicBlocks, method);
+                var inlineSucceeded = InsertInlineeBlocks(basicBlocks, method, inlineInfo);
+                if (inlineSucceeded)
+                    return true;
+
+                // Need to undo some changes made during the inlining attempt
+                // Temps may have been allocated need to do this
+                method.Locals.ResetCount(startVars);
             }
 
             return false;
         }
 
-        private static bool InsertInlineeBlocks(IList<BasicBlock> blocks, InlineMethod method)
+        private static InlineInfo InitVars(InlineMethod method)
+        {
+            var inlineInfo = new InlineInfo
+            {
+                InlineLocalVariableTable = method.Locals,
+                InlineArgumentInfos = new InlineArgumentInfo[method.Call.Arguments.Count]
+            };
+
+            for (int i = 0; i < method.Call.Arguments.Count; i++)
+            {
+                var inlineArgumentInfo = new InlineArgumentInfo()
+                {
+                    Argument = method.Call.Arguments[i],
+                };
+                inlineInfo.InlineArgumentInfos[i] = inlineArgumentInfo;
+            }
+
+            inlineInfo.LocalVariableInfos = new LocalVariableInfo[method.Call.Method!.Locals.Count];
+
+            for (int i = 0; i < method.Call.Method!.Locals.Count; i++)
+            {
+                var local = method.Call.Method!.Locals[i];
+                var localVariableInfo = new LocalVariableInfo()
+                {
+                    Type = local.Type.VarType,
+                };
+                inlineInfo.LocalVariableInfos[i] = localVariableInfo;
+            }
+
+            return inlineInfo;
+        }
+
+        private bool InsertInlineeBlocks(IList<BasicBlock> blocks, InlineMethod method, InlineInfo inlineInfo)
         {
             if (blocks.Count == 1)
             {
                 method.Block.Statements.RemoveAt(method.StatementIndex);
 
+                // Prepend statements
+                int afterStatementIndex = method.StatementIndex;
+                PrependStatements(method, inlineInfo, ref afterStatementIndex);
+
                 var inlineeBlock = blocks[0];
                 foreach (var inlineeStatement in inlineeBlock.Statements)
                 {
-                    method.Block.Statements.Insert(method.StatementIndex++, inlineeStatement);
+                    method.Block.Statements.Insert(afterStatementIndex++, inlineeStatement);
                 }
 
                 return true;
             }
 
             return false;
+        }
+
+        private void PrependStatements(InlineMethod method, InlineInfo inlineInfo, ref int afterStatementIndex)
+        {
+            for (int argumentIndex = 0; argumentIndex < method.Call.Arguments.Count;  argumentIndex++)
+            {
+                InsertInlineeArgument(method, ref afterStatementIndex, argumentIndex, method.Call.Arguments[argumentIndex], inlineInfo);
+            }
+        }
+
+        private void InsertInlineeArgument(InlineMethod method, ref int afterStatementIndex, int argumentIndex, StackEntry argument, InlineInfo inlineInfo)
+        {
+            var tempNumber = inlineInfo.InlineArgumentInfos[argumentIndex].TempNumber;
+
+            var store = new StoreLocalVariableEntry(tempNumber, false, argument.Duplicate());
+
+            var storeStatement = new Statement(store);
+
+            method.Block.Statements.Insert(afterStatementIndex++, storeStatement);
         }
     }
 }

--- a/ILCompiler/Compiler/LocalVariableTable.cs
+++ b/ILCompiler/Compiler/LocalVariableTable.cs
@@ -35,5 +35,16 @@ namespace ILCompiler.Compiler
 
             return _locals.Count - 1;
         }
+
+        public void ResetCount(int count)
+        {
+            // Remove any variables added after count
+            int removeAt = count;
+
+            while (count-- > 0)
+            {
+                _locals.RemoveAt(removeAt);
+            }
+        }
     }
 }

--- a/ILCompiler/Interfaces/IILImporter.cs
+++ b/ILCompiler/Interfaces/IILImporter.cs
@@ -6,6 +6,6 @@ namespace ILCompiler.Interfaces
 {
     public interface IILImporter : IPhase
     {
-        public IList<BasicBlock> Import(int parameterCount, int? returnBufferArgIndex, MethodDesc method, LocalVariableTable locals, IList<EHClause> ehClauses, bool inlining = false);
+        public IList<BasicBlock> Import(int parameterCount, int? returnBufferArgIndex, MethodDesc method, LocalVariableTable locals, IList<EHClause> ehClauses, InlineInfo? inlineInfo = null);
     }
 }

--- a/ILCompiler/Interfaces/IILImporterProxy.cs
+++ b/ILCompiler/Interfaces/IILImporterProxy.cs
@@ -17,5 +17,11 @@ namespace ILCompiler.Interfaces
         BasicBlock[] BasicBlocks { get; }
 
         int? ReturnBufferArgIndex { get; }
+
+        InlineInfo? InlineInfo { get; }
+
+        public StackEntry InlineFetchArgument(int ilArgNum);
+
+        public int InlineFetchLocal(int localNumber);
     }
 }

--- a/ILCompiler/Interfaces/IInliner.cs
+++ b/ILCompiler/Interfaces/IInliner.cs
@@ -4,6 +4,6 @@ namespace ILCompiler.Interfaces
 {
     internal interface IInliner : IPhase
     {
-        void Inline(IList<BasicBlock> blocks, string inputFilePath);
+        void Inline(IList<BasicBlock> blocks, LocalVariableTable locals, string inputFilePath);
     }
 }

--- a/Tests/Methodical/Inlining/Inlining.cs
+++ b/Tests/Methodical/Inlining/Inlining.cs
@@ -4,6 +4,21 @@ namespace Inlining
 {
     public static class Test
     {
+        private static int _parameter = 0;
+        
+        // This is not initialized as this causes all od the static method
+        // calls to be imported as comma nodes to call the cctor before
+        // the method. 
+        private static string _str;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void InlineMethodWithParameters(int i, string s)
+        {
+            int j = i + 1;
+            _parameter = j;
+            _str = s;
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void InlineMethod2()
         {
@@ -21,6 +36,12 @@ namespace Inlining
         public static int Main()
         {
             InlineMethod();
+
+            string strParameter = "Test";
+            InlineMethodWithParameters(1, strParameter);
+
+            if (_parameter != 2) return 2;
+            if (!ReferenceEquals(_str, strParameter)) return 3;
 
             return _result;
         }


### PR DESCRIPTION
Arguments are spilled into temps that can be used in the inlined method.
Locals of the inlinee are added to the locals of the method calling the inlinee.

Contributes to #230 