### PR TITLE
Use HL instead of DE when copying 2 or less bytes from ix to stack

### DIFF
--- a/ILCompiler/Compiler/CodeGenerators/CopyHelper.cs
+++ b/ILCompiler/Compiler/CodeGenerators/CopyHelper.cs
@@ -324,8 +324,8 @@ namespace ILCompiler.Compiler.CodeGenerators
 
             bool pushImmediately = size > 4;
             int originalSize = size;
-            var destHigh = size == 2 ? H : D;
-            var destLow = size == 2 ? L : E;
+            var destHigh = size <= 2 ? H : D;
+            var destLow = size <= 2 ? L : E;
 
             int originalIxOffset = ixOffset;
             ixOffset += size - 2;


### PR DESCRIPTION
Copying 1 byte was using DE but pushing HL.