### PR TITLE
Extend loop finder to identify loop children and siblings

### DIFF
--- a/ILCompiler/Interfaces/ILoopFinder.cs
+++ b/ILCompiler/Interfaces/ILoopFinder.cs
@@ -5,6 +5,6 @@ namespace ILCompiler.Interfaces
 {
     public interface ILoopFinder : IPhase
     {
-        void FindLoops(IList<BasicBlock> blocks, FlowgraphDfsTree dfs);
+        FlowGraphNaturalLoops FindLoops(IList<BasicBlock> blocks, FlowgraphDfsTree dfs);
     }
 }


### PR DESCRIPTION
These will be required for strength reduction of induction variables in #701 