### PR TITLE
Code folding for native ints

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/JumpTrueCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/JumpTrueCodeGenerator.cs
@@ -8,27 +8,27 @@ namespace ILCompiler.Compiler.CodeGenerators
     {
         public void GenerateCode(JumpTrueEntry entry, CodeGeneratorContext context)
         {
-            var binOp = (BinaryOperator)entry.Condition;
+            if (entry.Condition is BinaryOperator binOp)
+            {
+                if (binOp.Op1.Contained)
+                {
+                    GenerateJumpCompareCode(entry, context, binOp);
+                    return;
+                }
 
-            if (binOp.Op1.Contained)
-            {
-                GenerateJumpCompareCode(entry, context, binOp);
-                return;
+                if (binOp.ResultUsedInJump)
+                {
+                    context.InstructionsBuilder.Jp(Condition.C, entry.TargetLabel);
+                    return;
+                }
             }
 
-            if (binOp.ResultUsedInJump)
-            {
-                context.InstructionsBuilder.Jp(Condition.C, entry.TargetLabel);
-            }
-            else
-            {
-                // Pop i4 from stack and jump if non zero
-                context.InstructionsBuilder.Pop(HL);      // LSW
-                context.InstructionsBuilder.Ld(A, 0);
-                context.InstructionsBuilder.Add(A, L);
-                context.InstructionsBuilder.Pop(HL);      // MSW
-                context.InstructionsBuilder.Jp(Condition.NZ, entry.TargetLabel);
-            }
+            // Pop i4 from stack and jump if non zero
+            context.InstructionsBuilder.Pop(HL);      // LSW
+            context.InstructionsBuilder.Ld(A, 0);
+            context.InstructionsBuilder.Add(A, L);
+            context.InstructionsBuilder.Pop(HL);      // MSW
+            context.InstructionsBuilder.Jp(Condition.NZ, entry.TargetLabel);
         }
 
         private static void GenerateJumpCompareCode(JumpTrueEntry entry, CodeGeneratorContext context, BinaryOperator binOp)

--- a/ILCompiler/Compiler/OpcodeImporters/CodeFolder.cs
+++ b/ILCompiler/Compiler/OpcodeImporters/CodeFolder.cs
@@ -39,10 +39,22 @@ namespace ILCompiler.Compiler.OpcodeImporters
                 case VarType.Ptr:
                 case VarType.Int:
                     {
+                        var resultType = tree.Op2.Type;
+
                         i1 = tree.Op1.GetIntConstant();
                         i2 = tree.Op2.GetIntConstant();
                         switch (tree.Operation)
                         {
+                            case Operation.Eq:
+                                i1 = i1 == i2 ? 1 : 0;
+                                resultType = VarType.Int;
+                                break;
+
+                            case Operation.Ne_Un:
+                                i1 = i1 != i2 ? 1 : 0;
+                                resultType = VarType.Int;
+                                break;
+
                             case Operation.Add:
                                 i1 = i1 + i2;
                                 break;
@@ -64,11 +76,19 @@ namespace ILCompiler.Compiler.OpcodeImporters
                                 i1  = i1 / i2;
                                 break;
 
+                            case Operation.Lsh:
+                                i1 <<= (i2 & 0x1F);
+                                break;
+
+                            case Operation.Rsh:
+                                i1 >>= (i2 & 0x1F);
+                                break;
+
                             default:
                                 return tree;
                         }
 
-                        return tree.Op2.Type == VarType.Ptr
+                        return resultType == VarType.Ptr
                             ? new NativeIntConstantEntry((short)i1)
                             : new Int32ConstantEntry(i1);
                     }

--- a/ILCompiler/Compiler/OpcodeImporters/CodeFolder.cs
+++ b/ILCompiler/Compiler/OpcodeImporters/CodeFolder.cs
@@ -36,10 +36,11 @@ namespace ILCompiler.Compiler.OpcodeImporters
 
             switch (tree.Op2.Type)
             {
+                case VarType.Ptr:
                 case VarType.Int:
                     {
-                        i1 = ((Int32ConstantEntry)tree.Op1).GetIntConstant();
-                        i2 = ((Int32ConstantEntry)tree.Op2).GetIntConstant();
+                        i1 = tree.Op1.GetIntConstant();
+                        i2 = tree.Op2.GetIntConstant();
                         switch (tree.Operation)
                         {
                             case Operation.Add:
@@ -67,8 +68,9 @@ namespace ILCompiler.Compiler.OpcodeImporters
                                 return tree;
                         }
 
-                        // TODO: should this always return an Int32? What about native ints?
-                        return new Int32ConstantEntry(i1);
+                        return tree.Op2.Type == VarType.Ptr
+                            ? new NativeIntConstantEntry((short)i1)
+                            : new Int32ConstantEntry(i1);
                     }
 
                 default:


### PR DESCRIPTION
Also fix code gen for jump tree as it was assuming condition was a binary operator but now code folding may collapse this to a int32