### PR TITLE
Implement Debugger.Break to invoke DOS debugger on TRS80.

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/IntrinsicCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/IntrinsicCodeGenerator.cs
@@ -47,6 +47,17 @@ namespace ILCompiler.Compiler.CodeGenerators
                 case "Exit":
                     context.InstructionsBuilder.Jp("EXITRETCODE");
                     break;
+
+                case "DebugBreak":
+                    if (context.Configuration.TargetArchitecture == TargetArchitecture.TRS80)
+                    {
+                        context.InstructionsBuilder.Call(0x440d);
+                    }
+                    else
+                    {
+                        // TODO: Implement for other architectures
+                    }
+                    break;
             }
         }
     }

--- a/ILCompiler/Compiler/OpcodeImporters/CallImporter.cs
+++ b/ILCompiler/Compiler/OpcodeImporters/CallImporter.cs
@@ -249,6 +249,13 @@ namespace ILCompiler.Compiler.OpcodeImporters
             var targetMethodName = methodToCall.Name;
             switch (targetMethodName)
             {
+                case "DebugBreak":
+                    {
+                        var callNode = new IntrinsicEntry(targetMethodName, arguments, VarType.Void);
+                        importer.ImportAppendTree(callNode);
+                        return true;
+                    }
+
                 case "Memmove":
                     if (IsTypeName(methodToCall, "System", "SpanHelpers"))
                     {

--- a/System.Private.CoreLib/System/Diagnostics/Debug.cs
+++ b/System.Private.CoreLib/System/Diagnostics/Debug.cs
@@ -1,4 +1,6 @@
-﻿namespace System.Diagnostics
+﻿using System.Runtime.CompilerServices;
+
+namespace System.Diagnostics
 {
     public static class Debug
     {
@@ -25,6 +27,12 @@
         public static void WriteLine(string message)
         {
             Console.WriteLine(message);
+        }
+
+        [Intrinsic]
+        internal static void DebugBreak()
+        {
+            throw new PlatformNotSupportedException();
         }
     }
 }

--- a/System.Private.CoreLib/System/Diagnostics/Debugger.cs
+++ b/System.Private.CoreLib/System/Diagnostics/Debugger.cs
@@ -1,0 +1,13 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace System.Diagnostics
+{
+    public static class Debugger
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void Break()
+        {
+            Debug.DebugBreak();
+        }
+    }
+}


### PR DESCRIPTION
Contributes to #559.

With following code:

```
        public unsafe static int Main()
        {
            Console.WriteLine("Press a key to enter the debugger");
            Console.ReadLine();

            Debugger.Break();

            Console.WriteLine("Back in the C# program");
            Console.ReadLine();
        }

```

We get this behaviour:

![Launch Debugger](https://github.com/user-attachments/assets/0eb10656-5320-42f3-94d8-7c30be92519a)
