### PR TITLE
Inliner improvements

### DIFF
--- a/ILCompiler/Compiler/DependencyAnalysis/ILScanner.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/ILScanner.cs
@@ -237,9 +237,9 @@ namespace ILCompiler.Compiler.DependencyAnalysis
             }
         }
 
-        private void ImportStoreField(Instruction instuction, bool isStatic)
+        private void ImportStoreField(Instruction instruction, bool isStatic)
         {
-            ImportFieldAccess(instuction, isStatic);
+            ImportFieldAccess(instruction, isStatic);
         }
 
         private void ImportLoadField(Instruction instruction, bool isStatic)

--- a/ILCompiler/Compiler/EvaluationStack/CallEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/CallEntry.cs
@@ -1,4 +1,5 @@
-﻿using ILCompiler.TypeSystem.Common;
+﻿using ILCompiler.Compiler.Inlining;
+using ILCompiler.TypeSystem.Common;
 using System.Diagnostics.CodeAnalysis;
 
 namespace ILCompiler.Compiler.EvaluationStack

--- a/ILCompiler/Compiler/EvaluationStack/Statement.cs
+++ b/ILCompiler/Compiler/EvaluationStack/Statement.cs
@@ -3,6 +3,7 @@
     public class Statement
     {
         public int StartOffset { get; set; }
+        public int EndOffset { get; set; }
         public StackEntry RootNode { get; set; }
 
         public List<StackEntry> TreeList { get; set; } = [];

--- a/ILCompiler/Compiler/Importer.cs
+++ b/ILCompiler/Compiler/Importer.cs
@@ -1,5 +1,6 @@
 ﻿using ILCompiler.Compiler.DependencyAnalysis;
 using ILCompiler.Compiler.EvaluationStack;
+using ILCompiler.Compiler.Inlining;
 using ILCompiler.Compiler.OpcodeImporters;
 using ILCompiler.Interfaces;
 using ILCompiler.TypeSystem.Common;
@@ -45,6 +46,7 @@ namespace ILCompiler.Compiler
         public bool StopImporting { get; set; }
 
         private int _currentILOffset = 0;
+        private int _currentInstructionSize = 0;
 
 
         private readonly CodeFolder _codeFolder;
@@ -135,6 +137,7 @@ namespace ILCompiler.Compiler
                 var statement = new Statement(entry)
                 {
                     StartOffset = _currentILOffset,
+                    EndOffset = _currentILOffset + _currentInstructionSize - 1
                 };
                 _currentBasicBlock?.Statements.Add(statement);
             }
@@ -181,7 +184,8 @@ namespace ILCompiler.Compiler
             while (true)
             {
                 var currentInstruction = _methodIL!.Instructions[currentIndex];
-                _currentILOffset += currentInstruction.GetSize();
+                _currentInstructionSize = currentInstruction.GetSize();
+                _currentILOffset += _currentInstructionSize;
                 currentIndex++;
 
                 FallThroughBlock = _currentILOffset < BasicBlocks.Length ? BasicBlocks[_currentILOffset] : null;

--- a/ILCompiler/Compiler/Inliner.cs
+++ b/ILCompiler/Compiler/Inliner.cs
@@ -106,7 +106,10 @@ namespace ILCompiler.Compiler
 
         private static bool IsDisallowedRecursiveInline(InlineContext ancestor, InlineInfo inlineInfo)
         {
-            // TODO: verify if inline is recursive
+            if (ancestor.Callee?.Method == inlineInfo.InlineCall.Method)
+            {
+                return true;
+            }
 
             return false;
         }
@@ -169,7 +172,7 @@ namespace ILCompiler.Compiler
                 inlineInfo.StaticConstructorMethod = method.GetStaticConstructor();
             }
 
-            inlineInfo.InlineContext = NewContext(inlineInfo.InlineCandidateInfo.InlinersContext);
+            inlineInfo.InlineContext = NewContext(inlineInfo.InlineCandidateInfo.InlinersContext, methodInfo.Call);
 
             var compiler = new MethodCompiler(_logger, _configuration, _phaseFactory);
             var basicBlocks = compiler.CompileInlineeMethod(method, _inputFilePath!, inlineInfo);
@@ -208,7 +211,7 @@ namespace ILCompiler.Compiler
                     else
                     {
                         // Put all inline attempts into the inline tree
-                        var context = NewContext(inlineCandidateInfo!.InlinersContext);
+                        var context = NewContext(inlineCandidateInfo!.InlinersContext, methodInfo.Call);
                         context.SetFailed(inlineResult);
                     }
 
@@ -233,10 +236,11 @@ namespace ILCompiler.Compiler
             }
         }
 
-        private static InlineContext NewContext(InlineContext? parentContext)
+        private static InlineContext NewContext(InlineContext? parentContext, CallEntry call)
         {
             var context = new InlineContext();
             context.Parent = parentContext;
+            context.Callee = call;
 
             return context;
         }

--- a/ILCompiler/Compiler/Inliner.cs
+++ b/ILCompiler/Compiler/Inliner.cs
@@ -74,7 +74,7 @@ namespace ILCompiler.Compiler
             } while (blockIndex < blocks.Count);
         }
 
-        private int CheckInlineDepthAndRecursion(InlineInfo inlineInfo)
+        private static int CheckInlineDepthAndRecursion(InlineInfo inlineInfo)
         {
             const int MaxInlineDepth = 2;
 

--- a/ILCompiler/Compiler/Inliner.cs
+++ b/ILCompiler/Compiler/Inliner.cs
@@ -1,109 +1,14 @@
-﻿using ILCompiler.Compiler.EvaluationStack;
+﻿using System.Diagnostics;
+using ILCompiler.Compiler.EvaluationStack;
+using ILCompiler.Compiler.Inlining;
 using ILCompiler.Compiler.OpcodeImporters;
 using ILCompiler.Compiler.PreInit;
 using ILCompiler.Interfaces;
-using ILCompiler.TypeSystem.Common;
 using Microsoft.Extensions.Logging;
-using System.Diagnostics;
 using StackEntry = ILCompiler.Compiler.EvaluationStack.StackEntry;
 
 namespace ILCompiler.Compiler
 {
-    public record InlineMethodInfo
-    {
-        public required CallEntry Call { get; set; }
-        public required Statement Statement { get; set; }
-        public required int StatementIndex { get; set; }
-        public required BasicBlock Block { get; set; }
-        public required LocalVariableTable Locals { get; set; }
-    }
-
-    public record InlineArgumentInfo
-    {
-        public required StackEntry Argument {  get; set; }
-        public int TempNumber { get; set; }
-        public bool HasTemp { get; set; }
-        public bool IsInvariant { get; set; }
-        public bool IsLocalVariable { get; set; }
-        public bool IsUsed { get; set; }
-        public bool HasLdargaOp { get; set; }
-        public bool HasStargOp { get; set; }
-    }
-
-    public record LocalVariableInfo
-    {
-        public int TempNumber { get; set; }
-        public bool HasTemp { get; set; }
-        public TypeDesc? Type { get; set; }
-    }
-
-    public record InlineInfo
-    {
-        public required CallEntry InlineCall { get; set; }
-        public InlineArgumentInfo[] InlineArgumentInfos { get; set; } = [];
-        public LocalVariableInfo[] LocalVariableInfos { get; set; } = [];
-        public required LocalVariableTable InlineLocalVariableTable { get; set; }
-
-        public int? InlineeReturnSpillTempNumber { get; set; } = null;
-
-        public InlineCandidateInfo? InlineCandidateInfo { get; set; } = null;
-        public MethodDesc? StaticConstructorMethod { get; set; } = null;
-    }
-
-    public record InlineCandidateInfo
-    {
-        public ReturnExpressionEntry? ReturnExpressionEntry { get; set; } = null;
-    }
-
-    public class SubstitutePlaceholdersWalker : StackEntryVisitor
-    {
-        private readonly CodeFolder _codeFolder;
-        public SubstitutePlaceholdersWalker(CodeFolder codeFolder) : base() 
-        {
-            _codeFolder = codeFolder;
-        }
-
-        public Statement WalkStatement(Statement statement)
-        {
-            WalkTree(new Edge<StackEntry>(() => statement.RootNode, x => { statement.RootNode = x; }), null);
-
-            return statement;
-        }
-
-        public override void PreOrderVisit(Edge<StackEntry> use, StackEntry? user)
-        {
-            var node = use.Get();
-            if (node is ReturnExpressionEntry)
-            {
-                UpdateInlineReturnExpressionPlaceHolder(use, user, _codeFolder);
-            }
-        }
-
-        public override void PostOrderVisit(Edge<StackEntry> use, StackEntry? user)
-        {
-            use.Set(_codeFolder.FoldExpression(use.Get()!));
-        }
-
-        private static void UpdateInlineReturnExpressionPlaceHolder(Edge<StackEntry> use, StackEntry? user, CodeFolder codeFolder)
-        {
-            while (use.Get() is ReturnExpressionEntry)
-            {
-                var tree = use.Get();
-                var inlineCandidate = tree;
-
-                do
-                {
-                    var returnExpression = inlineCandidate as ReturnExpressionEntry;
-                    inlineCandidate = returnExpression!.SubstitutionExpression;
-                } while (inlineCandidate is ReturnExpressionEntry);
-
-                inlineCandidate = codeFolder.FoldExpression(inlineCandidate!);
-
-                use.Set(inlineCandidate!);
-            }
-        }
-    }
-
     public class Inliner(ILogger<MethodCompiler> logger, IConfiguration configuration, IPhaseFactory phaseFactory, INameMangler nameMangler, PreinitializationManager preinitializationManager, CodeFolder codeFolder) : IInliner
     {
         private readonly IConfiguration _configuration = configuration;
@@ -146,6 +51,8 @@ namespace ILCompiler.Compiler
                         var callInlined = false;
                         if (expr is CallEntry call && call.IsInlineCandidate)
                         {
+                            var inlineResult = new InlineResult() { InlineCall = call };
+
                             var inlineMethodInfo = new InlineMethodInfo()
                             {
                                 Call = call,
@@ -154,7 +61,7 @@ namespace ILCompiler.Compiler
                                 Block = block,
                                 Locals = locals,
                             };
-                            MorphCallInline(inlineMethodInfo);
+                            MorphCallInline(inlineMethodInfo, inlineResult);
                         }
 
                         // Skip over the statement that has either not been inlined
@@ -167,7 +74,69 @@ namespace ILCompiler.Compiler
             } while (blockIndex < blocks.Count);
         }
 
-        private void MorphCallInline(InlineMethodInfo methodInfo)
+        private int CheckInlineDepthAndRecursion(InlineInfo inlineInfo)
+        {
+            const int MaxInlineDepth = 2;
+
+            int depth = 0;
+
+            var inlineContext = inlineInfo.InlineCandidateInfo!.InlinersContext;
+            var inlineResult = inlineInfo.InlineResult!;
+
+            for (; inlineContext is not null; inlineContext = inlineContext.Parent)
+            {
+                depth++;
+
+                if (IsDisallowedRecursiveInline(inlineContext, inlineInfo))
+                {
+                    inlineResult.NoteFatal(InlineObservation.IsRecursive);
+                    return depth;
+                }
+
+                if (depth > MaxInlineDepth)
+                {
+                    break;
+                }
+            }
+
+            inlineResult.NoteInt(InlineObservation.Depth, depth);
+
+            return depth;
+        }
+
+        private static bool IsDisallowedRecursiveInline(InlineContext ancestor, InlineInfo inlineInfo)
+        {
+            // TODO: verify if inline is recursive
+
+            return false;
+        }
+
+        private InlineContext? MorphCallInlineHelper(InlineMethodInfo methodInfo, InlineResult result)
+        {
+            var call = methodInfo.Call;
+
+            if (call.IsVirtual)
+            {
+                result.NoteFatal(InlineObservation.IsVirtual);
+                return null;
+            }
+
+            var startVars = methodInfo.Locals.Count;
+
+            var createdConext = InvokeInlineeCompiler(methodInfo, result);
+
+            if (result.IsFailure)
+            {
+                // Need to undo some changes made during the inlining attempt
+                // Temps may have been allocated need to do this
+                methodInfo.Locals.ResetCount(startVars);
+                Debug.Assert(methodInfo.Locals.Count == startVars);
+            }
+
+            return createdConext;
+        }
+
+        private InlineContext? InvokeInlineeCompiler(InlineMethodInfo methodInfo, InlineResult inlineResult)
         {
             var method = methodInfo.Call.Method;
             if (method is null)
@@ -175,8 +144,24 @@ namespace ILCompiler.Compiler
                 throw new InvalidOperationException("Method is null");
             }
 
-            InlineInfo inlineInfo = InitVars(methodInfo);
+            var inlineInfo = new InlineInfo
+            {
+                InlineCall = methodInfo.Call,
+                InlineLocalVariableTable = methodInfo.Locals,
+                InlineResult = inlineResult,
+            };
+
             inlineInfo.InlineCandidateInfo = methodInfo.Call.InlineCandidateInfo;
+            Debug.Assert(inlineInfo.InlineCandidateInfo is not null);
+
+            var inlineDepth = CheckInlineDepthAndRecursion(inlineInfo);
+
+            if (inlineResult.IsFailure)
+            {
+                return null;
+            }
+
+            InitVars(methodInfo, inlineInfo);
 
             var staticConstructorMethod = method.GetStaticConstructor();
             if (staticConstructorMethod is not null && !_preinitializationManager.IsPreinitialized(method.OwningType))
@@ -184,7 +169,7 @@ namespace ILCompiler.Compiler
                 inlineInfo.StaticConstructorMethod = method.GetStaticConstructor();
             }
 
-            var startVars = methodInfo.Locals.Count;
+            inlineInfo.InlineContext = NewContext(inlineInfo.InlineCandidateInfo.InlinersContext);
 
             var compiler = new MethodCompiler(_logger, _configuration, _phaseFactory);
             var basicBlocks = compiler.CompileInlineeMethod(method, _inputFilePath!, inlineInfo);
@@ -194,29 +179,69 @@ namespace ILCompiler.Compiler
                 var inlineSucceeded = InsertInlineeBlocks(basicBlocks, methodInfo, inlineInfo);
                 if (inlineSucceeded)
                 {
-                    _logger.LogInformation("Inlined call to method: {MethodName}", method.FullName);
-                    return;
+                    inlineResult.NoteSuccess();
+                    _logger.LogInformation("Inlined call to method: {MethodName} (depth {Depth})", method.FullName, inlineDepth);
+                    return inlineInfo.InlineContext;
                 }
+            }
 
+            return null;
+        }
+
+        private void MorphCallInline(InlineMethodInfo methodInfo, InlineResult inlineResult)
+        {
+            var inlineCandidateInfo = methodInfo.Call.InlineCandidateInfo;
+
+            bool inliningFailed = false;
+            if (methodInfo.Call.IsInlineCandidate)
+            {
+                var createdContext = MorphCallInlineHelper(methodInfo, inlineResult);
+
+                Debug.Assert(inlineResult.IsDecided);
+
+                if (inlineResult.IsFailure)
+                {
+                    if (createdContext is not null)
+                    {
+                        createdContext.SetFailed(inlineResult);
+                    }
+                    else
+                    {
+                        // Put all inline attempts into the inline tree
+                        var context = NewContext(inlineCandidateInfo!.InlinersContext);
+                        context.SetFailed(inlineResult);
+                    }
+
+                    inliningFailed = true;
+                }
+            }
+            else
+            {
+                inliningFailed = true;
+            }
+
+            if (inliningFailed)
+            {
+                var method = methodInfo.Call.Method!;
                 if (method.HasReturnType)
                 {
-                    inlineInfo.InlineCandidateInfo!.ReturnExpressionEntry!.SubstitutionExpression = methodInfo.Call;
+                    inlineCandidateInfo!.ReturnExpressionEntry!.SubstitutionExpression = methodInfo.Call;
 
                     // Need to blank out the original call node
                     methodInfo.Statement!.RootNode = new NothingEntry();
                 }
-
-                // Need to undo some changes made during the inlining attempt
-                // Temps may have been allocated need to do this
-                methodInfo.Locals.ResetCount(startVars);
-
-                inlineInfo.InlineCall.IsInlineCandidate = false;
             }
-
-            Debug.Assert(methodInfo.Locals.Count == startVars);
         }
 
-        private static InlineInfo InitVars(InlineMethodInfo methodInfo)
+        private static InlineContext NewContext(InlineContext? parentContext)
+        {
+            var context = new InlineContext();
+            context.Parent = parentContext;
+
+            return context;
+        }
+
+        private static void InitVars(InlineMethodInfo methodInfo, InlineInfo inlineInfo)
         {
             int returnBufferArgIndex = -1;
             if (methodInfo.Call.HasReturnBuffer)
@@ -226,13 +251,8 @@ namespace ILCompiler.Compiler
             }
 
             var argumentCount = methodInfo.Call.Arguments.Count - (methodInfo.Call.HasReturnBuffer ? 1 : 0);
-
-            var inlineInfo = new InlineInfo
-            {
-                InlineCall = methodInfo.Call,
-                InlineLocalVariableTable = methodInfo.Locals,
-                InlineArgumentInfos = new InlineArgumentInfo[argumentCount]
-            };
+            
+            inlineInfo.InlineArgumentInfos = new InlineArgumentInfo[argumentCount];
 
             int inlineArgumentIndex = 0;
             for (int i = 0; i < methodInfo.Call.Arguments.Count; i++)
@@ -260,19 +280,17 @@ namespace ILCompiler.Compiler
             }
 
             var method = methodInfo.Call.Method!;
-            inlineInfo.LocalVariableInfos = new LocalVariableInfo[method.Locals.Count];
+            inlineInfo.LocalVariableInfos = new InlineLocalVariableInfo[method.Locals.Count];
 
             for (int i = 0; i < method.Locals.Count; i++)
             {
                 var local = method.Locals[i];
-                var localVariableInfo = new LocalVariableInfo()
+                var localVariableInfo = new InlineLocalVariableInfo()
                 {
                     Type = local.Type,
                 };
                 inlineInfo.LocalVariableInfos[i] = localVariableInfo;
             }
-
-            return inlineInfo;
         }
 
         private static void RecordArgumentInfo(StackEntry? argument, InlineArgumentInfo argumentInfo)
@@ -290,6 +308,8 @@ namespace ILCompiler.Compiler
             // when we have multiple blocks in the inlinee
             if (blocks.Count > 1 && methodInfo.Block.Handlers.Count > 0)
                 return false;
+
+            inlineInfo.InlineContext!.SetSucceeded(inlineInfo);
 
             // Prepend statements
             PrependStatements(methodInfo, inlineInfo, ref afterStatementIndex);
@@ -352,8 +372,9 @@ namespace ILCompiler.Compiler
         public static BasicBlock SplitBlockAfterStatement(BasicBlock block, int statementIndex)
         {
             // Create a new block
-            var statement = block.Statements[statementIndex + 1];
-            var newBlock = new BasicBlock(statement.StartOffset);
+            var statementToSplitAfter = block.Statements[statementIndex];
+            var newBlock = new BasicBlock(statementToSplitAfter.EndOffset + 1);
+
             newBlock.JumpKind = block.JumpKind;
             block.JumpKind = JumpKind.Always; // Set the original block to always jump to the new block
 
@@ -423,6 +444,10 @@ namespace ILCompiler.Compiler
             // TODO: Add nullcheck for this pointer here
 
             // TODO: Zero init inlinee locals
+            // Zero init inlinee locals
+            // If the callee contains zero-init locals then explicitly initialize them if
+            // the caller does not have init set. Otherwise we can rely on the normal logic
+            // in the caller to insert zero-init
         }
 
         private static void InsertInlineeArgument(InlineMethodInfo methodInfo, ref int afterStatementIndex, int argumentIndex, StackEntry argument, InlineInfo inlineInfo)

--- a/ILCompiler/Compiler/Inlining/InlineArgumentInfo.cs
+++ b/ILCompiler/Compiler/Inlining/InlineArgumentInfo.cs
@@ -1,0 +1,16 @@
+﻿using ILCompiler.Compiler.EvaluationStack;
+
+namespace ILCompiler.Compiler.Inlining
+{
+    public record InlineArgumentInfo
+    {
+        public required StackEntry Argument { get; set; }
+        public int TempNumber { get; set; }
+        public bool HasTemp { get; set; }
+        public bool IsInvariant { get; set; }
+        public bool IsLocalVariable { get; set; }
+        public bool IsUsed { get; set; }
+        public bool HasLdargaOp { get; set; }
+        public bool HasStargOp { get; set; }
+    }
+}

--- a/ILCompiler/Compiler/Inlining/InlineCandidateInfo.cs
+++ b/ILCompiler/Compiler/Inlining/InlineCandidateInfo.cs
@@ -1,0 +1,10 @@
+﻿using ILCompiler.Compiler.EvaluationStack;
+
+namespace ILCompiler.Compiler.Inlining
+{
+    public record InlineCandidateInfo
+    {
+        public ReturnExpressionEntry? ReturnExpressionEntry { get; set; } = null;
+        public InlineContext? InlinersContext { get; set; } = null;
+    }
+}

--- a/ILCompiler/Compiler/Inlining/InlineContext.cs
+++ b/ILCompiler/Compiler/Inlining/InlineContext.cs
@@ -1,8 +1,12 @@
-﻿namespace ILCompiler.Compiler.Inlining
+﻿using ILCompiler.Compiler.EvaluationStack;
+
+namespace ILCompiler.Compiler.Inlining
 {
     public class InlineContext
     {
         public InlineContext? Parent { get; set; } = null;
+
+        public CallEntry? Callee { get; set; } = null;
 
         public InlineObservation? Observation { get; set; }
         public bool Success { get; set; } = false;

--- a/ILCompiler/Compiler/Inlining/InlineContext.cs
+++ b/ILCompiler/Compiler/Inlining/InlineContext.cs
@@ -1,0 +1,22 @@
+﻿namespace ILCompiler.Compiler.Inlining
+{
+    public class InlineContext
+    {
+        public InlineContext? Parent { get; set; } = null;
+
+        public InlineObservation? Observation { get; set; }
+        public bool Success { get; set; } = false;
+
+        public void SetSucceeded(InlineInfo info)
+        {
+            Observation = info.InlineResult!.Observation;
+            Success = true;
+        }
+
+        public void SetFailed(InlineResult result)
+        {
+            Observation = result.Observation;
+            Success = false;
+        }
+    }
+}

--- a/ILCompiler/Compiler/Inlining/InlineDecision.cs
+++ b/ILCompiler/Compiler/Inlining/InlineDecision.cs
@@ -1,0 +1,29 @@
+﻿namespace ILCompiler.Compiler.Inlining
+{
+    public enum InlineDecision
+    {
+        Undecided,
+        Candidate,
+        Success,
+        Failure,
+        Never,
+    }
+
+    public static class InlineDecisionExtensions
+    {
+        public static bool IsDecided(this InlineDecision decision) => decision switch
+        {
+            InlineDecision.Undecided => false,
+            InlineDecision.Candidate => false,
+            _ => true
+        };
+        public static bool IsFailure(this InlineDecision decision) => decision switch
+        {
+            InlineDecision.Failure => true,
+            InlineDecision.Never => true,
+            _ => false
+        };
+
+        public static bool IsCandidate(this InlineDecision decision) => !decision.IsFailure();
+    }
+}

--- a/ILCompiler/Compiler/Inlining/InlineInfo.cs
+++ b/ILCompiler/Compiler/Inlining/InlineInfo.cs
@@ -1,0 +1,21 @@
+﻿using ILCompiler.Compiler.EvaluationStack;
+using ILCompiler.TypeSystem.Common;
+
+namespace ILCompiler.Compiler.Inlining
+{
+    public record InlineInfo
+    {
+        public required CallEntry InlineCall { get; set; }
+        public InlineContext? InlineContext { get; set; }
+
+        public InlineResult? InlineResult { get; set; }
+        public InlineArgumentInfo[] InlineArgumentInfos { get; set; } = [];
+        public InlineLocalVariableInfo[] LocalVariableInfos { get; set; } = [];
+        public required LocalVariableTable InlineLocalVariableTable { get; set; }
+
+        public int? InlineeReturnSpillTempNumber { get; set; } = null;
+
+        public InlineCandidateInfo? InlineCandidateInfo { get; set; } = null;
+        public MethodDesc? StaticConstructorMethod { get; set; } = null;
+    }
+}

--- a/ILCompiler/Compiler/Inlining/InlineLocalVariableInfo.cs
+++ b/ILCompiler/Compiler/Inlining/InlineLocalVariableInfo.cs
@@ -1,0 +1,11 @@
+﻿using ILCompiler.TypeSystem.Common;
+
+namespace ILCompiler.Compiler.Inlining
+{
+    public record InlineLocalVariableInfo
+    {
+        public int TempNumber { get; set; }
+        public bool HasTemp { get; set; }
+        public TypeDesc? Type { get; set; }
+    }
+}

--- a/ILCompiler/Compiler/Inlining/InlineMethodInfo.cs
+++ b/ILCompiler/Compiler/Inlining/InlineMethodInfo.cs
@@ -1,0 +1,13 @@
+﻿using ILCompiler.Compiler.EvaluationStack;
+
+namespace ILCompiler.Compiler.Inlining
+{
+    public record InlineMethodInfo
+    {
+        public required CallEntry Call { get; set; }
+        public required Statement Statement { get; set; }
+        public required int StatementIndex { get; set; }
+        public required BasicBlock Block { get; set; }
+        public required LocalVariableTable Locals { get; set; }
+    }
+}

--- a/ILCompiler/Compiler/Inlining/InlineObservation.cs
+++ b/ILCompiler/Compiler/Inlining/InlineObservation.cs
@@ -1,0 +1,68 @@
+﻿namespace ILCompiler.Compiler.Inlining
+{
+    public enum InlineTarget
+    {
+        Caller,
+        Callee,
+        CallSite,
+    }
+
+    public enum InlineObservationName
+    {
+        ILCodeSize,
+        IsForceInline,
+        BelowAlwaysInlineSize,
+
+        NoMethodInfo,
+        HasNoBody,
+        IsNoInline,
+        IsStructReturn,
+        IsPInvoke,
+        IsInternal,
+
+        TooMuchIL,
+
+        DebugCodeGen,
+
+        IsNotDirect,
+        IsVirtual,
+        IsWithinFilter,
+        IsRecursive,
+        IsTooDeep,
+
+        Depth,
+    }
+
+    public record InlineObservation(InlineObservationName name, InlineTarget target)
+    {
+        // Callee Information
+        public static InlineObservation ILCodeSize { get; } = new(InlineObservationName.ILCodeSize, InlineTarget.Callee);
+        public static InlineObservation IsForceInline { get; } = new(InlineObservationName.IsForceInline, InlineTarget.Callee);
+        public static InlineObservation BelowAlwaysInlineSize { get; } = new(InlineObservationName.BelowAlwaysInlineSize, InlineTarget.Callee);
+
+        // Callee Fatal
+        public static InlineObservation NoMethodInfo { get; } = new(InlineObservationName.NoMethodInfo, InlineTarget.Callee);
+        public static InlineObservation HasNoBody { get; } = new(InlineObservationName.HasNoBody, InlineTarget.Callee);
+        public static InlineObservation IsNoInline { get; } = new(InlineObservationName.IsNoInline, InlineTarget.Callee);
+        public static InlineObservation IsStructReturn { get; } = new(InlineObservationName.IsStructReturn, InlineTarget.Callee);
+        public static InlineObservation IsPInvoke { get; } = new(InlineObservationName.IsPInvoke, InlineTarget.Callee);
+        public static InlineObservation IsInternal { get; } = new(InlineObservationName.IsInternal, InlineTarget.Callee);
+
+        // Callee Performance
+        public static InlineObservation TooMuchIL { get; } = new(InlineObservationName.TooMuchIL, InlineTarget.Callee);
+
+
+        // Caller Correctness
+        public static InlineObservation DebugCodeGen { get; } = new(InlineObservationName.DebugCodeGen, InlineTarget.Caller);
+
+        // Callsite Correctness
+        public static InlineObservation IsNotDirect { get; } = new(InlineObservationName.IsNotDirect, InlineTarget.CallSite);
+        public static InlineObservation IsVirtual { get; } = new(InlineObservationName.IsVirtual, InlineTarget.CallSite);
+        public static InlineObservation IsWithinFilter { get; } = new(InlineObservationName.IsWithinFilter, InlineTarget.CallSite);
+        public static InlineObservation IsRecursive { get; } = new(InlineObservationName.IsRecursive, InlineTarget.CallSite);
+        public static InlineObservation IsTooDeep { get; } = new(InlineObservationName.IsTooDeep, InlineTarget.CallSite);
+
+        // Callsite Information
+        public static InlineObservation Depth { get; } = new(InlineObservationName.Depth, InlineTarget.CallSite);
+    }
+}

--- a/ILCompiler/Compiler/Inlining/InlineObservation.cs
+++ b/ILCompiler/Compiler/Inlining/InlineObservation.cs
@@ -19,6 +19,7 @@
         IsStructReturn,
         IsPInvoke,
         IsInternal,
+        NotMarkedForAggressiveInlining,
 
         TooMuchIL,
 
@@ -47,6 +48,7 @@
         public static InlineObservation IsStructReturn { get; } = new(InlineObservationName.IsStructReturn, InlineTarget.Callee);
         public static InlineObservation IsPInvoke { get; } = new(InlineObservationName.IsPInvoke, InlineTarget.Callee);
         public static InlineObservation IsInternal { get; } = new(InlineObservationName.IsInternal, InlineTarget.Callee);
+        public static InlineObservation NotMarkedForAggressiveInlining { get; } = new(InlineObservationName.NotMarkedForAggressiveInlining, InlineTarget.Callee);
 
         // Callee Performance
         public static InlineObservation TooMuchIL { get; } = new(InlineObservationName.TooMuchIL, InlineTarget.Callee);

--- a/ILCompiler/Compiler/Inlining/InlinePolicy.cs
+++ b/ILCompiler/Compiler/Inlining/InlinePolicy.cs
@@ -1,0 +1,103 @@
+﻿using System.Diagnostics;
+
+namespace ILCompiler.Compiler.Inlining
+{
+    public class InlinePolicy
+    {
+        public InlineDecision Decision { get; private set; } = InlineDecision.Undecided;
+        public InlineObservation? Observation { get; private set; }
+
+        public int CodeSize { get; private set; }
+        public bool? ForceInline { get; private set; } = null;
+        public int CallSiteDepth { get; private set; } = 0;
+
+        public void NoteSuccess()
+        {
+            Debug.Assert(Decision.IsCandidate());
+            Decision = InlineDecision.Success;
+        }
+
+        public void NoteFatal(InlineObservation observation)
+        {
+            NoteInternal(observation);
+        }
+
+        public void NoteBool(InlineObservation observation, bool value)
+        {
+            if (observation.name == InlineObservationName.IsForceInline)
+            {
+                ForceInline = value;
+            }
+        }
+
+        public void NoteInt(InlineObservation observation, int value)
+        {
+            const int AlwaysInlineSize = 16;
+            const int MaxInlineDepth = 20;
+
+            switch (observation.name)
+            {
+                case InlineObservationName.ILCodeSize:
+                    CodeSize = value;
+
+                    if (ForceInline == true)
+                    {
+                        SetCandidate(InlineObservation.IsForceInline);
+                    }
+                    else if (CodeSize < AlwaysInlineSize)
+                    {
+                        SetCandidate(InlineObservation.BelowAlwaysInlineSize);
+                    }
+                    else
+                    {
+                        SetNever(InlineObservation.TooMuchIL);
+                    }
+                    break;
+
+                case InlineObservationName.Depth:
+                    CallSiteDepth = value;
+                    if (CallSiteDepth > MaxInlineDepth)
+                    {
+                        SetNever(InlineObservation.IsTooDeep);
+                    }
+                    break;
+
+                default:
+                    break;
+            }
+        }
+
+        private void NoteInternal(InlineObservation observation)
+        {
+            if (observation.target == InlineTarget.Callee)
+            {
+                SetNever(observation);
+            }
+            else
+            {
+                SetFailure(observation);
+            }
+        }
+
+        private void SetFailure(InlineObservation observation)
+        {
+            Decision = InlineDecision.Failure;
+            Observation = observation;
+        }
+
+        private void SetNever(InlineObservation observation)
+        {
+            Decision = InlineDecision.Never;
+            Observation = observation;
+        }
+
+        private void SetCandidate(InlineObservation observation)
+        {
+            if (Decision == InlineDecision.Undecided)
+            {
+                Decision = InlineDecision.Candidate;
+                Observation = observation;
+            }
+        }
+    }
+}

--- a/ILCompiler/Compiler/Inlining/InlineResult.cs
+++ b/ILCompiler/Compiler/Inlining/InlineResult.cs
@@ -1,0 +1,21 @@
+﻿using ILCompiler.Compiler.EvaluationStack;
+
+namespace ILCompiler.Compiler.Inlining
+{
+    public class InlineResult
+    {
+        public InlinePolicy Policy { get; init; } = new InlinePolicy();
+        public required CallEntry InlineCall { get; set; }
+
+        public bool IsDecided => Policy.Decision.IsDecided();
+        public bool IsFailure => Policy.Decision.IsFailure();
+
+        public InlineObservation? Observation => Policy.Observation;
+
+        public void NoteSuccess() => Policy.NoteSuccess();
+        public void NoteFatal(InlineObservation observation) => Policy.NoteFatal(observation);
+
+        public void NoteBool(InlineObservation observation, bool value) => Policy.NoteBool(observation, value);
+        public void NoteInt(InlineObservation observation, int value) => Policy.NoteInt(observation, value);
+    }
+}

--- a/ILCompiler/Compiler/Inlining/SubstitutePlaceholdersWalker.cs
+++ b/ILCompiler/Compiler/Inlining/SubstitutePlaceholdersWalker.cs
@@ -1,0 +1,54 @@
+﻿using ILCompiler.Compiler.EvaluationStack;
+using ILCompiler.Compiler.OpcodeImporters;
+
+namespace ILCompiler.Compiler.Inlining
+{
+    public class SubstitutePlaceholdersWalker : StackEntryVisitor
+    {
+        private readonly CodeFolder _codeFolder;
+        public SubstitutePlaceholdersWalker(CodeFolder codeFolder) : base()
+        {
+            _codeFolder = codeFolder;
+        }
+
+        public Statement WalkStatement(Statement statement)
+        {
+            WalkTree(new Edge<StackEntry>(() => statement.RootNode, x => { statement.RootNode = x; }), null);
+
+            return statement;
+        }
+
+        public override void PreOrderVisit(Edge<StackEntry> use, StackEntry? user)
+        {
+            var node = use.Get();
+            if (node is ReturnExpressionEntry)
+            {
+                UpdateInlineReturnExpressionPlaceHolder(use, user, _codeFolder);
+            }
+        }
+
+        public override void PostOrderVisit(Edge<StackEntry> use, StackEntry? user)
+        {
+            use.Set(_codeFolder.FoldExpression(use.Get()!));
+        }
+
+        private static void UpdateInlineReturnExpressionPlaceHolder(Edge<StackEntry> use, StackEntry? user, CodeFolder codeFolder)
+        {
+            while (use.Get() is ReturnExpressionEntry)
+            {
+                var tree = use.Get();
+                var inlineCandidate = tree;
+
+                do
+                {
+                    var returnExpression = inlineCandidate as ReturnExpressionEntry;
+                    inlineCandidate = returnExpression!.SubstitutionExpression;
+                } while (inlineCandidate is ReturnExpressionEntry);
+
+                inlineCandidate = codeFolder.FoldExpression(inlineCandidate!);
+
+                use.Set(inlineCandidate!);
+            }
+        }
+    }
+}

--- a/ILCompiler/Compiler/MethodCompiler.cs
+++ b/ILCompiler/Compiler/MethodCompiler.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text;
 using ILCompiler.Compiler.DependencyAnalysis;
 using ILCompiler.Compiler.FlowgraphHelpers;
+using ILCompiler.Compiler.Inlining;
 using ILCompiler.Interfaces;
 using ILCompiler.TypeSystem.Common;
 using Microsoft.Extensions.Logging;

--- a/ILCompiler/Compiler/OpcodeImporters/CallImporter.cs
+++ b/ILCompiler/Compiler/OpcodeImporters/CallImporter.cs
@@ -443,6 +443,15 @@ namespace ILCompiler.Compiler.OpcodeImporters
                 return;
             }
 
+            // Temporarily only inline methods marked with AggressiveInlining
+            // TODO: need to investigate more aggressive inlining as currently
+            // results in too much code bloat
+            if (!call.Method.IsAggressiveInlining)
+            {
+                inlineResult.NoteFatal(InlineObservation.NotMarkedForAggressiveInlining);
+                return;
+            }
+
             var inlineCandidateInfo = CheckCanInline(call, inlinersContext, inlineResult);
 
             if (inlineResult.IsFailure)

--- a/ILCompiler/Interfaces/IImporter.cs
+++ b/ILCompiler/Interfaces/IImporter.cs
@@ -1,5 +1,6 @@
 ﻿using ILCompiler.Compiler;
 using ILCompiler.Compiler.DependencyAnalysis;
+using ILCompiler.Compiler.Inlining;
 using ILCompiler.Compiler.OpcodeImporters;
 using ILCompiler.Compiler.PreInit;
 using ILCompiler.TypeSystem.Common;

--- a/ILCompiler/TypeSystem/Common/ArrayType.cs
+++ b/ILCompiler/TypeSystem/Common/ArrayType.cs
@@ -125,8 +125,6 @@ namespace ILCompiler.TypeSystem.Common
 
         public override TypeDesc OwningType => _owningType;
 
-        public override bool IsNoInlining => Kind == ArrayMethodKind.Address;
-
         public override bool HasReturnType 
             => Kind switch
             {

--- a/ILCompiler/TypeSystem/Common/ArrayType.cs
+++ b/ILCompiler/TypeSystem/Common/ArrayType.cs
@@ -125,6 +125,7 @@ namespace ILCompiler.TypeSystem.Common
 
         public override TypeDesc OwningType => _owningType;
 
+        public override bool IsNoInlining => Kind == ArrayMethodKind.Address;
 
         public override bool HasReturnType 
             => Kind switch

--- a/ILCompiler/TypeSystem/Common/InstantiatedMethod.cs
+++ b/ILCompiler/TypeSystem/Common/InstantiatedMethod.cs
@@ -48,6 +48,7 @@ namespace ILCompiler.TypeSystem.Common
         public override bool IsPInvoke => _methodDesc.IsPInvoke;
         public override PInvokeMetaData? GetPInvokeMetaData() => _methodDesc.GetPInvokeMetaData();
         public override bool IsInternalCall => _methodDesc.IsInternalCall;
+        public override bool IsNoInlining => _methodDesc.IsNoInlining;
 
         public override bool IsStatic => _methodDesc.IsStatic;
 

--- a/ILCompiler/TypeSystem/Common/MethodDesc.cs
+++ b/ILCompiler/TypeSystem/Common/MethodDesc.cs
@@ -17,6 +17,7 @@ namespace ILCompiler.TypeSystem.Common
         public virtual PInvokeMetaData? GetPInvokeMetaData() => default;
 
         public virtual bool IsInternalCall => false;
+        public virtual bool IsNoInlining => false;
 
         public virtual bool IsStaticConstructor => OwningType.GetStaticConstructor() == this;
 

--- a/ILCompiler/TypeSystem/Common/MethodForInstantiatedType.cs
+++ b/ILCompiler/TypeSystem/Common/MethodForInstantiatedType.cs
@@ -76,6 +76,8 @@ namespace ILCompiler.TypeSystem.Common
         public override string FullName => ToString();
         public override bool HasReturnType => _typicalMethodDef.HasReturnType;
 
+        public override bool IsInternalCall => _typicalMethodDef.IsInternalCall;
+        public override bool IsNoInlining => _typicalMethodDef.IsNoInlining;
         public override bool IsVirtual => _typicalMethodDef.IsVirtual;
         public override bool IsAbstract => _typicalMethodDef.IsAbstract;
 

--- a/ILCompiler/TypeSystem/Dnlib/DnlibMethod.cs
+++ b/ILCompiler/TypeSystem/Dnlib/DnlibMethod.cs
@@ -33,6 +33,8 @@ namespace ILCompiler.TypeSystem.Dnlib
 
         public override bool IsAggressiveInlining => _methodDef.IsAggressiveInlining;
 
+        public override bool IsNoInlining => _methodDef.IsNoInlining;
+
         public override bool IsPInvoke => _methodDef.IsPinvokeImpl;
 
         public override PInvokeMetaData? GetPInvokeMetaData()

--- a/ILCompiler/TypeSystem/Dnlib/DnlibMethodIL.cs
+++ b/ILCompiler/TypeSystem/Dnlib/DnlibMethodIL.cs
@@ -11,10 +11,14 @@ namespace ILCompiler.TypeSystem.Dnlib
         private readonly ILExceptionRegion[] _exceptionRegions;
 
         private readonly int _localsCount;
-        private readonly bool _isInitLocals;
+        private readonly bool _isInitLocals;        
+
+        private readonly int _ilCodeSize;
 
         public DnlibMethodIL(DnlibModule module, CilBody body)
         {
+            _ilCodeSize = (int)(body.Instructions[^1].GetOffset() + body.Instructions[^1].GetSize());
+
             foreach (var instruction in body.Instructions)
             {
                 _instructions.Add(new DnlibInstruction(module, instruction));
@@ -39,6 +43,7 @@ namespace ILCompiler.TypeSystem.Dnlib
 
         }
 
+        public override int ILCodeSize => _ilCodeSize;
         public override int LocalsCount => _localsCount;
 
         public override IList<IL.Instruction> Instructions => _instructions;

--- a/ILCompiler/TypeSystem/IL/InstantiatedMethodIL.cs
+++ b/ILCompiler/TypeSystem/IL/InstantiatedMethodIL.cs
@@ -57,6 +57,7 @@ namespace ILCompiler.TypeSystem.IL
 
         public override IList<Instruction> Instructions => _instantiatedInstructions;
         public override ILExceptionRegion[] GetExceptionRegions() => _methodIL.GetExceptionRegions();
+        public override int ILCodeSize => _methodIL.ILCodeSize;
         public override int LocalsCount => _methodIL.LocalsCount;
 
         public override bool IsInitLocals => _methodIL.IsInitLocals;

--- a/ILCompiler/TypeSystem/IL/MethodIL.cs
+++ b/ILCompiler/TypeSystem/IL/MethodIL.cs
@@ -11,6 +11,8 @@ namespace ILCompiler.TypeSystem.IL
 
         public virtual int LocalsCount { get; set; }
 
+        public virtual int ILCodeSize => 0;
+
         public List<LocalVariableDefinition> Locals { get; set; } = new List<LocalVariableDefinition>();
 
         public virtual MethodIL GetMethodILDefinition()

--- a/Samples/Chess/Board.cs
+++ b/Samples/Chess/Board.cs
@@ -19,11 +19,7 @@ namespace Chess
 
         public void SetupPosition(string fen)
         {
-            // Array.Clear(_state, 0, _state.Length);
-            for (int i = 0; i < _state.Length; i++)
-            {
-                _state[i] = 0;
-            }
+            Array.Clear(_state, 0, _state.Length);
 
             for (int rank = 0; rank < 8; rank++)
             {

--- a/Samples/Mines/Game.cs
+++ b/Samples/Mines/Game.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace Mines
@@ -96,6 +97,8 @@ namespace Mines
             _revealMines = false;
         }
 
+        // TODO: Why does inlining this cause an issue where no keypress is recognised?
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void WaitForKeyPress()
         {
             while (!Console.KeyAvailable)

--- a/Tests/Methodical/Inlining/Inlining.cs
+++ b/Tests/Methodical/Inlining/Inlining.cs
@@ -27,6 +27,24 @@ namespace Inlining
             InlineMethod2();
         }
 
+        private static int _unused = 0;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void InlineMethodWithMoreThanOneBasicBlock(int n)
+        {
+            if (n < 0)
+            {
+                _unused = 1;
+            }
+        }
+
+        public static void InlineMethodAtEndOfBasicBlock()
+        {
+            if (_result != 1)
+            {
+                InlineMethodWithMoreThanOneBasicBlock(42);
+            }
+        }
+
         private static int _result = 1;
 
         public static int Main()
@@ -38,6 +56,8 @@ namespace Inlining
 
             if (_parameter != 2) return 2;
             if (!ReferenceEquals(_str, strParameter)) return 3;
+
+            InlineMethodAtEndOfBasicBlock();
 
             return _result;
         }

--- a/Tests/Methodical/ZeroInit/init_int32.il
+++ b/Tests/Methodical/ZeroInit/init_int32.il
@@ -213,7 +213,7 @@
 .method public static int32 Main() {
 .entrypoint
 .maxstack  5
-.locals (int32)
+.locals init (int32)
 
 	call int32 Test_Init_Int32::Test1()
 	brfalse t2


### PR DESCRIPTION
Refactor inlining code into separate files in Inlining folder.
Add scaffolding to support more aggressive inlining including inlining policy, observation, decision classes.
Use IL code size as indication as to whether to inline a method.

However, given all of the above too many methods are being inlined resulting in too much code bloat. More work/investigation required to get an appropriate balance. One option to explore here is to use the number of times a method is called as well as the IL code size. The more times a method is called the more inlining it will bloat the code.

Contributes to #230 