### PR TITLE
Add FlagsEx to EEType

### DIFF
--- a/Common/Internal/Runtime/EEType.cs
+++ b/Common/Internal/Runtime/EEType.cs
@@ -1,5 +1,5 @@
-﻿using Internal.Runtime.CompilerServices;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
+using Internal.Runtime.CompilerServices;
 
 namespace Internal.Runtime
 {
@@ -9,6 +9,7 @@ namespace Internal.Runtime
 #pragma warning disable 649
         private ushort _usComponentSize;
         private ushort _usFlags;
+        private ushort _usFlagsEx;
         private ushort _usBaseSize;
         private EEType* _relatedType;
         private byte _numVtableSlots;
@@ -41,7 +42,14 @@ namespace Internal.Runtime
 
         internal bool IsValueType => ElementType < EETypeElementType.Class;
 
+        internal bool IsInterface => ElementType == EETypeElementType.Interface;
+
+        internal bool IsArray => ElementType == EETypeElementType.Array;
+
         internal EETypeElementType ElementType => (EETypeElementType)(_usFlags);
+
+        // TODO: this should check FlagsEx
+        internal bool IsNullable => ElementType == EETypeElementType.Nullable;
 
         internal uint ValueTypeSize => (uint)(BaseSize - 2);
     }

--- a/ILCompiler/Compiler/CodeGenerators/CallCodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerators/CallCodeGenerator.cs
@@ -76,12 +76,12 @@ namespace ILCompiler.Compiler.CodeGenerators
 
             // EEType header comprises of following:
             //    2 bytes for component size
-            //    2 bytes for Flags
+            //    4 bytes for Flags
             //    2 bytes for base size
             //    2 bytes for related type
             //    1 byte for vtable slot count
             //    1 byte for interface slot count
-            const int eeTypeHeader = 2 + 2 + 2 + 2 + 1 + 1;
+            const int eeTypeHeader = 2 + 4 + 2 + 2 + 1 + 1;
             context.InstructionsBuilder.Ld(BC, (byte)((slot * 2) + eeTypeHeader));
 
             context.InstructionsBuilder.Call("VirtualCall");

--- a/ILCompiler/Compiler/OpcodeImporters/CallImporter.cs
+++ b/ILCompiler/Compiler/OpcodeImporters/CallImporter.cs
@@ -353,7 +353,7 @@ namespace ILCompiler.Compiler.OpcodeImporters
 
             // Get the base size
             var eeTypePtr = new IndirectEntry(arrayRef, VarType.Ptr, pointerSize);
-            var baseSize = new IndirectEntry(eeTypePtr, VarType.Ptr, pointerSize, 4);   // Base size is at offset 4
+            var baseSize = new IndirectEntry(eeTypePtr, VarType.Ptr, pointerSize, 6);   // Base size is at offset 6
 
             StackEntry destinationAddress = new BinaryOperator(Operation.Add, isComparison: false, arrayRef2, baseSize, VarType.Ptr);
 

--- a/ILCompiler/Runtime/InterfaceCall.asm
+++ b/ILCompiler/Runtime/InterfaceCall.asm
@@ -14,8 +14,8 @@
 ;
 ; On Entry: BC = Interface EEType Ptr, E = method slot, this pointer is on stack behind return address
 
-; EEType contains, Component Size (2 bytes), flags (2 bytes), base size (2 bytes), related type (2 bytes), vtable slot count (1 byte), inteface slot count (1 byte)
-BaseTypeOffset:		EQU 2 + 2 + 2
+; EEType contains, Component Size (2 bytes), flags (4 bytes), base size (2 bytes), related type (2 bytes), vtable slot count (1 byte), inteface slot count (1 byte)
+BaseTypeOffset:		EQU 2 + 4 + 2
 
 InterfaceCall:	
 	LD (REQDINTERFACE), BC

--- a/ILCompiler/Runtime/NewArray.asm
+++ b/ILCompiler/Runtime/NewArray.asm
@@ -2,7 +2,7 @@
 ;
 ; Uses: HL, DE, BC, AF, HL'
 
-; On entry on stack: EETypePtr, ElementCount in DEHL
+; On entry on stack: EETypePtr, ElementCount in HL
 
 NewArray:
 	; Save return address
@@ -50,7 +50,7 @@ NEWARR_NOMUL16:
 	PUSH HL
 
 	; Add base size to bytes to allocate
-	LD HL, 4
+	LD HL, 6
 	ADD HL, BC
 	LD E, (HL)
 	INC HL

--- a/ILCompiler/Runtime/NewObject.asm
+++ b/ILCompiler/Runtime/NewObject.asm
@@ -12,7 +12,7 @@ NewObjectNoSize:
 
 	LD B, H
 	LD C, L
-	LD DE, 4	; Offset to BaseSize
+	LD DE, 6	; Offset to BaseSize
 	ADD HL, DE
 	LD E, (HL)
 	INC HL

--- a/ILCompiler/TypeSystem/Common/TypeDesc.cs
+++ b/ILCompiler/TypeSystem/Common/TypeDesc.cs
@@ -216,5 +216,13 @@ namespace ILCompiler.TypeSystem.Common
             }
             return null;
         }
+
+        public bool IsNullable
+        {
+            get
+            {
+                return GetTypeDefinition().IsWellKnownType(WellKnownType.Nullable);
+            }
+        }
     }
 }

--- a/ILCompiler/TypeSystem/Common/TypeSystemContext.cs
+++ b/ILCompiler/TypeSystem/Common/TypeSystemContext.cs
@@ -225,6 +225,8 @@ namespace ILCompiler.TypeSystem.Common
                     return (DefType)SystemModule!.GetType(SystemNameSpace, "IntPtr");
                 case WellKnownType.Void:
                     return (DefType)SystemModule!.GetType(SystemNameSpace, "Void");
+                case WellKnownType.Nullable:
+                    return (DefType)SystemModule!.GetType(SystemNameSpace, "Nullable`1");
                 default:
                     throw new TypeLoadException();
             }


### PR DESCRIPTION
This is just a placeholder currently but will contain information about if type is nullable and the nullable value offset in future. 
Emit instantiation data if the type is nullable which will be used in future PR to enhance the RuntimeExports.Box method to correctly handle nullable types.

Contributes to #568 