### PR TITLE
Extend unsafe intrinsics to cover Add<T>

### DIFF
--- a/ILCompiler/IL/Stubs/UnsafeIntrinsics.cs
+++ b/ILCompiler/IL/Stubs/UnsafeIntrinsics.cs
@@ -10,6 +10,8 @@ namespace ILCompiler.Common.TypeSystem.IL
         {
             switch (method.Name)
             {
+                case "Add":
+                    return EmitAdd(method);
                 case "As":
                 case "AsRef":
                     return EmitAs();
@@ -114,6 +116,35 @@ namespace ILCompiler.Common.TypeSystem.IL
 
             codeStream.Emit(ILOpcode.ldarg_0);
             codeStream.Emit(ILOpcode.ldarg_1);
+            codeStream.Emit(ILOpcode.add);
+            codeStream.Emit(ILOpcode.ret);
+
+            return emitter.Link();
+        }
+
+        private static MethodIL? EmitAdd(MethodDesc method)
+        {
+            // ldarg .0
+            // ldarg .1
+            // sizeof !!T
+            // conv.i (if necessary)
+            // mul
+            // add
+            // ret
+
+            var emitter = new ILEmitter();
+            var codeStream = emitter.NewCodeStream();
+
+            codeStream.Emit(ILOpcode.ldarg_0);
+            codeStream.Emit(ILOpcode.ldarg_1);
+            codeStream.Emit(ILOpcode.sizeof_, new SignatureMethodVariable(method.Context, 0));
+
+            if (method.Signature.Parameters[1].Type.IsWellKnownType(WellKnownType.Int32))
+            {
+                codeStream.Emit(ILOpcode.conv_i);
+            }
+
+            codeStream.Emit(ILOpcode.mul);
             codeStream.Emit(ILOpcode.add);
             codeStream.Emit(ILOpcode.ret);
 

--- a/System.Private.CoreLib/Internal/Runtime/CompilerServices/Unsafe.cs
+++ b/System.Private.CoreLib/Internal/Runtime/CompilerServices/Unsafe.cs
@@ -47,6 +47,7 @@ namespace Internal.Runtime.CompilerServices
         }
 
         [Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref T AddByteOffset<T>(ref T source, IntPtr byteOffset)
         {
             throw new PlatformNotSupportedException();
@@ -72,12 +73,14 @@ namespace Internal.Runtime.CompilerServices
         /// <summary>
         /// Adds an element offset to the given reference.
         /// </summary>
+        [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref T Add<T>(ref T source, int elementOffset)
         {
             return ref AddByteOffset(ref source, (IntPtr)(elementOffset * (nint)SizeOf<T>()));
         }
 
+        [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref T Add<T>(ref T source, IntPtr elementOffset)
         {


### PR DESCRIPTION
Also mark AddByteOffset with IntPtr as inlineable.