### PR TITLE
Add optimize option

### DIFF
--- a/ILCompiler/Compiler/Inliner.cs
+++ b/ILCompiler/Compiler/Inliner.cs
@@ -115,6 +115,9 @@ namespace ILCompiler.Compiler
 
         public void Inline(IList<BasicBlock> blocks, LocalVariableTable locals, string inputFilePath)
         {
+            if (!_configuration.Optimize)
+                return;
+
             _blocks = blocks;
             _inputFilePath = inputFilePath;
 

--- a/ILCompiler/Compiler/MethodCompiler.cs
+++ b/ILCompiler/Compiler/MethodCompiler.cs
@@ -125,7 +125,7 @@ namespace ILCompiler.Compiler
 
             var ilImporter = _phaseFactory.Create<IImporter>();
 
-            // When inlining we only run the import phaser
+            // When inlining we only run the import phase
             IList<EHClause> ehClauses = new List<EHClause>();
             var basicBlocks = ilImporter.Import(parameterCount, _returnBufferArgIndex, method, _locals, ehClauses, inlineInfo);
 

--- a/ILCompiler/Compiler/OpcodeImporters/CallImporter.cs
+++ b/ILCompiler/Compiler/OpcodeImporters/CallImporter.cs
@@ -182,7 +182,7 @@ namespace ILCompiler.Compiler.OpcodeImporters
             }
             else
             {
-                if (callNode.IsInlineCandidate)
+                if (callNode.IsInlineCandidate && importer.Configuration.Optimize)
                 {
                     // Split call into two parts: the call itself and the return expression
                     importer.ImportAppendTree(callNode, true);

--- a/ILCompiler/Configuration.cs
+++ b/ILCompiler/Configuration.cs
@@ -19,5 +19,6 @@ namespace ILCompiler
         public bool NoListFile { get; set; } = true;
         public bool SkipArrayBoundsCheck { get; set; } = false;
         public bool SkipNullReferenceCheck { get; set; } = false;
+        public bool Optimize { get; set; } = true;
     }
 }

--- a/ILCompiler/ConfigurationBinder.cs
+++ b/ILCompiler/ConfigurationBinder.cs
@@ -30,6 +30,7 @@ namespace ILCompiler
                 NoListFile = bindingContext.ParseResult.GetValueForOption(_configurationOptions.NoListFile),
                 SkipArrayBoundsCheck = bindingContext.ParseResult.GetValueForOption(_configurationOptions.SkipArrayBoundsCheck),
                 SkipNullReferenceCheck = bindingContext.ParseResult.GetValueForOption(_configurationOptions.SkipNullReferenceCheck),
+                Optimize = bindingContext.ParseResult.GetValueForOption(_configurationOptions.Optimize),
             };
         }
     }

--- a/ILCompiler/ConfigurationOptions.cs
+++ b/ILCompiler/ConfigurationOptions.cs
@@ -20,6 +20,7 @@ namespace ILCompiler
         public readonly Option<bool> NoListFile = new(new[] { "-nl", "--noListFile" }, "No list file");
         public readonly Option<bool> SkipArrayBoundsCheck = new(new[] { "-nb", "--noBoundsCheck" }, "No Array Bounds Check");
         public readonly Option<bool> SkipNullReferenceCheck = new(new[] { "-nn", "--noNullCheck" }, "No Null Reference Check");
+        public readonly Option<bool> Optimize = new(new[] { "-O", "--optimize" }, "Enable Optimizations");
 
         public void AddToCommand(Command command)
         {
@@ -35,6 +36,7 @@ namespace ILCompiler
             command.AddOption(NoListFile);
             command.AddOption(SkipArrayBoundsCheck);
             command.AddOption(SkipNullReferenceCheck);
+            command.AddOption(Optimize);
         }
     }
 }

--- a/ILCompiler/Interfaces/IConfiguration.cs
+++ b/ILCompiler/Interfaces/IConfiguration.cs
@@ -18,5 +18,6 @@ namespace ILCompiler.Interfaces
         public bool NoListFile { get; set; }
         public bool SkipArrayBoundsCheck { get; set; }
         public bool SkipNullReferenceCheck { get; set; }
+        public bool Optimize { get; set; }
     }
 }

--- a/System.Private.CoreLib/System/Diagnostics/DebuggableAttribute.cs
+++ b/System.Private.CoreLib/System/Diagnostics/DebuggableAttribute.cs
@@ -1,0 +1,43 @@
+﻿namespace System.Diagnostics
+{
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module, AllowMultiple = false)]
+    public sealed class DebuggableAttribute : Attribute
+    {
+        [Flags]
+        public enum DebuggingModes
+        {
+            None = 0x0,
+            Default = 0x1,
+            DisableOptimizations = 0x100,
+            IgnoreSymbolStoreSequencePoints = 0x2,
+            EnableEditAndContinue = 0x4
+        }
+
+        public DebuggableAttribute(bool isJITTrackingEnabled, bool isJITOptimizerDisabled)
+        {
+            DebuggingFlags = 0;
+
+            if (isJITTrackingEnabled)
+            {
+                DebuggingFlags |= DebuggingModes.Default;
+            }
+
+            if (isJITOptimizerDisabled)
+            {
+                DebuggingFlags |= DebuggingModes.DisableOptimizations;
+            }
+        }
+
+        public DebuggableAttribute(DebuggingModes modes)
+        {
+            DebuggingFlags = modes;
+        }
+
+        public bool IsJITTrackingEnabled => (DebuggingFlags & DebuggingModes.Default) != 0;
+
+        public bool IsJITOptimizerDisabled => (DebuggingFlags & DebuggingModes.DisableOptimizations) != 0;
+
+        public DebuggingModes DebuggingFlags { get; }
+
+    }
+}


### PR DESCRIPTION
This is enabled by default and will determine if inlining happens or not.
Also look for DebuggableAttribute on module being compiled and if present and DebuggingModes has DisableOptimizations set then this will override the Optimize setting.

Contributes to #677 