### PR TITLE
Replace ILocalVariable with an abstract class common

### DIFF
--- a/ILCompiler/Compiler/EvaluationStack/ILocalVariable.cs
+++ b/ILCompiler/Compiler/EvaluationStack/ILocalVariable.cs
@@ -1,8 +1,0 @@
-﻿namespace ILCompiler.Compiler.EvaluationStack
-{
-    public interface ILocalVariable
-    {
-        public int LocalNumber { get; }
-        public int SsaNumber { get; set; }
-    }
-}

--- a/ILCompiler/Compiler/EvaluationStack/LocalVariableAddressEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/LocalVariableAddressEntry.cs
@@ -1,10 +1,7 @@
 ﻿namespace ILCompiler.Compiler.EvaluationStack
 {
-    public class LocalVariableAddressEntry : StackEntry, ILocalVariable
+    public class LocalVariableAddressEntry : LocalVariableCommon
     {
-        public int LocalNumber { get; }
-        public int SsaNumber { get; set;  }
-
         public LocalVariableAddressEntry(int localNumber) : base(VarType.Ptr, VarType.Ptr.GetTypeSize())
         {
             LocalNumber = localNumber;

--- a/ILCompiler/Compiler/EvaluationStack/LocalVariableCommon.cs
+++ b/ILCompiler/Compiler/EvaluationStack/LocalVariableCommon.cs
@@ -1,0 +1,10 @@
+﻿namespace ILCompiler.Compiler.EvaluationStack
+{
+    public abstract class LocalVariableCommon(VarType type, int? exactSize = null) : StackEntry(type, exactSize)
+    {
+        public int LocalNumber { get; init; }
+        public int SsaNumber { get; set; }
+
+        public StackEntry Data => ((StoreLocalVariableEntry)this).Op1;
+    }
+}

--- a/ILCompiler/Compiler/EvaluationStack/LocalVariableEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/LocalVariableEntry.cs
@@ -1,9 +1,7 @@
 ﻿namespace ILCompiler.Compiler.EvaluationStack
 {
-    public class LocalVariableEntry : StackEntry, ILocalVariable
+    public class LocalVariableEntry : LocalVariableCommon
     {
-        public int LocalNumber { get; }
-        public int SsaNumber { get; set; }
         public LocalVariableEntry(int localNumber, VarType type, int? exactSize) : base(type, exactSize)
         {
             LocalNumber = localNumber;

--- a/ILCompiler/Compiler/EvaluationStack/PhiArg.cs
+++ b/ILCompiler/Compiler/EvaluationStack/PhiArg.cs
@@ -1,9 +1,7 @@
 ﻿namespace ILCompiler.Compiler.EvaluationStack
 {
-    public class PhiArg : StackEntry, ILocalVariable
+    public class PhiArg : LocalVariableCommon
     {
-        public int LocalNumber { get; }
-        public int SsaNumber { get; set; }
         public BasicBlock Block { get; }
 
         public PhiArg(VarType type, int localNumber, int ssaNumber, BasicBlock block) : base(type)

--- a/ILCompiler/Compiler/EvaluationStack/StoreLocalVariableEntry.cs
+++ b/ILCompiler/Compiler/EvaluationStack/StoreLocalVariableEntry.cs
@@ -2,12 +2,9 @@
 
 namespace ILCompiler.Compiler.EvaluationStack
 {
-    public class StoreLocalVariableEntry : StackEntry, ILocalVariable, IStoreEntry
+    public class StoreLocalVariableEntry : LocalVariableCommon, IStoreEntry
     {
         public StackEntry Op1 { get; set; }
-
-        public int LocalNumber { get; }
-        public int SsaNumber { get; set; }
 
         public bool IsParameter { get; }
 

--- a/ILCompiler/Compiler/Ssa/Liveness.cs
+++ b/ILCompiler/Compiler/Ssa/Liveness.cs
@@ -99,13 +99,13 @@ namespace ILCompiler.Compiler
         private static void PerNodeLocalVarLiveness(StackEntry node, VariableSet useSet, VariableSet defSet)
         {
             // For LocalVariableEntry, LocalVariableAddressEntry, StoreLocalVariableEntry, StoreIndEntry??, FieldAddressEntry?
-            if (node is ILocalVariable localVarNode)
+            if (node is LocalVariableCommon localVarNode)
             {
                 MarkUseDef(localVarNode, useSet, defSet);
             }
         }
 
-        private static void MarkUseDef(ILocalVariable tree, VariableSet useSet, VariableSet defSet)
+        private static void MarkUseDef(LocalVariableCommon tree, VariableSet useSet, VariableSet defSet)
         {
             // Assignment is a definition, everything else is a use.
 

--- a/ILCompiler/Compiler/Ssa/LocalSsaVariableDescriptor.cs
+++ b/ILCompiler/Compiler/Ssa/LocalSsaVariableDescriptor.cs
@@ -11,14 +11,14 @@ namespace ILCompiler.Compiler.Ssa
 
         public int NumberOfUses { get; private set; } = 0;
 
-        public StackEntry? DefNode { get; private set; }
+        public LocalVariableCommon? DefNode { get; private set; }
 
         public LocalSsaVariableDescriptor(BasicBlock block)
         {
             Block = block;
         }
 
-        public LocalSsaVariableDescriptor(BasicBlock block, StackEntry defNode)
+        public LocalSsaVariableDescriptor(BasicBlock block, LocalVariableCommon defNode)
         {
             Block = block;
             DefNode = defNode;

--- a/ILCompiler/Compiler/Ssa/SsaRenameDominatorTreeVisitor.cs
+++ b/ILCompiler/Compiler/Ssa/SsaRenameDominatorTreeVisitor.cs
@@ -117,12 +117,12 @@ namespace ILCompiler.Compiler.Ssa
                 var localVariableDescriptor = _locals[localNumber];
                 if (localVariableDescriptor.InSsa)
                 {
-                    localNode.SsaNumber = RenamePushDef(defNode, block, localNumber);
+                    localNode.SsaNumber = RenamePushDef(localNode, block, localNumber);
                 }
             }
         }
 
-        private void RenameLocalUse(ILocalVariable tree, BasicBlock block)
+        private void RenameLocalUse(LocalVariableCommon tree, BasicBlock block)
         {
             var localNumber = tree.LocalNumber;
             var localVariableDescriptor = _locals[localNumber];
@@ -136,7 +136,7 @@ namespace ILCompiler.Compiler.Ssa
             }
         }
 
-        private int RenamePushDef(StackEntry defNode, BasicBlock block, int localNumber)
+        private int RenamePushDef(LocalVariableCommon defNode, BasicBlock block, int localNumber)
         {
             var localVariableDescriptor = _locals[localNumber];
             int ssaNumber = localVariableDescriptor.PerSsaData.AllocSsaNumber(() => new LocalSsaVariableDescriptor(block, defNode));


### PR DESCRIPTION
The common class encapsulates the local number and ssa number for all local variable related IR node types:

- LocalVariableEntry
- LocalVariableAddressEntry
- PhiArg
- StoreLocalVariableEntry 

Also add a Data method to access the Op1 field if the node type is StoreLocalVariableEntry.

This will simplify code in scalar evolution analysis in future PRs.

Contributes to #701 