### PR TITLE
Fix il compiler tool pack content path

### DIFF
--- a/ILCompiler.ToolPack/ILCompiler.ToolPack.csproj
+++ b/ILCompiler.ToolPack/ILCompiler.ToolPack.csproj
@@ -23,7 +23,7 @@
   
   <ItemGroup>
     <ProjectReference Include="..\ILCompiler\ILCompiler.csproj" />
-    <Content Include="$(SolutionDir)/ILCompiler/bin/ILCompiler/$(Configuration)/net10.0/**/*" PackagePath="tools/" />
+    <Content Include="$(SolutionDir)/ILCompiler/bin/$(Configuration)/net10.0/**/*" PackagePath="tools/" />
     <None Include="../LICENSE" Pack="true" PackagePath="" />
     <None Include="build/CSharp-80.ILCompiler.targets" Pack="true" PackagePath="build/" />
     <None Include="build/CSharp-80.ILCompiler.props" Pack="true" PackagePath="build/" />


### PR DESCRIPTION
Path was incorrect which explains why the ILCompiler binaries are missing from the ILCompiler nuget package.