### PR TITLE
Use MSBuildThisFileDirectory in ILToolPack

### DIFF
--- a/ILCompiler.ToolPack/ILCompiler.ToolPack.csproj
+++ b/ILCompiler.ToolPack/ILCompiler.ToolPack.csproj
@@ -23,7 +23,7 @@
   
   <ItemGroup>
     <ProjectReference Include="..\ILCompiler\ILCompiler.csproj" />
-    <Content Include="$(SolutionDir)/ILCompiler/bin/$(Configuration)/net10.0/**/*" PackagePath="tools/" />
+    <Content Include="$(MSBuildThisFileDirectory)../ILCompiler/bin/$(Configuration)/net10.0/**/*" PackagePath="tools/" />
     <None Include="../LICENSE" Pack="true" PackagePath="" />
     <None Include="build/CSharp-80.ILCompiler.targets" Pack="true" PackagePath="build/" />
     <None Include="build/CSharp-80.ILCompiler.props" Pack="true" PackagePath="build/" />


### PR DESCRIPTION
Suspect SolutionDir is not defined when github actions run.
Tested locally by running:

```
dotnet clean
dotnet build ILCompiler.ToolPack/ILCompiler.ToolPack.csproj -c Release -p:TargetPlatform=Trs80

```
which reproduced the problem of the nuget package missing the ILCompiler content.
With this fix this same test now includes the ILCompiler content in the nupkg.