### PR TITLE
Fix dominator tree construction

### DIFF
--- a/ILCompiler/Compiler/SsaBuilder.cs
+++ b/ILCompiler/Compiler/SsaBuilder.cs
@@ -373,7 +373,7 @@ namespace ILCompiler.Compiler
             return dominanceFrontierMap;
         }
 
-        private static DominatorTreeNode GetOrCreate(BasicBlock block, IDictionary<BasicBlock, DominatorTreeNode> nodeMap)
+        private static DominatorTreeNode GetOrCreate(BasicBlock block, Dictionary<BasicBlock, DominatorTreeNode> nodeMap)
         {
             if (!nodeMap.TryGetValue(block, out var node))
             {

--- a/ILCompiler/Compiler/SsaBuilder.cs
+++ b/ILCompiler/Compiler/SsaBuilder.cs
@@ -373,6 +373,16 @@ namespace ILCompiler.Compiler
             return dominanceFrontierMap;
         }
 
+        private static DominatorTreeNode GetOrCreate(BasicBlock block, IDictionary<BasicBlock, DominatorTreeNode> nodeMap)
+        {
+            if (!nodeMap.TryGetValue(block, out var node))
+            {
+                node = new DominatorTreeNode(block);
+                nodeMap[block] = node;
+            }
+            return node;
+        }
+
         private DominatorTreeNode BuildDominatorTree(IList<BasicBlock> blocks)
         {
             _logger.LogDebug("[SsaBuilder:BuildDominatorTree])");
@@ -386,30 +396,15 @@ namespace ILCompiler.Compiler
                 var immediateDominator = block.ImmediateDominator;
                 if (immediateDominator != null)
                 {
-                    DominatorTreeNode? node;
-                    if (!nodeMap.TryGetValue(immediateDominator, out node))
-                    {
-                        node = new DominatorTreeNode(immediateDominator);
-                        nodeMap[immediateDominator] = node;
-                    }
-
-                    DominatorTreeNode? childNode;
-                    if (!nodeMap.TryGetValue(block, out childNode))
-                    {
-                        childNode = new DominatorTreeNode(block);
-                        nodeMap[block] = childNode;
-                    }
-
+                    DominatorTreeNode node = GetOrCreate(immediateDominator, nodeMap);
+                    DominatorTreeNode childNode = GetOrCreate(block, nodeMap);
                     nodeMap[block] = childNode;
                     node.Children.Add(childNode);
                 }
                 else
                 {
-                    if (!nodeMap.TryGetValue(block, out rootNode))
-                    {
-                        rootNode = new DominatorTreeNode(block);
-                        nodeMap.Add(block, rootNode);
-                    }
+                    rootNode = new DominatorTreeNode(block);
+                    nodeMap.Add(block, rootNode);
                 }
             }
 

--- a/Tests/Regression/Regression/RegressionTests.cs
+++ b/Tests/Regression/Regression/RegressionTests.cs
@@ -22,6 +22,8 @@ namespace Regression
 
             Bug617();
 
+            Bug660Test();
+
             return 0;
         }
 
@@ -68,6 +70,23 @@ namespace Regression
             return t.ToArray();
         }
 
+        public static void Bug660Test()
+        {
+            int[] balls = new int[10];
+
+            bool bouncing = true;
+            while (bouncing)
+            {
+                for (int i = 0; i < balls.Length; i++)
+                {
+                    if (i == 5)
+                    {
+                        bouncing = false;
+                        break;
+                    }
+                }
+            }
+        }
     }
 
     public class Bug545Test<T>()


### PR DESCRIPTION
Construction of dominator tree was failing to look for child in nodeMap.
Also refactored immediate dominator code to match standard algorithm more closely.

Resolves #660