### PR TITLE
Refactor phases to accept MethodCompiler

### DIFF
--- a/ILCompiler/Compiler/CodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerator.cs
@@ -1,13 +1,12 @@
-﻿using ILCompiler.Compiler.CodeGenerators;
+﻿using System.Diagnostics;
+using ILCompiler.Compiler.CodeGenerators;
 using ILCompiler.Compiler.DependencyAnalysis;
 using ILCompiler.Compiler.Emit;
 using ILCompiler.Compiler.EvaluationStack;
 using ILCompiler.Compiler.Peephole;
 using ILCompiler.Interfaces;
 using ILCompiler.TypeSystem.Dnlib;
-using System.Diagnostics;
 using static ILCompiler.Compiler.Emit.Registers;
-using System.Linq;
 
 namespace ILCompiler.Compiler
 {
@@ -22,7 +21,7 @@ namespace ILCompiler.Compiler
 
         private CodeGeneratorContext _context = null!;
 
-        public CodeGenerator(INameMangler nameMangler, ICodeGeneratorFactory codeGeneratorFactory, IConfiguration configuration, 
+        public CodeGenerator(INameMangler nameMangler, ICodeGeneratorFactory codeGeneratorFactory, IConfiguration configuration,
             CorLibModuleProvider corLibModuleProvider, NodeFactory nodeFactory, Optimizer optimizer)
         {
             _nameMangler = nameMangler;
@@ -33,8 +32,11 @@ namespace ILCompiler.Compiler
             _optimizer = optimizer;
         }
 
-        public IList<Instruction> Generate(IList<BasicBlock> blocks, LocalVariableTable locals, Z80MethodCodeNode methodCodeNode)
+        public IList<Instruction> Generate(MethodCompiler compiler, Z80MethodCodeNode methodCodeNode)
         {
+            LocalVariableTable locals = compiler.Locals;
+            IList<BasicBlock> blocks = compiler.Blocks;
+
             _context = new CodeGeneratorContext(locals, methodCodeNode, _configuration, _nameMangler, _nodeFactory, _corLibModuleProvider);
 
             AssignFrameOffsets();

--- a/ILCompiler/Compiler/Dominators/FlowgraphDominatorTreeBuilder.cs
+++ b/ILCompiler/Compiler/Dominators/FlowgraphDominatorTreeBuilder.cs
@@ -1,5 +1,4 @@
 ﻿using System.Text;
-using ILCompiler.Compiler.FlowgraphHelpers;
 using ILCompiler.Interfaces;
 using Microsoft.Extensions.Logging;
 
@@ -14,9 +13,10 @@ namespace ILCompiler.Compiler.Dominators
             _logger = logger;
         }
 
-
-        public FlowgraphDominatorTree Build(FlowgraphDfsTree dfs, IList<BasicBlock> blocks)
+        public FlowgraphDominatorTree Build(MethodCompiler compiler)
         {
+            var dfs = compiler.DfsTree!;
+
             // Topologically sort the graph
             var postOrder = dfs.PostOrder;
 
@@ -24,7 +24,7 @@ namespace ILCompiler.Compiler.Dominators
             ComputeImmediateDominators(postOrder);
 
             // Create the dominator tree
-            var root = BuildDominatorTree(blocks);
+            var root = BuildDominatorTree(compiler.Blocks);
 
             // Assign preorder and postorder numbers for quick dominance checks
             NumberDomTreeVisitor numberDomTreeVisitor = new NumberDomTreeVisitor(root, postOrder.Count);

--- a/ILCompiler/Compiler/EarlyValuePropagation.cs
+++ b/ILCompiler/Compiler/EarlyValuePropagation.cs
@@ -6,22 +6,16 @@ namespace ILCompiler.Compiler
 {
     internal class EarlyValuePropagation : IEarlyValuePropagation
     {
-        private readonly IFlowgraph _flowgraph;
-        public EarlyValuePropagation(IFlowgraph flowgraph)
+        public void Run(MethodCompiler compiler)
         {
-            _flowgraph = flowgraph;
-        }
-
-        public void Run(IList<BasicBlock> blocks, LocalVariableTable locals)
-        {
-            foreach (var block in blocks)
+            foreach (var block in compiler.Blocks)
             {
                 foreach (var statement in block.Statements)
                 {
                     bool isRewritten = false;
                     foreach (var tree in statement.TreeList)
                     {
-                        var rewrittenTree = EarlyPropagationRewriteTree(block, tree, locals);
+                        var rewrittenTree = EarlyPropagationRewriteTree(block, tree, compiler.Locals);
                         if (rewrittenTree != null)
                         {
                             isRewritten = true;
@@ -31,7 +25,7 @@ namespace ILCompiler.Compiler
                     if (isRewritten)
                     {
                         // Update the evaluation order
-                        _flowgraph.SetStatementSequence(statement);
+                        compiler.Flowgraph!.SetStatementSequence(statement);
                     }
                 }
             }

--- a/ILCompiler/Compiler/LocalVariableTable.cs
+++ b/ILCompiler/Compiler/LocalVariableTable.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using ILCompiler.TypeSystem.Common;
 
 namespace ILCompiler.Compiler
 {
@@ -8,8 +9,25 @@ namespace ILCompiler.Compiler
 
         public LocalVariableDescriptor this[int i] => _locals[i];
 
-        public void Add(LocalVariableDescriptor local) => _locals.Add(local);
-        public void Insert(int index, LocalVariableDescriptor local) => _locals.Insert(index, local);
+        public int ParameterCount { get; private set; } = 0;
+        public void Add(LocalVariableDescriptor local)
+        {
+            _locals.Add(local);
+            if (local.IsParameter)
+            {
+                ParameterCount++;
+            }
+        }
+
+        public int? ReturnBufferArgIndex { get; set; }
+        public void Insert(int index, LocalVariableDescriptor local)
+        {
+            if (local.IsParameter)
+            {
+                ParameterCount++;
+            }
+            _locals.Insert(index, local);
+        }
 
         public int Count => _locals.Count;
 
@@ -23,7 +41,7 @@ namespace ILCompiler.Compiler
 
         public int GrabTemp(VarType type, int? exactSize)
         {
-            var temp = new LocalVariableDescriptor()
+            LocalVariableDescriptor temp = new()
             {
                 IsParameter = false,
                 IsTemp = true,
@@ -45,6 +63,80 @@ namespace ILCompiler.Compiler
             while (removeCount-- > 0)
             {
                 _locals.RemoveAt(removeAt);
+            }
+        }
+
+        public void SetupLocalVariableTable(MethodDesc method)
+        {
+            int parameterCount = 0;
+
+            if (method.HasThis)
+            {
+                LocalVariableDescriptor local = new()
+                {
+                    IsParameter = true,
+                    IsTemp = false,
+                    Name = "",
+                    ExactSize = 2,
+                    Type = VarType.Ref,
+                };
+                Add(local);
+                parameterCount++;
+            }
+
+            // Setup local variable table - includes parameters as well as locals in method
+            for (int parameterIndex = 0; parameterIndex < method.Signature.Length; parameterIndex++)
+            {
+                MethodParameter parameter = method.Signature[parameterIndex];
+                LocalVariableDescriptor local = new()
+                {
+                    IsParameter = true,
+                    IsTemp = false,
+                    Name = parameter.Name,
+                    ExactSize = parameter.Type.GetElementSize().AsInt,
+                    Type = parameter.Type.VarType,
+                };
+                Add(local);
+                parameterCount++;
+            }
+
+            foreach (var local in method.Locals)
+            {
+                LocalVariableDescriptor localVariableDescriptor = new()
+                {
+                    IsParameter = false,
+                    IsTemp = false,
+                    Name = local.Name,
+                    ExactSize = local.Type.GetElementSize().AsInt,
+                    Type = local.Type.VarType,
+                };
+                Add(localVariableDescriptor);
+            }
+
+            if (!method.Signature.ReturnType.IsVoid)
+            {
+                InitReturnBufferArg(method);
+            }
+        }
+
+        private void InitReturnBufferArg(MethodDesc method)
+        {
+            TypeDesc returnType = method.Signature.ReturnType;
+            if (returnType.IsValueType && !returnType.IsPrimitive && !returnType.IsEnum)
+            {
+                TargetDetails target = new(TypeSystem.Common.TargetArchitecture.Z80);
+
+                var returnBuffer = new LocalVariableDescriptor()
+                {
+                    IsParameter = true,
+                    Type = VarType.ByRef,
+                    IsTemp = false,
+                    ExactSize = target.PointerSize,
+                };
+
+                // Ensure return buffer parameter goes after the this parameter if present
+                ReturnBufferArgIndex = method!.HasThis ? 1 : 0;
+                Insert(ReturnBufferArgIndex.Value, returnBuffer);
             }
         }
     }

--- a/ILCompiler/Compiler/LoopFinder.cs
+++ b/ILCompiler/Compiler/LoopFinder.cs
@@ -8,17 +8,18 @@ namespace ILCompiler.Compiler
     public class LoopFinder : ILoopFinder
     {
         private readonly ILogger<LoopFinder> _logger;
-        public LoopFinder(ILogger<LoopFinder> logger) 
+
+        public LoopFinder(ILogger<LoopFinder> logger)
         {
             _logger = logger;
         }
 
-        public FlowGraphNaturalLoops FindLoops(IList<BasicBlock> blocks, FlowgraphDfsTree dfs)
+        public FlowGraphNaturalLoops FindLoops(MethodCompiler compiler)
         {
-            var loops = FlowGraphNaturalLoops.Find(dfs, _logger);
+            var loops = FlowGraphNaturalLoops.Find(compiler.DfsTree!, _logger);
 
             // Consider moving out of here
-            ComputeReachabilitySets(dfs);
+            ComputeReachabilitySets(compiler.DfsTree!);
 
             return loops;
         }
@@ -169,7 +170,7 @@ namespace ILCompiler.Compiler
             _loops.Add(loop);
         }
 
-        public static FlowGraphNaturalLoops Find(FlowgraphDfsTree dfsTree, ILogger<LoopFinder> logger)
+        public static FlowGraphNaturalLoops Find(FlowgraphDfsTree dfsTree, ILogger logger)
         {
             logger.LogDebug("Finding loops in DFS tree");
             logger.LogDebug("Reverse Post Order -> Block [pre, post]");
@@ -252,7 +253,7 @@ namespace ILCompiler.Compiler
             return loops;
         }
 
-        private static FlowGraphNaturalLoop? FindBackEdges(FlowgraphDfsTree dfsTree, ILogger<LoopFinder> logger, BasicBlock header, FlowGraphNaturalLoop? loop)
+        private static FlowGraphNaturalLoop? FindBackEdges(FlowgraphDfsTree dfsTree, ILogger logger, BasicBlock header, FlowGraphNaturalLoop? loop)
         {
             foreach (BasicBlock predecessorBlock in header.Predecessors)
             {
@@ -268,7 +269,7 @@ namespace ILCompiler.Compiler
             return loop;
         }
 
-        private static void FindParentLoop(ILogger<LoopFinder> logger, FlowGraphNaturalLoops loops, BasicBlock header, FlowGraphNaturalLoop loop)
+        private static void FindParentLoop(ILogger logger, FlowGraphNaturalLoops loops, BasicBlock header, FlowGraphNaturalLoop loop)
         {
             foreach (FlowGraphNaturalLoop otherLoop in loops.InPostOrder)
             {
@@ -283,7 +284,7 @@ namespace ILCompiler.Compiler
             }
         }
 
-        private static void FindEntryEdges(FlowgraphDfsTree dfsTree, ILogger<LoopFinder> logger, BasicBlock header, FlowGraphNaturalLoop loop)
+        private static void FindEntryEdges(FlowgraphDfsTree dfsTree, ILogger logger, BasicBlock header, FlowGraphNaturalLoop loop)
         {
             foreach (BasicBlock predecessor in header.Predecessors)
             {
@@ -296,7 +297,7 @@ namespace ILCompiler.Compiler
             }
         }
 
-        private static void FindExitEdges(ILogger<LoopFinder> logger, FlowGraphNaturalLoop loop)
+        private static void FindExitEdges(ILogger logger, FlowGraphNaturalLoop loop)
         {
             loop.VisitLoopBlocksReversePostOrder(loopBlock =>
             {
@@ -314,7 +315,7 @@ namespace ILCompiler.Compiler
             });
         }
 
-        private static bool FindNaturalLoopBlocks(FlowGraphNaturalLoop loop, Stack<BasicBlock> worklist, ILogger<LoopFinder> logger)
+        private static bool FindNaturalLoopBlocks(FlowGraphNaturalLoop loop, Stack<BasicBlock> worklist, ILogger logger)
         {
             var dfsTree = loop.DfsTree;
             loop.Blocks.Add(loop.Header);

--- a/ILCompiler/Compiler/Lowering.cs
+++ b/ILCompiler/Compiler/Lowering.cs
@@ -16,10 +16,10 @@ namespace ILCompiler.Compiler
         private BasicBlock _currentBlock = null!;
         private LocalVariableTable _locals = null!;
 
-        public void Run(IList<BasicBlock> blocks, LocalVariableTable locals)
+        public void Run(MethodCompiler compiler)
         {
-            _locals = locals;
-            foreach (var block in blocks)
+            _locals = compiler.Locals;
+            foreach (var block in compiler.Blocks)
             {
                 _currentBlock = block;
                 LowerBlock(block);

--- a/ILCompiler/Compiler/Rationalizer.cs
+++ b/ILCompiler/Compiler/Rationalizer.cs
@@ -6,9 +6,9 @@ namespace ILCompiler.Compiler
 {
     public class Rationalizer : IRationalizer
     {
-        public void Rationalize(IList<BasicBlock> blocks)
+        public void Rationalize(MethodCompiler compiler)
         {
-            foreach (var block in blocks)
+            foreach (var block in compiler.Blocks)
             {
                 // Link IR in statements together
                 foreach (var statement in block.Statements)

--- a/ILCompiler/Compiler/Ssa/SsaRenameState.cs
+++ b/ILCompiler/Compiler/Ssa/SsaRenameState.cs
@@ -11,10 +11,10 @@ namespace ILCompiler.Compiler.Ssa
             public int SsaNumber;
         }
 
-        private readonly ILogger<SsaBuilder> _logger;
+        private readonly ILogger _logger;
         private readonly Stack<StackNode>[] _stacks;
 
-        public SsaRenameState(ILogger<SsaBuilder> logger, int lclCount)
+        public SsaRenameState(ILogger logger, int lclCount)
         {
             _logger = logger;
             _stacks = new Stack<StackNode>[lclCount];

--- a/ILCompiler/Interfaces/ICodeGenerator.cs
+++ b/ILCompiler/Interfaces/ICodeGenerator.cs
@@ -6,6 +6,6 @@ namespace ILCompiler.Interfaces
 {
     public interface ICodeGenerator : IPhase
     {
-        public IList<Instruction> Generate(IList<BasicBlock> blocks, LocalVariableTable locals, Z80MethodCodeNode methodCodeNode);
+        public IList<Instruction> Generate(MethodCompiler compiler, Z80MethodCodeNode methodCodeNode);
     }
 }

--- a/ILCompiler/Interfaces/IComputeDominators.cs
+++ b/ILCompiler/Interfaces/IComputeDominators.cs
@@ -1,11 +1,10 @@
 ﻿using ILCompiler.Compiler;
 using ILCompiler.Compiler.Dominators;
-using ILCompiler.Compiler.FlowgraphHelpers;
 
 namespace ILCompiler.Interfaces
 {
     internal interface IComputeDominators : IPhase
     {
-        FlowgraphDominatorTree Build(FlowgraphDfsTree dfs, IList<BasicBlock> blocks);
+        FlowgraphDominatorTree Build(MethodCompiler compiler);
     }
 }

--- a/ILCompiler/Interfaces/IEarlyValuePropagation.cs
+++ b/ILCompiler/Interfaces/IEarlyValuePropagation.cs
@@ -4,6 +4,6 @@ namespace ILCompiler.Interfaces
 {
     internal interface IEarlyValuePropagation : IPhase
     {
-        void Run(IList<BasicBlock> blocks, LocalVariableTable locals);
+        void Run(MethodCompiler compiler);
     }
 }

--- a/ILCompiler/Interfaces/IImporter.cs
+++ b/ILCompiler/Interfaces/IImporter.cs
@@ -16,7 +16,7 @@ namespace ILCompiler.Interfaces
         public PreinitializationManager PreinitializationManager { get; }
         public NodeFactory NodeFactory { get; }
 
-        public IList<BasicBlock> Import(int parameterCount, int? returnBufferArgIndex, MethodDesc method, LocalVariableTable locals, IList<EHClause> ehClauses, InlineInfo? inlineInfo = null);
+        public void Import(MethodCompiler compiler, IList<EHClause> ehClauses, InlineInfo? inlineInfo = null);
 
         void Push(StackEntry entry);
         StackEntry Pop();

--- a/ILCompiler/Interfaces/IInductionVariableOptimizer.cs
+++ b/ILCompiler/Interfaces/IInductionVariableOptimizer.cs
@@ -4,6 +4,6 @@ namespace ILCompiler.Interfaces
 {
     public interface IInductionVariableOptimizer : IPhase
     {
-        void Run(IList<BasicBlock> blocks, FlowGraphNaturalLoops loops, LocalVariableTable locals);
+        void Run(MethodCompiler compiler);
     }
 }

--- a/ILCompiler/Interfaces/IInliner.cs
+++ b/ILCompiler/Interfaces/IInliner.cs
@@ -4,6 +4,6 @@ namespace ILCompiler.Interfaces
 {
     internal interface IInliner : IPhase
     {
-        void Inline(IList<BasicBlock> blocks, LocalVariableTable locals, string inputFilePath);
+        void Inline(MethodCompiler compiler, string inputFilePath);
     }
 }

--- a/ILCompiler/Interfaces/ILoopFinder.cs
+++ b/ILCompiler/Interfaces/ILoopFinder.cs
@@ -1,10 +1,9 @@
 ﻿using ILCompiler.Compiler;
-using ILCompiler.Compiler.FlowgraphHelpers;
 
 namespace ILCompiler.Interfaces
 {
     public interface ILoopFinder : IPhase
     {
-        FlowGraphNaturalLoops FindLoops(IList<BasicBlock> blocks, FlowgraphDfsTree dfs);
+        FlowGraphNaturalLoops FindLoops(MethodCompiler compiler);
     }
 }

--- a/ILCompiler/Interfaces/ILowering.cs
+++ b/ILCompiler/Interfaces/ILowering.cs
@@ -4,6 +4,6 @@ namespace ILCompiler.Interfaces
 {
     public interface ILowering : IPhase
     {
-        public void Run(IList<BasicBlock> blocks, LocalVariableTable locals);
+        public void Run(MethodCompiler compiler);
     }
 }

--- a/ILCompiler/Interfaces/IMorpher.cs
+++ b/ILCompiler/Interfaces/IMorpher.cs
@@ -1,11 +1,10 @@
 ﻿using ILCompiler.Compiler;
-using ILCompiler.TypeSystem.Common;
 
 namespace ILCompiler.Interfaces
 {
     internal interface IMorpher : IPhase
     {
-        void Init(MethodDesc method, IList<BasicBlock> blocks);
-        void Morph(IList<BasicBlock> blocks, LocalVariableTable locals);
+        void Init(MethodCompiler compiler);
+        void Morph();
     }
 }

--- a/ILCompiler/Interfaces/IPhase.cs
+++ b/ILCompiler/Interfaces/IPhase.cs
@@ -2,6 +2,5 @@
 {
     public interface IPhase
     {
-        // TODO: consider adding a Run method
     }
 }

--- a/ILCompiler/Interfaces/IRationalizer.cs
+++ b/ILCompiler/Interfaces/IRationalizer.cs
@@ -4,6 +4,6 @@ namespace ILCompiler.Interfaces
 {
     internal interface IRationalizer : IPhase
     {
-        void Rationalize(IList<BasicBlock> blocks);
+        void Rationalize(MethodCompiler compiler);
     }
 }

--- a/ILCompiler/Interfaces/ISsaBuilder.cs
+++ b/ILCompiler/Interfaces/ISsaBuilder.cs
@@ -1,11 +1,9 @@
 ﻿using ILCompiler.Compiler;
-using ILCompiler.Compiler.Dominators;
-using ILCompiler.Compiler.FlowgraphHelpers;
 
 namespace ILCompiler.Interfaces
 {
     public interface ISsaBuilder : IPhase
     {
-        public void Build(FlowgraphDominatorTree dominatorTree, IList<BasicBlock> blocks, LocalVariableTable locals, bool dumpSsa, FlowgraphDfsTree dfs);
+        public void Build(MethodCompiler compiler);
     }
 }


### PR DESCRIPTION
Allow phases to access the state of the method compiler rather than passing the individual parts of the state to the phases
Move setup of local variables into the LocalVariableTable