### PR TITLE
Reduce stack usage in corelib tests to give a bit more headroom.

### DIFF
--- a/Tests/CoreLib/ArrayListTests/ArrayList.IList.Tests.cs
+++ b/Tests/CoreLib/ArrayListTests/ArrayList.IList.Tests.cs
@@ -9,7 +9,7 @@
 	{
         public void RunTests()
         {
-            var validCollectionSizes = new int[] { 0, 1, 10 };
+            var validCollectionSizes = new int[] { 0, 1, 8 };
 
             foreach (int size in validCollectionSizes)
                 RunTests(size);

--- a/Tests/CoreLib/CoreLib/UnsafeTests.cs
+++ b/Tests/CoreLib/CoreLib/UnsafeTests.cs
@@ -40,7 +40,6 @@ namespace CoreLib
         [InlineData(1)]
         [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static unsafe void CopyBlockStack(int numBytes)
         {
             byte* source = stackalloc byte[numBytes];


### PR DESCRIPTION
In prep for changing code gen to zero init local vars when optimization is disabled.