### PR TITLE
Inlining arg refactoring

### DIFF
--- a/ILCompiler/Compiler/BasicBlockAnalyser.cs
+++ b/ILCompiler/Compiler/BasicBlockAnalyser.cs
@@ -232,11 +232,10 @@ namespace ILCompiler.Compiler
                         {
                             var parameter = (ParameterDefinition)currentInstruction.Operand;
                             var index = parameter.Index;
-                            var localNumber = _importer!.MapIlArgNum(index);
 
                             if (_importer!.Inlining)
                             {
-                                _importer.InlineInfo!.InlineArgumentInfos[localNumber].HasLdargaOp = true;
+                                _importer.InlineInfo!.InlineArgumentInfos[index].HasLdargaOp = true;
                             }
                         }
                         break;
@@ -246,11 +245,10 @@ namespace ILCompiler.Compiler
                         {
                             var parameter = (ParameterDefinition)currentInstruction.Operand;
                             var index = parameter.Index;
-                            var localNumber = _importer!.MapIlArgNum(index);
 
                             if (_importer!.Inlining)
                             {
-                                _importer.InlineInfo!.InlineArgumentInfos[localNumber].HasStargOp = true;
+                                _importer.InlineInfo!.InlineArgumentInfos[index].HasStargOp = true;
                             }
                         }
                         break;

--- a/ILCompiler/Compiler/Importer.cs
+++ b/ILCompiler/Compiler/Importer.cs
@@ -534,6 +534,7 @@ namespace ILCompiler.Compiler
                         // Insert the return buffer into the argument list of the call as first byref parameter after the this pointer
                         var hasThis = call.Method!.HasThis;
                         call.Arguments.Insert(hasThis ? 1 : 0, destinationAddress);
+                        call.HasReturnBuffer = true;
                     }
 
                     return call;
@@ -547,6 +548,7 @@ namespace ILCompiler.Compiler
                     // Insert the return buffer into the argument list of the call as first byref parameter after the this pointer
                     var hasThis = inlineCall.Method!.HasThis;
                     inlineCall.Arguments.Insert(hasThis ? 1 : 0, destinationAddress);
+                    inlineCall.HasReturnBuffer = true;
 
                     inlineCall.SetReturnType(VarType.Void);
 

--- a/ILCompiler/Compiler/OpcodeImporters/CodeFolder.cs
+++ b/ILCompiler/Compiler/OpcodeImporters/CodeFolder.cs
@@ -12,6 +12,55 @@ namespace ILCompiler.Compiler.OpcodeImporters
                 return FoldConstantExpression(tree);
             }
 
+            if (tree is BinaryOperator binaryOperator)
+            {
+                if (binaryOperator.Op1.IsIntCnsOrI() || binaryOperator.Op2.IsIntCnsOrI())
+                {
+                    return FoldBinaryOpWithOneConstantOperand(binaryOperator);
+                }
+            }
+
+            return tree;
+        }
+
+        public static StackEntry FoldBinaryOpWithOneConstantOperand(BinaryOperator tree)
+        {
+            StackEntry op;
+            StackEntry constant;
+            if (tree.Op1.IsIntCnsOrI())
+            {
+                op = tree.Op2;
+                constant = tree.Op1;
+            }
+            else if (tree.Op2.IsIntCnsOrI())
+            {
+                op = tree.Op1;
+                constant = tree.Op2;
+            }
+            else
+            {
+                return tree;
+            }
+
+            var value = constant.GetIntConstant();
+
+            if (tree.Operation == Operation.Add && value == 0)
+            {
+                return op;
+            }
+            if (tree.Operation == Operation.Mul && value == 1)
+            {
+                return op;
+            }
+            if (tree.Operation == Operation.Div && value == 1)
+            {
+                return op;
+            }
+            if (tree.Operation == Operation.Sub && value == 0)
+            {
+                return op;
+            }
+
             return tree;
         }
 

--- a/ILCompiler/Compiler/OpcodeImporters/LoadArgAddressImporter.cs
+++ b/ILCompiler/Compiler/OpcodeImporters/LoadArgAddressImporter.cs
@@ -15,7 +15,6 @@ namespace ILCompiler.Compiler.OpcodeImporters
                 case ILOpcode.ldarga_s:
                     var parameter = (ParameterDefinition)instruction.Operand;
                     var index = parameter.Index;
-                    var localNumber = importer.MapIlArgNum(index);
 
                     if (importer.Inlining)
                     {
@@ -25,6 +24,7 @@ namespace ILCompiler.Compiler.OpcodeImporters
                     }
                     else
                     {
+                        var localNumber = importer.MapIlArgNum(index);
                         importer.Push(new LocalVariableAddressEntry(localNumber));
                         importer.LocalVariableTable[localNumber].AddressExposed = true;
                     }

--- a/ILCompiler/Compiler/OpcodeImporters/LoadArgImporter.cs
+++ b/ILCompiler/Compiler/OpcodeImporters/LoadArgImporter.cs
@@ -29,16 +29,16 @@ namespace ILCompiler.Compiler.OpcodeImporters
                     return false;
             }
 
-            var lclNum = importer.MapIlArgNum(index);
 
             if (importer.Inlining)
             {
                 // Need to get arg from inline info.
-                var node = importer.InlineFetchArgument(lclNum);
+                var node = importer.InlineFetchArgument(index);
                 importer.Push(node);
             }
             else
             {
+                var lclNum = importer.MapIlArgNum(index);
                 var argument = importer.LocalVariableTable[lclNum];
                 var node = new LocalVariableEntry(lclNum, argument.Type, argument.ExactSize);
                 importer.Push(node);


### PR DESCRIPTION
Refactoring inlining to not expect return buffer in InlineArgInfos. This can happen if the method being inlined does not have its return struct value actually consumed e.g. it might be thrown away by a pop opcode.

Also improve cold folding which is now much more important when methods are inlined.
Fix inlining to run code folding on the tree that has had something inlined into it.
Minor optimisation improvements in binary operator importer.

Contributes to #230