### PR TITLE
Force MSBuild to re‑evaluate the file list after the compiler has been built

### DIFF
--- a/ILCompiler.ToolPack/ILCompiler.ToolPack.csproj
+++ b/ILCompiler.ToolPack/ILCompiler.ToolPack.csproj
@@ -20,10 +20,15 @@
     <!-- We don't want a DLL from this project -->
     <IncludeBuildOutput>false</IncludeBuildOutput>
   </PropertyGroup>
-  
+
+	<Target Name="CollectCompilerFiles" AfterTargets="Build">
+		<ItemGroup>
+			<Content Include="$(MSBuildThisFileDirectory)../ILCompiler/bin/$(Configuration)/net10.0/**/*" PackagePath="tools/" />
+		</ItemGroup>
+	</Target>
+	
   <ItemGroup>
     <ProjectReference Include="..\ILCompiler\ILCompiler.csproj" />
-    <Content Include="$(MSBuildThisFileDirectory)../ILCompiler/bin/$(Configuration)/net10.0/**/*" PackagePath="tools/" />
     <None Include="../LICENSE" Pack="true" PackagePath="" />
     <None Include="build/CSharp-80.ILCompiler.targets" Pack="true" PackagePath="build/" />
     <None Include="build/CSharp-80.ILCompiler.props" Pack="true" PackagePath="build/" />


### PR DESCRIPTION
To ensure the compiler files are included into the nuget package