### PR TITLE
Lift restriction on inlining methods with multiple returns

### DIFF
--- a/ILCompiler/Compiler/Inliner.cs
+++ b/ILCompiler/Compiler/Inliner.cs
@@ -285,12 +285,6 @@ namespace ILCompiler.Compiler
             if (blocks.Count > 1 && methodInfo.Block.Handlers.Count > 0)
                 return false;
 
-            if (blocks.Count > 1 && inlineInfo.InlineeReturnSpillTempNumber.HasValue)
-            {
-                // TODO: Currently can't handle inlining methods with multiple blocks and returns
-                return false;
-            }
-
             // Prepend statements
             PrependStatements(methodInfo, inlineInfo, ref afterStatementIndex);
 

--- a/ILCompiler/Compiler/OpcodeImporters/RetImporter.cs
+++ b/ILCompiler/Compiler/OpcodeImporters/RetImporter.cs
@@ -47,12 +47,18 @@ namespace ILCompiler.Compiler.OpcodeImporters
                     if (returnBufferArgIndex.HasValue)
                     {
                         var returnBufferArg = importer.InlineInfo!.InlineCall.Arguments[returnBufferArgIndex.Value].Duplicate();
-                        returnExpressionEntry!.SubstitutionExpression = StoreStructPtr(returnBufferArg, returnValue, importer);
+                        returnValue = StoreStructPtr(returnBufferArg, returnValue, importer);
                     }
-                    else
+
+                    if (importer.InlineInfo.InlineeReturnSpillTempNumber.HasValue)
                     {
-                        returnExpressionEntry!.SubstitutionExpression = returnValue;
+                        var store = importer.NewTempStore(importer.InlineInfo.InlineeReturnSpillTempNumber.Value, returnValue!);
+                        importer.ImportAppendTree(store, true);
+
+                        returnValue = new LocalVariableEntry(importer.InlineInfo.InlineeReturnSpillTempNumber.Value, returnValue!.Type, returnValue.ExactSize);
                     }
+
+                    returnExpressionEntry!.SubstitutionExpression = returnValue;
                 }
             }
 


### PR DESCRIPTION
When importing return if basic block analysis identified that there are multiple returns and created a spill temp for the returns then store the return value into the temp and return the temp.

This is tested via the ifelse optimisation test in the getter for property A.Prop. This results in a whopping saving of 5 t-states for this test with the property getter inlined!

Contributes to #230 