### PR TITLE
Spill stack to only one set of temps at end of blocks

### DIFF
--- a/ILCompiler/Compiler/BasicBlock.cs
+++ b/ILCompiler/Compiler/BasicBlock.cs
@@ -65,5 +65,7 @@ namespace ILCompiler.Compiler
             Label = LabelGenerator.GetLabel(LabelType.BasicBlock);
             JumpKind = JumpKind.Always;
         }
+
+        public IDictionary<StackEntry, LocalVariableEntry> SpilledStackEntries { get; set; } = new Dictionary<StackEntry, LocalVariableEntry>();
     }
 }


### PR DESCRIPTION
The existing code for spilling stack was spilling for each possible exit path from the block. This change ensures that the stack contents are only spilled to one set of temps across all exits from the block.

This has the nice side effect of not requiring to duplicate the tree nodes in ImportSpillStackEntry

This addresses #201