### PR TITLE
Allow inlining of method with single block into method with exception handlers

### DIFF
--- a/ILCompiler/Compiler/Inliner.cs
+++ b/ILCompiler/Compiler/Inliner.cs
@@ -282,7 +282,7 @@ namespace ILCompiler.Compiler
 
             // Don't inline calls in blocks that have exception handlers
             // when we have multiple blocks in the inlinee
-            if (blocks.Count > 0 && methodInfo.Block.Handlers.Count > 0)
+            if (blocks.Count > 1 && methodInfo.Block.Handlers.Count > 0)
                 return false;
 
             if (blocks.Count > 1 && inlineInfo.InlineeReturnSpillTempNumber.HasValue)


### PR DESCRIPTION
Inliner was being overly restrictive when inlining into method with exception handlers. It's safe to inline into such methods if the methods being inlined are only single blocks as the statements just get inserted into the existing blocks.

If there are multiple blocks in the method being inlined then these need to be inserted into the flowgraph of the method with exception handlers which will require some careful manipulation that the inliner doesn't do currently.

This should gain back the performance on the optimisation inline test.

Contributes to #230 