### PR TITLE
Fix codegen for brtrue/brfalse

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/JumpTrueCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/JumpTrueCodeGenerator.cs
@@ -108,8 +108,11 @@ namespace ILCompiler.Compiler.CodeGenerators
             {
                 context.InstructionsBuilder.Pop(HL);
                 context.InstructionsBuilder.Pop(BC);
-                context.InstructionsBuilder.And(A);
-                context.InstructionsBuilder.Sbc(HL, BC);
+
+                context.InstructionsBuilder.Ld(A, H); 
+                context.InstructionsBuilder.Or(L);
+                context.InstructionsBuilder.Or(B);
+                context.InstructionsBuilder.Or(C);
             }
             context.InstructionsBuilder.Jp(condition, entry.TargetLabel);
         }

--- a/Tests/ILCompiler.IntegrationTests/il_bvt/brfalse.il
+++ b/Tests/ILCompiler.IntegrationTests/il_bvt/brfalse.il
@@ -7,20 +7,64 @@
 }
 .method public static int32 Main() {
 .entrypoint
-.locals ()
+.locals (int32)
 	ldc.i4 0x0
+    stloc   0
+    ldloc   0
 	brfalse next1
 	br fail
 
 next1:
 	ldnull
+    stloc   0
+    ldloc   0
 	brfalse next2
 	br fail
 
 next2:
 	ldc.i4.0
+    stloc   0
+    ldloc   0
 	conv.i
-	brfalse pass
+	brfalse next3
+    br fail
+
+next3:
+    // -1
+    ldc.i4 0xFFFFFFFF
+    stloc   0
+    ldloc   0
+    brfalse fail
+
+    // 2147483647 
+    ldc.i4 0x7FFFFFFF
+    stloc   0
+    ldloc   0
+    brfalse fail
+
+    // -2147483648
+    ldc.i4 0x80000000
+    stloc   0
+    ldloc   0
+    brfalse fail
+
+    // 1431655765
+    ldc.i4 0x55555555
+    stloc   0
+    ldloc   0
+    brfalse fail
+
+    // -1431655766
+    ldc.i4 0xAAAAAAAA
+    stloc   0
+    ldloc   0
+    brfalse fail
+
+    // 0
+    ldc.i4 0x00000000
+    stloc   0
+    ldloc   0
+    brfalse pass
 
 fail:
 	ldc.i4 0x0001

--- a/Tests/ILCompiler.IntegrationTests/il_bvt/brtrue.il
+++ b/Tests/ILCompiler.IntegrationTests/il_bvt/brtrue.il
@@ -7,31 +7,85 @@
 }
 .method public static int32 Main() {
 .entrypoint
-.locals ()
+.locals (int32)
 	ldc.i4 0x1
+    stloc   0
+    ldloc   0
 	brtrue next0
 	br fail
 
 next0:
 	ldc.i4 0x2
-	brtrue pass
-
-	ldnull
-	brtrue fail
-
-	ldc.i4 0x1
-	conv.i
-	brtrue next1
+    stloc   0
+    ldloc   0
+    brtrue next1
 	br fail
 
 next1:
-	ldc.i4 0x2
-	brtrue pass
+	ldnull
+    stloc   0
+    ldloc   0
+	brtrue fail
+
+	ldc.i4 0x1
+    stloc   0
+    ldloc   0
+	conv.i
+	brtrue next2
+	br fail
+
+next2:
+    // -1
+    ldc.i4 0xFFFFFFFF
+    stloc   0
+    ldloc   0
+    brtrue next3
+    br fail
+
+next3:
+    // 2147483647 
+    ldc.i4 0x7FFFFFFF
+    stloc   0
+    ldloc   0
+    brtrue next4
+    br fail
+
+next4:
+    // -2147483648
+    ldc.i4 0x80000000
+    stloc   0
+    ldloc   0
+    brtrue next5
+    br fail
+
+next5:
+    // 1431655765
+    ldc.i4 0x55555555
+    stloc   0
+    ldloc   0
+    brtrue next6
+    br fail
+
+next6:
+    // -1431655766
+    ldc.i4 0xAAAAAAAA
+    stloc   0
+    ldloc   0
+    brtrue next7
+    br fail
+
+next7:
+    // 0
+    ldc.i4 0x00000000
+    stloc   0
+    ldloc   0
+    brtrue fail
+
+pass:
+	ldc.i4 0x0000
+	ret
 
 fail:
 	ldc.i4 0x0001
-	ret
-pass:
-	ldc.i4 0x0000
 	ret
 }


### PR DESCRIPTION
The codegen was subtracting the high/low words which fails when the high/low words are the same and non-zero.
Instead of subtracting just or all the bytes together.
Improve bvt tests for brtrue/brfalse to use a  number of values with high/low words the same

Resolves #725 