### PR TITLE
ILCompiler packing is failing to publish the ilcompiler first

### DIFF
--- a/ILCompiler.ToolPack/ILCompiler.ToolPack.csproj
+++ b/ILCompiler.ToolPack/ILCompiler.ToolPack.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <!-- Publish ILCompiler before packing -->
-  <Target Name="PublishILCompiler" BeforeTargets="Pack">
+  <Target Name="PublishILCompiler" BeforeTargets="Build">
     <Exec Command="dotnet publish ../ILCompiler/ILCompiler.csproj -c Release -r win-x64 --output $(MSBuildThisFileDirectory)tools" />
   </Target>
   


### PR DESCRIPTION
Packing of ILCompiler nuget package is happening without the ILCompiler actually having been built. See if this changes fixes this