### PR TITLE
Inlining return buffers

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/BinaryOperatorCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/BinaryOperatorCodeGenerator.cs
@@ -29,6 +29,8 @@ namespace ILCompiler.Compiler.CodeGenerators
             { Tuple.Create(Operation.Rsh, VarType.Ptr), "i_rsh16" },
             { Tuple.Create(Operation.And, VarType.Ptr), "i_and16" },
             { Tuple.Create(Operation.Or, VarType.Ptr), "i_or16" },
+
+            { Tuple.Create(Operation.Sub, VarType.ByRef), "i_sub16" },
         };
 
         private static bool IsAddOrSub(BinaryOperator op) => op.Operation == Operation.Add || op.Operation == Operation.Sub;

--- a/ILCompiler/Compiler/EvaluationStack/CallEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/CallEntry.cs
@@ -15,6 +15,10 @@ namespace ILCompiler.Compiler.EvaluationStack
         public InlineCandidateInfo? InlineCandidateInfo{ get ;set; } = null;
         public MethodDesc? Method { get; }
 
+        public bool HasReturnBuffer { get; set; }
+
+        public void SetReturnType(VarType type) => Type = type;
+
         public CallEntry(string targetMethod, IList<StackEntry> arguments, VarType returnType, int? returnSize, bool isVirtual = false, MethodDesc? method = null, bool isInlineCandidate = false) : base(returnType, returnSize)
         {
             TargetMethod = targetMethod;
@@ -27,6 +31,7 @@ namespace ILCompiler.Compiler.EvaluationStack
         public override StackEntry Duplicate()
         {
             var duplicate = new CallEntry(TargetMethod, Arguments, Type, ExactSize, IsVirtual, Method, IsInlineCandidate);
+            duplicate.HasReturnBuffer = HasReturnBuffer;
             duplicate.InlineInfo = InlineInfo;
             duplicate.InlineCandidateInfo = InlineCandidateInfo;
             return duplicate;

--- a/ILCompiler/Compiler/EvaluationStack/IStoreEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/IStoreEntry.cs
@@ -1,0 +1,7 @@
+﻿namespace ILCompiler.Compiler.EvaluationStack
+{
+    internal interface IStoreEntry
+    {
+        public StackEntry Op1 { get; set; }
+    }
+}

--- a/ILCompiler/Compiler/EvaluationStack/ReturnEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/ReturnEntry.cs
@@ -1,28 +1,19 @@
-﻿using ILCompiler.Compiler.LinearIR;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 
 namespace ILCompiler.Compiler.EvaluationStack
 {
     public class ReturnEntry : StackEntry
     {
         public StackEntry? Return { get; set; }
-        public int? ReturnBufferArgIndex { get; }
-        public int? ReturnTypeExactSize { get; }
 
-        public ReturnEntry() : this(null, null, null)
-        {
-        }
-
-        public ReturnEntry(StackEntry? returnValue, int? returnBufferArgIndex, int? returnTypeExactSize) : base(returnValue?.Type ?? VarType.Void)
+        public ReturnEntry(StackEntry? returnValue) : base(returnValue?.Type ?? VarType.Void)
         {
             Return = returnValue;
-            ReturnBufferArgIndex = returnBufferArgIndex;
-            ReturnTypeExactSize = returnTypeExactSize;
         }
 
         public override StackEntry Duplicate()
         {
-            return new ReturnEntry(Return, ReturnBufferArgIndex, ReturnTypeExactSize);
+            return new ReturnEntry(Return);
         }
 
         public override void Accept(IStackEntryVisitor visitor) => visitor.Visit(this);

--- a/ILCompiler/Compiler/EvaluationStack/ReturnExpressionEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/ReturnExpressionEntry.cs
@@ -5,7 +5,11 @@ namespace ILCompiler.Compiler.EvaluationStack
     public class ReturnExpressionEntry : StackEntry
     {
         public CallEntry InlineCandidate { get; set; }
-        public StackEntry? SubstExpr { get; set; } = null;
+
+        // Represents the inline candidate's value. This is null
+        // during the import that created the ReturnExpression
+        // and is set later when the inline candidate is processed.
+        public StackEntry? SubstitionExpression { get; set; }
 
         public ReturnExpressionEntry(CallEntry inlineCandidate) : base(inlineCandidate.Type, inlineCandidate.Method!.Signature.ReturnType.GetElementSize().AsInt)
         {

--- a/ILCompiler/Compiler/EvaluationStack/StackEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/StackEntry.cs
@@ -38,7 +38,7 @@ namespace ILCompiler.Compiler.EvaluationStack
     // which will be the main output of the importer
     public abstract class StackEntry : IVisitableStackEntry
     {
-        public VarType Type { get; }
+        public VarType Type { get; protected set; }
 
         public int? ExactSize { get; }
 

--- a/ILCompiler/Compiler/EvaluationStack/StoreIndEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/StoreIndEntry.cs
@@ -1,9 +1,8 @@
-﻿using ILCompiler.Compiler.LinearIR;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 
 namespace ILCompiler.Compiler.EvaluationStack
 {
-    public class StoreIndEntry : StackEntry
+    public class StoreIndEntry : StackEntry, IStoreEntry
     {
         public StackEntry Addr { get; set; }
         public StackEntry Op1 { get; set; }

--- a/ILCompiler/Compiler/EvaluationStack/StoreLocalVariableEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/StoreLocalVariableEntry.cs
@@ -1,9 +1,8 @@
-﻿using ILCompiler.Compiler.LinearIR;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 
 namespace ILCompiler.Compiler.EvaluationStack
 {
-    public class StoreLocalVariableEntry : StackEntry, ILocalVariable
+    public class StoreLocalVariableEntry : StackEntry, ILocalVariable, IStoreEntry
     {
         public StackEntry Op1 { get; set; }
 
@@ -12,7 +11,7 @@ namespace ILCompiler.Compiler.EvaluationStack
 
         public bool IsParameter { get; }
 
-        public StoreLocalVariableEntry(int localNumber, bool parameter, StackEntry op1) : base(VarType.Void)
+        public StoreLocalVariableEntry(int localNumber, bool parameter, StackEntry op1, VarType type = VarType.Void, int? exactSize = null) : base(type, exactSize)
         {
             LocalNumber = localNumber;
             IsParameter = parameter;
@@ -21,7 +20,7 @@ namespace ILCompiler.Compiler.EvaluationStack
 
         public override StackEntry Duplicate()
         {
-            return new StoreLocalVariableEntry(LocalNumber, IsParameter, Op1.Duplicate());
+            return new StoreLocalVariableEntry(LocalNumber, IsParameter, Op1.Duplicate(), Type, ExactSize);
         }
 
         public override void Accept(IStackEntryVisitor visitor) => visitor.Visit(this);

--- a/ILCompiler/Compiler/Inliner.cs
+++ b/ILCompiler/Compiler/Inliner.cs
@@ -61,7 +61,7 @@ namespace ILCompiler.Compiler
 
         public Statement WalkStatement(Statement statement)
         {
-            WalkTree(new Edge<StackEntry>(() => statement.RootNode, x => { }), null);
+            WalkTree(new Edge<StackEntry>(() => statement.RootNode, x => { statement.RootNode = x; }), null);
 
             return statement;
         }
@@ -85,7 +85,7 @@ namespace ILCompiler.Compiler
                 do
                 {
                     var returnExpression = inlineCandidate as ReturnExpressionEntry;
-                    inlineCandidate = returnExpression!.SubstExpr;
+                    inlineCandidate = returnExpression!.SubstitionExpression;
                 } while (inlineCandidate is ReturnExpressionEntry);
 
                 inlineCandidate = CodeFolder.FoldExpression(inlineCandidate!);
@@ -180,7 +180,7 @@ namespace ILCompiler.Compiler
 
                 if (method.HasReturnType)
                 {
-                    inlineInfo.InlineCandidateInfo!.ReturnExpressionEntry!.SubstExpr = methodInfo.Call;
+                    inlineInfo.InlineCandidateInfo!.ReturnExpressionEntry!.SubstitionExpression = methodInfo.Call;
 
                     // Need to blank out the original call node
                     methodInfo.Statement!.RootNode = new NothingEntry();
@@ -189,6 +189,8 @@ namespace ILCompiler.Compiler
                 // Need to undo some changes made during the inlining attempt
                 // Temps may have been allocated need to do this
                 methodInfo.Locals.ResetCount(startVars);
+
+                inlineInfo.InlineCall.IsInlineCandidate = false;
             }
 
             Debug.Assert(methodInfo.Locals.Count == startVars);

--- a/ILCompiler/Compiler/Morpher.cs
+++ b/ILCompiler/Compiler/Morpher.cs
@@ -140,7 +140,7 @@ namespace ILCompiler.Compiler
                     {
                         returnValue = MorphTree(returnValue);
                     }
-                    tree = new ReturnEntry(returnValue, re.ReturnBufferArgIndex, re.ReturnTypeExactSize);
+                    tree = new ReturnEntry(returnValue);
                     break;
 
                 case StoreIndEntry sie:

--- a/ILCompiler/Compiler/OpcodeImporters/BinaryOperationImporter.cs
+++ b/ILCompiler/Compiler/OpcodeImporters/BinaryOperationImporter.cs
@@ -77,10 +77,12 @@ namespace ILCompiler.Compiler.OpcodeImporters
             {
                 return VarType.Ptr;
             }
-            else
+            else if (op1.Type == VarType.ByRef && op2.Type == VarType.ByRef)
             {
-                return VarType.Int;
+                return VarType.ByRef;
             }
+
+            return VarType.Int;
         }
     }
 }

--- a/ILCompiler/Compiler/OpcodeImporters/CallImporter.cs
+++ b/ILCompiler/Compiler/OpcodeImporters/CallImporter.cs
@@ -365,7 +365,7 @@ namespace ILCompiler.Compiler.OpcodeImporters
 
         private static StackEntry NormalizeStructValue(StackEntry argument, IImporter importer)
         {
-            if (argument is CallEntry callEntry)
+            if (argument is CallEntry)
             {
                 var temp = importer.GrabTemp(argument.Type, argument.ExactSize);
 

--- a/ILCompiler/Compiler/OpcodeImporters/CallImporter.cs
+++ b/ILCompiler/Compiler/OpcodeImporters/CallImporter.cs
@@ -38,6 +38,11 @@ namespace ILCompiler.Compiler.OpcodeImporters
             {
                 var argument = importer.Pop();
 
+                if (argument.Type == VarType.Struct)
+                {
+                    argument = NormalizeStructValue(argument, importer);
+                }
+
                 var parameter = methodToCall.Signature[i];
                 var parameterType = parameter;
 
@@ -164,15 +169,7 @@ namespace ILCompiler.Compiler.OpcodeImporters
                 throw new NotSupportedException("Non direct calls to generic methods not supported");
             }
 
-            int returnBufferArgIndex = 0;
             var returnType = methodToCall.Signature.ReturnType;
-            if (methodToCall.HasReturnType)
-            {
-                if (returnType.IsValueType && !returnType.IsPrimitive && !returnType.IsEnum)
-                {
-                    returnBufferArgIndex = FixupCallStructReturn(returnType, arguments, importer, methodToCall.HasThis);
-                }
-            }
 
             int? returnTypeSize = methodToCall.HasReturnType ? returnType.GetElementSize().AsInt : null;
 
@@ -187,9 +184,10 @@ namespace ILCompiler.Compiler.OpcodeImporters
             {
                 if (callNode.IsInlineCandidate)
                 {
+                    // Split call into two parts: the call itself and the return expression
                     importer.ImportAppendTree(callNode, true);
 
-                    ReturnExpressionEntry returnExpression = new ReturnExpressionEntry(callNode);
+                    ReturnExpressionEntry returnExpression = new(callNode);
 
                     var inlineCandidateInfo = new InlineCandidateInfo
                     {
@@ -201,33 +199,9 @@ namespace ILCompiler.Compiler.OpcodeImporters
                 }
                 else
                 {
-                    if (returnType.IsValueType && !returnType.IsPrimitive && !returnType.IsEnum)
-                    {
-                        importer.ImportAppendTree(callNode, true);
-
-                        // Load return buffer to stack
-                        var loadTemp = new LocalVariableEntry(returnBufferArgIndex, returnType.VarType, returnType.GetElementSize().AsInt);
-                        importer.Push(loadTemp);
-                    }
-                    else
-                    {
-                        importer.Push(callNode);
-                    }
+                    importer.Push(callNode);
                 }
             }
-        }
-
-        static private int FixupCallStructReturn(TypeDesc returnType, List<StackEntry> arguments, IImporter importer, bool hasThis)
-        {
-            // Create temp
-            var lclNum = importer.GrabTemp(returnType.VarType, returnType.GetElementSize().AsInt);
-            var returnBufferPtr = new LocalVariableAddressEntry(lclNum);
-
-            // Ensure return buffer parameter goes after the this parameter if present
-            var returnBufferArgPos = hasThis ? 1 : 0;
-            arguments.Insert(returnBufferArgPos, returnBufferPtr);
-
-            return lclNum;
         }
 
         private static string ImportInternalCall(MethodDesc methodToCall)
@@ -387,6 +361,22 @@ namespace ILCompiler.Compiler.OpcodeImporters
         private static IndirectEntry DereferenceThisPtr(StackEntry thisPtr, TypeDesc thisType)
         {
             return new IndirectEntry(thisPtr, thisType.VarType, thisType.GetElementSize().AsInt);
+        }
+
+        private static StackEntry NormalizeStructValue(StackEntry argument, IImporter importer)
+        {
+            if (argument is CallEntry callEntry)
+            {
+                var temp = importer.GrabTemp(argument.Type, argument.ExactSize);
+
+                // Import store to temp
+                StackEntry store = importer.NewTempStore(temp, argument);
+                importer.ImportAppendTree(store);
+
+                argument = new LocalVariableEntry(temp, argument.Type, argument.ExactSize);
+            }
+
+            return argument;
         }
     }
 }

--- a/ILCompiler/Compiler/OpcodeImporters/LoadFieldImporter.cs
+++ b/ILCompiler/Compiler/OpcodeImporters/LoadFieldImporter.cs
@@ -89,7 +89,8 @@ namespace ILCompiler.Compiler.OpcodeImporters
             // Copy the struct to a new temp local variable
             // and then return the address of the new temp local variable
             var lclNum = importer.GrabTemp(structVal.Type, structVal.ExactSize);
-            var asg = new StoreLocalVariableEntry(lclNum, false, structVal);
+            StackEntry asg = importer.NewTempStore(lclNum, structVal);
+
             importer.ImportAppendTree(asg);
 
             return new LocalVariableAddressEntry(lclNum);

--- a/ILCompiler/Compiler/OpcodeImporters/PopImporter.cs
+++ b/ILCompiler/Compiler/OpcodeImporters/PopImporter.cs
@@ -1,5 +1,4 @@
-﻿using ILCompiler.Compiler.EvaluationStack;
-using ILCompiler.Interfaces;
+﻿using ILCompiler.Interfaces;
 using ILCompiler.TypeSystem.IL;
 
 namespace ILCompiler.Compiler.OpcodeImporters
@@ -13,11 +12,9 @@ namespace ILCompiler.Compiler.OpcodeImporters
             var op1 = importer.Pop();
 
             // Need to spill result removed from stack to a temp that will never be used
-            var lclNum = importer.GrabTemp(op1.Type, op1.ExactSize);
-            var node = new StoreLocalVariableEntry(lclNum, false, op1);
-
-            // ctor has no return type so just append the tree
-            importer.ImportAppendTree(node);
+            var localNumber = importer.GrabTemp(op1.Type, op1.ExactSize);
+            var storeToTemp = importer.NewTempStore(localNumber, op1);
+            importer.ImportAppendTree(storeToTemp);
 
             return true;
         }

--- a/ILCompiler/Compiler/OpcodeImporters/RetImporter.cs
+++ b/ILCompiler/Compiler/OpcodeImporters/RetImporter.cs
@@ -1,6 +1,5 @@
 ﻿using ILCompiler.Compiler.EvaluationStack;
 using ILCompiler.Interfaces;
-using ILCompiler.TypeSystem.Common;
 using ILCompiler.TypeSystem.IL;
 
 namespace ILCompiler.Compiler.OpcodeImporters
@@ -13,7 +12,6 @@ namespace ILCompiler.Compiler.OpcodeImporters
 
             StackEntry? returnValue = null;
             int? returnBufferArgIndex = null;
-            int? returnTypeExactSize = null;
 
             if (importer.Method.HasReturnType)
             {
@@ -27,7 +25,6 @@ namespace ILCompiler.Compiler.OpcodeImporters
                     // copy struct on top of stack to the 
                     // return buffer.
                     returnBufferArgIndex = importer.Method.HasThis ? 1 : 0;
-                    returnTypeExactSize = returnType.GetElementSize().AsInt;
                 }
                 else
                 {

--- a/ILCompiler/Compiler/OpcodeImporters/StoreElemImporter.cs
+++ b/ILCompiler/Compiler/OpcodeImporters/StoreElemImporter.cs
@@ -66,7 +66,13 @@ namespace ILCompiler.Compiler.OpcodeImporters
             addr = new BinaryOperator(Operation.Add, isComparison: false, addr, arraySizeOffset, VarType.Ptr);
             addr = new BinaryOperator(Operation.Add, isComparison: false, arrayOp, addr, VarType.Ptr);
 
-            var op = new StoreIndEntry(addr, value, elemType, 0, elemSize);
+            StackEntry op = new StoreIndEntry(addr, value, elemType, 0, elemSize);
+
+            if (elemType == VarType.Struct)
+            {
+                op = importer.StoreStruct(op);
+            }
+
             importer.ImportAppendTree(op);
 
             return true;

--- a/ILCompiler/Compiler/OpcodeImporters/StoreFieldImporter.cs
+++ b/ILCompiler/Compiler/OpcodeImporters/StoreFieldImporter.cs
@@ -36,7 +36,12 @@ namespace ILCompiler.Compiler.OpcodeImporters
             var fieldSize = field.FieldType.GetElementSize().AsInt;
             var fieldOffset = field.Offset.AsInt;
 
-            var node = new StoreIndEntry(addr, value, field.FieldType.VarType, (uint)fieldOffset, fieldSize);
+            StackEntry node = new StoreIndEntry(addr, value, field.FieldType.VarType, (uint)fieldOffset, fieldSize);
+
+            if (field.FieldType.VarType == VarType.Struct)
+            {
+                node = importer.StoreStruct(node);
+            }
 
             importer.ImportAppendTree(node, true);
 

--- a/ILCompiler/Compiler/OpcodeImporters/StoreIndirectImporter.cs
+++ b/ILCompiler/Compiler/OpcodeImporters/StoreIndirectImporter.cs
@@ -67,7 +67,12 @@ namespace ILCompiler.Compiler.OpcodeImporters
                 value = CodeFolder.FoldExpression(new CastEntry(value, type));
             }
 
-            var node = new StoreIndEntry(addr, value, value.Type, fieldOffset: 0, exactSize);
+            StackEntry node = new StoreIndEntry(addr, value, value.Type, fieldOffset: 0, exactSize);
+
+            if (value.Type == VarType.Struct)
+            {
+                node = importer.StoreStruct(node);
+            }
 
             importer.ImportAppendTree(node);
 

--- a/ILCompiler/Compiler/OpcodeImporters/StoreVarImporter.cs
+++ b/ILCompiler/Compiler/OpcodeImporters/StoreVarImporter.cs
@@ -30,18 +30,22 @@ namespace ILCompiler.Compiler.OpcodeImporters
 
             var localNumber = index;
 
+            VarType localType;
+
             if (importer.Inlining)
             {
                 localNumber = importer.InlineFetchLocal(localNumber);
+                localType = importer.InlineInfo!.InlineLocalVariableTable[localNumber].Type;
             }
             else
             {
                 localNumber += importer.ParameterCount;
+                localType = importer.LocalVariableTable[localNumber].Type;
             }
 
             var value = importer.Pop();
 
-            var node = new StoreLocalVariableEntry(localNumber, false, value);
+            StackEntry node = importer.NewTempStore(localNumber, value);
             importer.ImportAppendTree(node, true);
 
             return true;

--- a/ILCompiler/Compiler/OpcodeImporters/StoreVarImporter.cs
+++ b/ILCompiler/Compiler/OpcodeImporters/StoreVarImporter.cs
@@ -30,17 +30,13 @@ namespace ILCompiler.Compiler.OpcodeImporters
 
             var localNumber = index;
 
-            VarType localType;
-
             if (importer.Inlining)
             {
                 localNumber = importer.InlineFetchLocal(localNumber);
-                localType = importer.InlineInfo!.InlineLocalVariableTable[localNumber].Type;
             }
             else
             {
                 localNumber += importer.ParameterCount;
-                localType = importer.LocalVariableTable[localNumber].Type;
             }
 
             var value = importer.Pop();

--- a/ILCompiler/IL/Stubs/UnsafeIntrinsics.cs
+++ b/ILCompiler/IL/Stubs/UnsafeIntrinsics.cs
@@ -17,8 +17,6 @@ namespace ILCompiler.Common.TypeSystem.IL
                     return EmitAsPointer();
                 case "SizeOf":
                     return EmitSizeOf(method);
-                case "Add":
-                    return EmitAdd(method);
                 case "AddByteOffset":
                     return EmitAddByteOffset();
                 case "InitBlock":
@@ -27,9 +25,24 @@ namespace ILCompiler.Common.TypeSystem.IL
                     return EmitCopyBlock();
                 case "AreSame":
                     return EmitAreSame();
+                case "ByteOffset":
+                    return EmitByteOffset();
             }
 
             return null;
+        }
+
+        private static MethodIL? EmitByteOffset()
+        {
+            var emitter = new ILEmitter();
+            var codeStream = emitter.NewCodeStream();
+
+            codeStream.Emit(ILOpcode.ldarg_1);
+            codeStream.Emit(ILOpcode.ldarg_0);
+            codeStream.Emit(ILOpcode.sub);
+            codeStream.Emit(ILOpcode.ret);
+
+            return emitter.Link();
         }
 
         private static MethodIL? EmitAs() 
@@ -89,22 +102,6 @@ namespace ILCompiler.Common.TypeSystem.IL
             codeStream.Emit(ILOpcode.ldarg_1);
             codeStream.Emit(ILOpcode.ldarg_2);
             codeStream.Emit(ILOpcode.cpblk);
-            codeStream.Emit(ILOpcode.ret);
-
-            return emitter.Link();
-        }
-
-        private static MethodIL? EmitAdd(MethodDesc method)
-        {
-            var emitter = new ILEmitter();
-            var codeStream = emitter.NewCodeStream();
-
-            codeStream.Emit(ILOpcode.ldarg_1);
-            codeStream.Emit(ILOpcode.sizeof_, new SignatureMethodVariable(method.Context, 0));
-            codeStream.Emit(ILOpcode.conv_i);
-            codeStream.Emit(ILOpcode.mul);
-            codeStream.Emit(ILOpcode.ldarg_0);
-            codeStream.Emit(ILOpcode.add);
             codeStream.Emit(ILOpcode.ret);
 
             return emitter.Link();

--- a/ILCompiler/Interfaces/IImporter.cs
+++ b/ILCompiler/Interfaces/IImporter.cs
@@ -44,5 +44,11 @@ namespace ILCompiler.Interfaces
         public bool StopImporting { get; set; }
 
         public int MapIlArgNum(int ilArgNum);
+
+        public StackEntry StoreStruct(StackEntry node);
+
+        public StackEntry GetNodeAddress(StackEntry value);
+
+        public StackEntry NewTempStore(int tempNumber, StackEntry value);
     }
 }

--- a/ILCompiler/TypeSystem/Common/InstantiatedMethod.cs
+++ b/ILCompiler/TypeSystem/Common/InstantiatedMethod.cs
@@ -55,6 +55,8 @@ namespace ILCompiler.TypeSystem.Common
         public override bool IsNewSlot => _methodDesc.IsNewSlot;
         public override bool IsAbstract => _methodDesc.IsAbstract;
 
+        public override bool IsAggressiveInlining => _methodDesc.IsAggressiveInlining;
+
         public override bool HasThis => _methodDesc.HasThis;
 
         public override TypeSystemContext Context => _methodDesc.Context;

--- a/System.Private.CoreLib/Internal/Runtime/CompilerServices/Unsafe.cs
+++ b/System.Private.CoreLib/Internal/Runtime/CompilerServices/Unsafe.cs
@@ -6,6 +6,17 @@ namespace Internal.Runtime.CompilerServices
     public static unsafe partial class Unsafe
     {
         [Intrinsic]
+        public static IntPtr ByteOffset<T>(ref readonly T origin, ref readonly T target)
+        {
+            throw new PlatformNotSupportedException();
+
+            // ldarg.1
+            // ldarg.0
+            // sub
+            // ret
+        }
+
+        [Intrinsic]
         public static void* AsPointer<T>(ref T value)
         {
             throw new PlatformNotSupportedException();
@@ -16,6 +27,7 @@ namespace Internal.Runtime.CompilerServices
         }
 
         [Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static T As<T>(object? value) where T : class
         {
             throw new PlatformNotSupportedException();
@@ -25,6 +37,7 @@ namespace Internal.Runtime.CompilerServices
         }
 
         [Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref TTo As<TFrom, TTo>(ref TFrom source)
         {
             throw new PlatformNotSupportedException();
@@ -45,6 +58,7 @@ namespace Internal.Runtime.CompilerServices
         }
 
         [Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref T AddByteOffset<T>(ref T source, nuint byteOffset)
         {
             return ref AddByteOffset(ref source, (IntPtr)(void*)byteOffset);
@@ -58,21 +72,20 @@ namespace Internal.Runtime.CompilerServices
         /// <summary>
         /// Adds an element offset to the given reference.
         /// </summary>
-        [Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref T Add<T>(ref T source, int elementOffset)
         {
-            return ref AddByteOffset(ref source, elementOffset * (nint)sizeof(T));
+            return ref AddByteOffset(ref source, (IntPtr)(elementOffset * (nint)SizeOf<T>()));
+        }
 
-            // ldarg .0
-            // ldarg .1
-            // sizeof !!T
-            // conv.i
-            // mul
-            // add
-            // ret
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ref T Add<T>(ref T source, IntPtr elementOffset)
+        {
+            return ref AddByteOffset(ref source, (IntPtr)((nint)elementOffset * (nint)SizeOf<T>()));
         }
 
         [Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int SizeOf<T>()
         {
             return sizeof(T);
@@ -82,6 +95,7 @@ namespace Internal.Runtime.CompilerServices
         /// Reinterprets the given location as a reference to a value of type <typeparamref name="T"/>.
         /// </summary>
         [Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref T AsRef<T>(in T source)
         {
             throw new PlatformNotSupportedException();
@@ -90,6 +104,7 @@ namespace Internal.Runtime.CompilerServices
             // ret
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref T AsRef<T>(void* source) // where T : allows ref struct
         {
             return ref *(T*)source;
@@ -97,6 +112,7 @@ namespace Internal.Runtime.CompilerServices
 
 
         [Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void InitBlock(void* startAddress, byte value, uint byteCount)
         {
             throw new PlatformNotSupportedException();
@@ -109,6 +125,7 @@ namespace Internal.Runtime.CompilerServices
         }
 
         [Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void CopyBlock(void* destination, void* source, uint byteCount)
         {
             throw new PlatformNotSupportedException();
@@ -121,6 +138,7 @@ namespace Internal.Runtime.CompilerServices
         }
 
         [Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void CopyBlock(ref byte destination, ref byte source, uint byteCount)
         {
             throw new PlatformNotSupportedException();
@@ -133,6 +151,7 @@ namespace Internal.Runtime.CompilerServices
         }
 
         [Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool AreSame<T>(ref readonly T left, ref readonly T right) // where T : allows ref struct
         {
             throw new PlatformNotSupportedException();

--- a/System.Private.CoreLib/System/Array.cs
+++ b/System.Private.CoreLib/System/Array.cs
@@ -18,6 +18,8 @@ namespace System
 
         public int Length => Unsafe.As<RawArrayData>(this).Length;
 
+        public static int MaxLength => 65535;
+
         public unsafe ushort ElementSize => this.GetMethodTable()->ComponentSize;
 
         public static void Copy(object?[] source, object?[] destination, int length)

--- a/System.Private.CoreLib/System/Buffer.cs
+++ b/System.Private.CoreLib/System/Buffer.cs
@@ -1,14 +1,21 @@
 ﻿using Internal.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
 
 namespace System
 {
     internal class Buffer
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void Memmove<T>(ref T destination, ref T source, nuint elementCount)
         {
-            Memmove(ref Unsafe.As<T, byte>(ref destination), ref Unsafe.As<T, byte>(ref source), elementCount * (nuint)Unsafe.SizeOf<T>());
+            // Since we don't have any GC it's safe to just use SpanHelpers.Memmove
+            SpanHelpers.Memmove(
+                ref Unsafe.As<T, byte>(ref destination), 
+                ref Unsafe.As<T, byte>(ref source), 
+                elementCount * (nuint)Unsafe.SizeOf<T>());
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void Memmove(ref byte dest, ref byte src, nuint len)
         {
             _Memmove(ref dest, ref src, len);

--- a/System.Private.CoreLib/System/Collections/Generic/EqualityComparer.cs
+++ b/System.Private.CoreLib/System/Collections/Generic/EqualityComparer.cs
@@ -31,6 +31,7 @@ namespace System.Collections.Generic
 
     public sealed class ObjectEqualityComparer<T> : EqualityComparer<T>
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override bool Equals(T x, T y)
         {
             if (x is not null)
@@ -44,6 +45,7 @@ namespace System.Collections.Generic
 
         public override bool Equals(object? obj) => throw new NotImplementedException();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override int GetHashCode(T obj)
         {
             if (obj is not null)
@@ -57,6 +59,7 @@ namespace System.Collections.Generic
 
     public sealed class GenericEqualityComparer<T> : EqualityComparer<T> where T : IEquatable<T>
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override bool Equals(T x, T y)
         {
             if (x is not null)
@@ -65,11 +68,14 @@ namespace System.Collections.Generic
                 return false;
             }
             if (y is not null) return false;
+
             return true;
         }
 
         public override bool Equals(object? obj) => throw new NotImplementedException();
 
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override int GetHashCode(T obj)
         {
             if (obj is not null)

--- a/System.Private.CoreLib/System/IntPtr.cs
+++ b/System.Private.CoreLib/System/IntPtr.cs
@@ -4,6 +4,9 @@
     {
         private readonly nint _value;
 
+        public static nint MaxValue => 32767;
+        public static nint MinValue => -32768;
+
         public unsafe IntPtr(void* value)
         {
             _value = (nint)value;

--- a/System.Private.CoreLib/System/Random.cs
+++ b/System.Private.CoreLib/System/Random.cs
@@ -23,5 +23,10 @@
         {
             return Next() % maxValue;
         }
-   }
+
+        public int Next(int minValue, int maxValue)
+        {
+            return Next() % (maxValue - minValue) + minValue;
+        }
+    }
 }

--- a/System.Private.CoreLib/System/Runtime/InteropServices/MemoryMarshal.cs
+++ b/System.Private.CoreLib/System/Runtime/InteropServices/MemoryMarshal.cs
@@ -10,6 +10,7 @@ namespace System.Runtime.InteropServices
         /// <summary>
         /// Returns a reference to the 0th element of <paramref name="array"/>
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref byte GetArrayDataReference(Array array)
         {
             // Arrays are laid out in memory as follows:

--- a/System.Private.CoreLib/System/SpanHelpers.cs
+++ b/System.Private.CoreLib/System/SpanHelpers.cs
@@ -4,6 +4,24 @@ namespace System
 {
     internal static class SpanHelpers
     {
+        internal static unsafe void Memmove(ref byte dest, ref byte src, nuint len)
+        {
+            if ((nuint)Unsafe.ByteOffset(ref src, ref dest) >= len)
+            {
+                for (nuint i = 0; i < len; i++)
+                {
+                    Unsafe.Add(ref dest, (nint)i) = Unsafe.Add(ref src, (nint)i);
+                }
+            }
+            else
+            {
+                for (nuint i = len; i > 0; i--)
+                {
+                    Unsafe.Add(ref dest, (nint)(i - 1)) = Unsafe.Add(ref src, (nint)(i - 1));
+                }
+            }
+        }
+
         public static bool SequenceEqual<T>(ref T first, ref T second, int length) where T : IEquatable<T>
         {
             int index = 0;

--- a/System.Private.CoreLib/System/UIntPtr.cs
+++ b/System.Private.CoreLib/System/UIntPtr.cs
@@ -4,6 +4,8 @@
     {
         private readonly nuint _value;
 
+        public static nint MaxValue => 65535;
+        public static nint MinValue => 0;
         public unsafe UIntPtr(void* value)
         {
             _value = (nuint)value;


### PR DESCRIPTION
Get inlining working properly with methods using return buffers
Needed to refactor how return buffers were working in general.
Return buffer argument is added to method only when method result is consumed by e.g. stloc, stelem, call, ...
Mark more methods as AggressiveInlining

Contributes to #230 