### PR TITLE
Associate method desc with CallEntry for static constructor

### DIFF
--- a/ILCompiler/Compiler/Importer.cs
+++ b/ILCompiler/Compiler/Importer.cs
@@ -298,7 +298,7 @@ namespace ILCompiler.Compiler
                 if (staticConstructorMethod != null)
                 {
                     var targetMethod = NameMangler.GetMangledMethodName(staticConstructorMethod);
-                    var staticInitCall = new CallEntry(targetMethod, [], VarType.Void, 0);
+                    var staticInitCall = new CallEntry(targetMethod, [], VarType.Void, 0, method: staticConstructorMethod);
 
                     BasicBlocks[0].Statements.Add(new Statement(staticInitCall));
                 }

--- a/ILCompiler/Compiler/Inliner.cs
+++ b/ILCompiler/Compiler/Inliner.cs
@@ -437,7 +437,7 @@ namespace ILCompiler.Compiler
             {
                 // Generate call to static constructor
                 var targetMethod = _nameMangler.GetMangledMethodName(inlineInfo.StaticConstructorMethod);
-                var staticInitCall = new CallEntry(targetMethod, [], VarType.Void, 0);
+                var staticInitCall = new CallEntry(targetMethod, [], VarType.Void, 0, method: inlineInfo.StaticConstructorMethod);
 
                 var newStatement = new Statement(staticInitCall);
 

--- a/ILCompiler/Compiler/OpcodeImporters/InitClassHelper.cs
+++ b/ILCompiler/Compiler/OpcodeImporters/InitClassHelper.cs
@@ -14,7 +14,7 @@ namespace ILCompiler.Compiler.OpcodeImporters
             {
                 // Generate call to static constructor
                 var targetMethod = importer.NameMangler.GetMangledMethodName(staticConstructorMethod);
-                var staticInitCall = new CallEntry(targetMethod, new List<StackEntry>(), VarType.Void, 0);
+                var staticInitCall = new CallEntry(targetMethod, new List<StackEntry>(), VarType.Void, 0, method: staticConstructorMethod);
                 obj = new CommaEntry(staticInitCall, obj);
             }
 


### PR DESCRIPTION
This ensures that ".cctor" appears in the dumped IR for the call