### PR TITLE
Fix bug with JumpTrue code gen expecting condition to always be i4 when condition is not contained

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/JumpTrueCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/JumpTrueCodeGenerator.cs
@@ -23,11 +23,16 @@ namespace ILCompiler.Compiler.CodeGenerators
                 }
             }
 
-            // Pop i4 from stack and jump if non zero
+            // Pop condition value from stack and jump if non-zero
+            // Note condition can be either int32 or native int (int 16)
             context.InstructionsBuilder.Pop(HL);      // LSW
             context.InstructionsBuilder.Ld(A, 0);
             context.InstructionsBuilder.Add(A, L);
-            context.InstructionsBuilder.Pop(HL);      // MSW
+            if (entry.Condition.Type.IsInt())
+            {
+                // If condition is int32, we need to throw away the MSW
+                context.InstructionsBuilder.Pop(HL);      // MSW
+            }
             context.InstructionsBuilder.Jp(Condition.NZ, entry.TargetLabel);
         }
 

--- a/ILCompiler/Compiler/OpcodeImporters/CodeFolder.cs
+++ b/ILCompiler/Compiler/OpcodeImporters/CodeFolder.cs
@@ -39,20 +39,16 @@ namespace ILCompiler.Compiler.OpcodeImporters
                 case VarType.Ptr:
                 case VarType.Int:
                     {
-                        var resultType = tree.Op2.Type;
-
                         i1 = tree.Op1.GetIntConstant();
                         i2 = tree.Op2.GetIntConstant();
                         switch (tree.Operation)
                         {
                             case Operation.Eq:
                                 i1 = i1 == i2 ? 1 : 0;
-                                resultType = VarType.Int;
                                 break;
 
                             case Operation.Ne_Un:
                                 i1 = i1 != i2 ? 1 : 0;
-                                resultType = VarType.Int;
                                 break;
 
                             case Operation.Add:
@@ -88,7 +84,7 @@ namespace ILCompiler.Compiler.OpcodeImporters
                                 return tree;
                         }
 
-                        return resultType == VarType.Ptr
+                        return tree.Type == VarType.Ptr
                             ? new NativeIntConstantEntry((short)i1)
                             : new Int32ConstantEntry(i1);
                     }


### PR DESCRIPTION
Also change code folding to use type of the binary operator tree node for the folded constant

Helps with inlining #230 