### PR TITLE
Change managed signatures of allocation helpers to take nuint

### DIFF
--- a/System.Private.CoreLib/System/Array.cs
+++ b/System.Private.CoreLib/System/Array.cs
@@ -269,16 +269,16 @@ namespace System
         internal unsafe static Array NewMultiDimArray(EEType* pEEType, int* pLengths, int rank)
         {
             // Calculate required size for array elements
-            uint totalLength = 1;
+            nuint totalLength = 1;
             for (int i = 0; i < rank; i++)
             {
-                totalLength *= (uint)pLengths[i];
+                totalLength *= (nuint)pLengths[i];
             }
 
             // Allocate array - note size allocated is totalLength + array base size
             // The base size incorporates the bounds for all dimensions plus the
             // eetype pointer and the number of components
-            Array result = RuntimeImports.NewArray(pEEType, (int)totalLength);
+            Array result = RuntimeImports.NewArray(pEEType, totalLength);
 
             // Setup upper bounds of dimensions as nints
             ref nint bounds = ref result.GetMultiDimensionalArrayBounds();

--- a/System.Private.CoreLib/System/Number.cs
+++ b/System.Private.CoreLib/System/Number.cs
@@ -15,12 +15,12 @@ namespace System
             if (value == 0)
                 return "0";
 
-            int bufferLength = CountDigits(value);
+            nuint bufferLength = CountDigits(value);
 
             string result = RuntimeImports.NewString(EEType.Of<string>(), bufferLength);
             fixed (char* buffer = result)
             {
-                char* p = buffer + bufferLength;
+                char* p = buffer + (int)(nint)bufferLength;
                 UInt32ToDecStr(p, value);
             }
             return result;
@@ -38,12 +38,12 @@ namespace System
         }
         private static unsafe string NegativeInt32ToDecStr(int value)
         {
-            int bufferLength = CountDigits((uint)-value) + 1;
+            nuint bufferLength = CountDigits((uint)-value) + 1;
             string result = RuntimeImports.NewString(EEType.Of<string>(), bufferLength);
 
             fixed (char* buffer = result)
             {
-                char* p = buffer + bufferLength;
+                char* p = buffer + (int)(nint)bufferLength;
                 p = UInt32ToDecStr(p, (uint)-value);
 
                 *(p-1) = '-';
@@ -52,9 +52,9 @@ namespace System
             return result;
         }
 
-        private static int CountDigits(uint value)
+        private static nuint CountDigits(uint value)
         {
-            int count = 0;
+            nuint count = 0;
 
             while (value > 0)
             {

--- a/System.Private.CoreLib/System/Runtime/RuntimeImports.cs
+++ b/System.Private.CoreLib/System/Runtime/RuntimeImports.cs
@@ -7,10 +7,10 @@ namespace System.Runtime
     {
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport("NewString")]
-        internal static unsafe extern string NewString(EEType* pEEType, int length);
+        internal static unsafe extern string NewString(EEType* pEEType, nuint length);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport("NewArray")]
-        internal static unsafe extern Array NewArray(EEType* pEEType, int length);
+        internal static unsafe extern Array NewArray(EEType* pEEType, nuint length);
     }
 }

--- a/System.Private.CoreLib/System/String.Manipulation.cs
+++ b/System.Private.CoreLib/System/String.Manipulation.cs
@@ -9,7 +9,7 @@ namespace System
     {
         public unsafe static string Concat(string str0, string str1, string str2, string str3)
         {
-            string result = RuntimeImports.NewString(EEType.Of<string>(), str0.Length + str1.Length + str2.Length + str3.Length);
+            string result = RuntimeImports.NewString(EEType.Of<string>(), (nuint)(str0.Length + str1.Length + str2.Length + str3.Length));
 
             FillStringChecked(result, 0, str0);
             FillStringChecked(result, str0.Length, str1);
@@ -21,7 +21,7 @@ namespace System
 
         public unsafe static string Concat(string str0, string str1, string str2)
         {
-            string result = RuntimeImports.NewString(EEType.Of<string>(), str0.Length + str1.Length + str2.Length);
+            string result = RuntimeImports.NewString(EEType.Of<string>(), (nuint)(str0.Length + str1.Length + str2.Length));
 
             FillStringChecked(result, 0, str0);
             FillStringChecked(result, str0.Length, str1);
@@ -32,7 +32,7 @@ namespace System
 
         public unsafe static string Concat(string str0, string str1)
         {
-            string result = RuntimeImports.NewString(EEType.Of<string>(), str0.Length + str1.Length);
+            string result = RuntimeImports.NewString(EEType.Of<string>(), (nuint)(str0.Length + str1.Length));
 
             FillStringChecked(result, 0, str0);
             FillStringChecked(result, str0.Length, str1);
@@ -67,10 +67,10 @@ namespace System
                 return null;
             }
 
-            return InternalSubstring(startIndex, length);
+            return InternalSubstring(startIndex, (nuint)length);
         }
 
-        private unsafe string InternalSubstring(int startIndex, int length)
+        private unsafe string InternalSubstring(int startIndex, nuint length)
         {
             string result = RuntimeImports.NewString(EEType.Of<string>(), length);
 

--- a/System.Private.CoreLib/System/String.cs
+++ b/System.Private.CoreLib/System/String.cs
@@ -40,7 +40,7 @@ namespace System
                 return Empty;
             }
 
-            string result = RuntimeImports.NewString(EEType.Of<string>(), value.Length);
+            string result = RuntimeImports.NewString(EEType.Of<string>(), (nuint)value.Length);
             Buffer.Memmove(ref result._firstChar, ref value[0], (uint)result.Length);
             return result;
         }
@@ -56,7 +56,7 @@ namespace System
                 return Empty;
             }
 
-            string result = RuntimeImports.NewString(EEType.Of<string>(), value.Length);
+            string result = RuntimeImports.NewString(EEType.Of<string>(), (nuint)value.Length);
             Buffer.Memmove(ref result._firstChar, ref MemoryMarshal.GetReference(value), (uint)result.Length);
             return result;
         }


### PR DESCRIPTION
Should yield a small improvement in size and performance due to using native uints which in CSharp-80 are 16 bits.