### PR TITLE
Move basic blocks into the FlowGraph

### DIFF
--- a/ILCompiler/Compiler/BasicBlockAnalyser.cs
+++ b/ILCompiler/Compiler/BasicBlockAnalyser.cs
@@ -157,7 +157,7 @@ namespace ILCompiler.Compiler
             ILExceptionRegionKind.Fault => EHClauseKind.Fault,
             ILExceptionRegionKind.Finally => EHClauseKind.Finally,
             ILExceptionRegionKind.Filter => EHClauseKind.Filter,
-            ILExceptionRegionKind => EHClauseKind.Typed
+            ILExceptionRegionKind.Catch => EHClauseKind.Typed,
         };
 
         private static List<BasicBlock> GetTryBlocks(ILExceptionRegion exceptionHandler, BasicBlock[] basicBlocks)

--- a/ILCompiler/Compiler/BasicBlockAnalyser.cs
+++ b/ILCompiler/Compiler/BasicBlockAnalyser.cs
@@ -128,11 +128,11 @@ namespace ILCompiler.Compiler
                 }
 
                 var handlerBeginBlock = CreateBasicBlock(basicBlocks, exceptionHandler.HandlerOffset);
-                var handlerEndBlock = GetHandlerLastBlock(exceptionHandler.HandlerEndOffset, basicBlocks);
+                var handlerEndBlock = exceptionHandler.HandlerEndOffset != null ? basicBlocks[(int)exceptionHandler.HandlerEndOffset] : null;
 
                 handlerBeginBlock.TryBlocks = GetTryBlocks(exceptionHandler, basicBlocks);
 
-                var tryEndBlock = GetHandlerLastBlock(exceptionHandler.TryEndOffset, basicBlocks);
+                var tryEndBlock = exceptionHandler.TryEndOffset != null ? basicBlocks[(int)exceptionHandler.TryEndOffset] : null;
 
                 handlerBeginBlock.HandlerStart = true;
                 tryBeginBlock.TryStart = true;
@@ -157,26 +157,6 @@ namespace ILCompiler.Compiler
                 var ehClause = new EHClause(tryBeginBlock, tryEndBlock, handlerBeginBlock, handlerEndBlock, filterBlock, kind, catchTypeMangledName);
                 ehClauses.Add(ehClause);
             }
-        }
-
-        private static BasicBlock GetHandlerLastBlock(int? handlerEndOffset, BasicBlock[] basicBlocks)
-        {
-            if (!handlerEndOffset.HasValue)
-            {
-                return basicBlocks[^1];
-            }
-
-            int blockIndex = handlerEndOffset.Value - 1;
-            BasicBlock? handlerLastBlock;
-            do
-            {
-                handlerLastBlock = basicBlocks[blockIndex--];
-
-            } while (handlerLastBlock is null && blockIndex >= 0);
-
-            Debug.Assert(handlerLastBlock != null, "Could not find a basic block for the end of the handler");
-
-            return handlerLastBlock;
         }
 
         private static List<BasicBlock> GetTryBlocks(ILExceptionRegion exceptionHandler, BasicBlock[] basicBlocks)

--- a/ILCompiler/Compiler/BasicBlockAnalyser.cs
+++ b/ILCompiler/Compiler/BasicBlockAnalyser.cs
@@ -8,10 +8,10 @@ namespace ILCompiler.Compiler
 {
     public enum EHClauseKind
     {
-        Typed,  // Catch handler with a specific type
-        Fault,  // Fault handler
-        Finally, // Finally handler
-        Filter  // Filter handler
+        Typed = 0,  // Catch handler with a specific type
+        Filter = 1,  // Filter handler
+        Finally = 2, // Finally handler
+        Fault = 4,  // Fault handler
     }
 
     public class EHClause
@@ -145,20 +145,10 @@ namespace ILCompiler.Compiler
 
                 tryBeginBlock.Handlers.Add(handlerBeginBlock);
 
-                EHClauseKind kind = ToEHClauseKind(exceptionHandler.Kind);
-
-                var ehClause = new EHClause(tryBeginBlock, tryEndBlock, handlerBeginBlock, handlerEndBlock, filterBlock, kind, catchTypeMangledName);
+                var ehClause = new EHClause(tryBeginBlock, tryEndBlock, handlerBeginBlock, handlerEndBlock, filterBlock, (EHClauseKind)exceptionHandler.Kind, catchTypeMangledName);
                 ehClauses.Add(ehClause);
             }
         }
-
-        private static EHClauseKind ToEHClauseKind(ILExceptionRegionKind exceptionRegionKind) => exceptionRegionKind switch
-        {
-            ILExceptionRegionKind.Fault => EHClauseKind.Fault,
-            ILExceptionRegionKind.Finally => EHClauseKind.Finally,
-            ILExceptionRegionKind.Filter => EHClauseKind.Filter,
-            ILExceptionRegionKind.Catch => EHClauseKind.Typed,
-        };
 
         private static List<BasicBlock> GetTryBlocks(ILExceptionRegion exceptionHandler, BasicBlock[] basicBlocks)
         {

--- a/ILCompiler/Compiler/BasicBlockAnalyser.cs
+++ b/ILCompiler/Compiler/BasicBlockAnalyser.cs
@@ -120,8 +120,7 @@ namespace ILCompiler.Compiler
                     // TODO: Implement finally blocks - just ignore them for now
                     continue;
                 }
-
-                if (exceptionHandler.Kind == ILExceptionRegionKind.Filter)
+                else if (exceptionHandler.Kind == ILExceptionRegionKind.Filter)
                 {
                     filterBlock = CreateBasicBlock(basicBlocks, exceptionHandler.FilterOffset);
                     filterBlock.FilterStart = true;
@@ -146,18 +145,20 @@ namespace ILCompiler.Compiler
 
                 tryBeginBlock.Handlers.Add(handlerBeginBlock);
 
-                EHClauseKind kind = exceptionHandler.Kind switch
-                {
-                    ILExceptionRegionKind.Fault => EHClauseKind.Fault,
-                    ILExceptionRegionKind.Finally => EHClauseKind.Finally,
-                    ILExceptionRegionKind.Filter => EHClauseKind.Filter,
-                    ILExceptionRegionKind => EHClauseKind.Typed
-                };
+                EHClauseKind kind = ToEHClauseKind(exceptionHandler.Kind);
 
                 var ehClause = new EHClause(tryBeginBlock, tryEndBlock, handlerBeginBlock, handlerEndBlock, filterBlock, kind, catchTypeMangledName);
                 ehClauses.Add(ehClause);
             }
         }
+
+        private static EHClauseKind ToEHClauseKind(ILExceptionRegionKind exceptionRegionKind) => exceptionRegionKind switch
+        {
+            ILExceptionRegionKind.Fault => EHClauseKind.Fault,
+            ILExceptionRegionKind.Finally => EHClauseKind.Finally,
+            ILExceptionRegionKind.Filter => EHClauseKind.Filter,
+            ILExceptionRegionKind => EHClauseKind.Typed
+        };
 
         private static List<BasicBlock> GetTryBlocks(ILExceptionRegion exceptionHandler, BasicBlock[] basicBlocks)
         {

--- a/ILCompiler/Compiler/CodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerator.cs
@@ -35,7 +35,7 @@ namespace ILCompiler.Compiler
         public IList<Instruction> Generate(MethodCompiler compiler, Z80MethodCodeNode methodCodeNode)
         {
             LocalVariableTable locals = compiler.Locals;
-            IList<BasicBlock> blocks = compiler.Blocks;
+            IList<BasicBlock> blocks = compiler.ControlFlowGraph.Blocks;
 
             _context = new CodeGeneratorContext(locals, methodCodeNode, _configuration, _nameMangler, _nodeFactory, _corLibModuleProvider);
 
@@ -93,17 +93,10 @@ namespace ILCompiler.Compiler
 
                 if (block.JumpKind == JumpKind.Always)
                 {
-                    var nonHandlerSuccessors = block.Successors.Where(s => !s.HandlerStart).ToList();
-                    if (nonHandlerSuccessors.Count == 1)
+                    if (block.Successors.Count == 1)
                     {
-                        _context.InstructionsBuilder.Jp(nonHandlerSuccessors[0].Label);
+                        _context.InstructionsBuilder.Jp(block.Successors[0].Label);
                     }
-                }
-
-                // If block is last block in a try handler then emit a label which will be used in the EH_CLAUSES
-                if (methodCodeNode.EhClauses.Any(x => x.TryEnd == block))
-                {
-                    _context.InstructionsBuilder.Label($"{block.Label}_END");
                 }
 
                 methodInstructions.AddRange(_context.InstructionsBuilder.Instructions);

--- a/ILCompiler/Compiler/CodeGenerator.cs
+++ b/ILCompiler/Compiler/CodeGenerator.cs
@@ -91,12 +91,9 @@ namespace ILCompiler.Compiler
                     currentNode = currentNode.Next;
                 }
 
-                if (block.JumpKind == JumpKind.Always)
+                if (block.JumpKind == JumpKind.Always && block.Successors.Count == 1)
                 {
-                    if (block.Successors.Count == 1)
-                    {
-                        _context.InstructionsBuilder.Jp(block.Successors[0].Label);
-                    }
+                    _context.InstructionsBuilder.Jp(block.Successors[0].Label);
                 }
 
                 methodInstructions.AddRange(_context.InstructionsBuilder.Instructions);

--- a/ILCompiler/Compiler/Diagnostics.cs
+++ b/ILCompiler/Compiler/Diagnostics.cs
@@ -39,7 +39,7 @@ namespace ILCompiler.Compiler
             return sb.ToString();
         }
 
-        public static void DumpFlowGraph(string inputFilePath, MethodDesc method, IList<BasicBlock> blocks)
+        public static void DumpFlowGraph(string inputFilePath, MethodDesc method, FlowGraph cfg)
         {
             var inputFolder = Path.GetDirectoryName(inputFilePath) ?? throw new ArgumentException("inputFilePath is null");
             var flowGraphFolder = Path.Combine(inputFolder, "FlowGraph");
@@ -54,14 +54,14 @@ namespace ILCompiler.Compiler
                 dotOutput.WriteLine($"    graph [label=\"{method.FullName}\"];");
                 dotOutput.WriteLine( "    node [shape=\"Box\"];");
 
-                foreach (var block in blocks)
+                foreach (var block in cfg.Blocks)
                 {
                     dotOutput.WriteLine($"    {block.Label}");
                 }
 
-                foreach (var block in blocks)
+                foreach (var block in cfg.Blocks)
                 {
-                    foreach (var successor in block.Successors)
+                    foreach (var successor in cfg.VisitAllSuccs(block))
                     {
                         dotOutput.WriteLine($"    {block.Label} -> {successor.Label}");
                     }

--- a/ILCompiler/Compiler/Dominators/FlowgraphDominatorTreeBuilder.cs
+++ b/ILCompiler/Compiler/Dominators/FlowgraphDominatorTreeBuilder.cs
@@ -24,7 +24,7 @@ namespace ILCompiler.Compiler.Dominators
             ComputeImmediateDominators(postOrder);
 
             // Create the dominator tree
-            var root = BuildDominatorTree(compiler.Blocks);
+            var root = BuildDominatorTree(compiler.ControlFlowGraph.Blocks);
 
             // Assign preorder and postorder numbers for quick dominance checks
             NumberDomTreeVisitor numberDomTreeVisitor = new NumberDomTreeVisitor(root, postOrder.Count);

--- a/ILCompiler/Compiler/EarlyValuePropagation.cs
+++ b/ILCompiler/Compiler/EarlyValuePropagation.cs
@@ -8,7 +8,7 @@ namespace ILCompiler.Compiler
     {
         public void Run(MethodCompiler compiler)
         {
-            foreach (var block in compiler.Blocks)
+            foreach (var block in compiler.ControlFlowGraph.Blocks)
             {
                 foreach (var statement in block.Statements)
                 {
@@ -25,7 +25,7 @@ namespace ILCompiler.Compiler
                     if (isRewritten)
                     {
                         // Update the evaluation order
-                        compiler.Flowgraph!.SetStatementSequence(statement);
+                        compiler.ControlFlowGraph.SetStatementSequence(statement);
                     }
                 }
             }

--- a/ILCompiler/Compiler/Flowgraph.cs
+++ b/ILCompiler/Compiler/Flowgraph.cs
@@ -3,11 +3,54 @@ using ILCompiler.Interfaces;
 
 namespace ILCompiler.Compiler
 {
-    public class Flowgraph : IFlowgraph
+    public class FlowGraph : IFlowgraph
     {
-        public void SetBlockOrder(IList<BasicBlock> blocks)
+        public IList<BasicBlock> Blocks { get; } = [];
+
+        public IList<EHClause> EhClauses { get; } = [];
+
+        public IEnumerable<BasicBlock> VisitAllSuccs(BasicBlock b)
         {
-            foreach (var block in blocks)
+            foreach (BasicBlock succ in b.Successors)
+                yield return succ;
+
+            foreach (BasicBlock ehSucc in GetEhSuccs(b))
+                yield return ehSucc;
+        }
+
+        private IEnumerable<BasicBlock> GetEhSuccs(BasicBlock b)
+        {
+            foreach (EHClause clause in EhClauses)
+            {
+                if (IsInTryRegion(b, clause))
+                {
+                    yield return clause.HandlerBegin;
+                }
+            }
+        }
+
+        bool IsInTryRegion(BasicBlock b, EHClause c)
+        {
+            bool inRegion = false;
+
+            foreach (BasicBlock block in Blocks)
+            {
+                if (block == c.TryBegin)
+                    inRegion = true;
+
+                if (block == c.TryEnd)
+                    break;
+
+                if (block == b && inRegion)
+                    return true;
+            }
+
+            return false;
+        }
+
+        public void SetBlockOrder()
+        {
+            foreach (var block in Blocks)
             {
                 SetBlockOrder(block);
             }
@@ -70,7 +113,7 @@ namespace ILCompiler.Compiler
             else
             {
                 InsertStatementAtEnd(block, statement);
-            }              
+            }
         }
 
         public void InsertStatementAtEnd(BasicBlock block, Statement statement)
@@ -84,39 +127,6 @@ namespace ILCompiler.Compiler
         public void RemoveStatement(BasicBlock block, Statement statement)
         {
             block.Statements.Remove(statement);
-        }
-    }
-
-    public class PostOrderTraversalVisitor : StackEntryVisitor
-    {
-        public StackEntry? Current { get; private set; }
-        public StackEntry? First { get; set; }
-
-        public List<StackEntry> PostOrderNodes { get; set; } = new List<StackEntry>();
-
-        public PostOrderTraversalVisitor(StackEntry? current)
-        {
-            Current = current;
-        }
-
-        public override WalkResult PostOrderVisit(Edge<StackEntry> use, StackEntry? user)
-        {
-            SetNext(use.Get());
-            return WalkResult.Continue;
-        }
-        private void SetNext(StackEntry entry)
-        {
-            PostOrderNodes.Add(entry);
-            if (Current != null)
-            {
-                Current.Next = entry;
-                entry.Prev = Current;
-            }
-            Current = entry;
-            if (First == null)
-            {
-                First = Current;
-            }
         }
     }
 }

--- a/ILCompiler/Compiler/FlowgraphHelpers/FlowgraphDfsTree.cs
+++ b/ILCompiler/Compiler/FlowgraphHelpers/FlowgraphDfsTree.cs
@@ -5,12 +5,12 @@
         public IList<BasicBlock> PostOrder { get; init; } = postOrder;
         public bool HasCycle { get; init; } = hasCycle;
 
-        public class AllSuccessorEnumerator(BasicBlock block)
+        public class AllSuccessorEnumerator(BasicBlock block, ControlFlowGraph controlFlowGraph)
         {
-            private int _position = 0;
             public BasicBlock Block { get; init; } = block;
 
-            public BasicBlock? NextSuccessor => _position < Block.Successors.Count ? Block.Successors[_position++] : null;
+            private readonly IEnumerator<BasicBlock> _successorEnumerator = controlFlowGraph.VisitAllSuccs(block).GetEnumerator();
+            public BasicBlock? NextSuccessor => _successorEnumerator.MoveNext() ? _successorEnumerator.Current : null;
         }
 
         public static bool IsAncestor(BasicBlock ancestor, BasicBlock descendant)
@@ -19,12 +19,11 @@
                 descendant.PostOrderNum <= ancestor.PostOrderNum;
         }
 
-        public static FlowgraphDfsTree BuildAndRemove(IList<BasicBlock> blocks)
+        public static FlowgraphDfsTree BuildAndRemove(ControlFlowGraph controlFlowGraph)
         {
-            blocks = SetupBasicBlockRoot(blocks);
+            var blocks = SetupBasicBlockRoot(controlFlowGraph.Blocks);
 
-            var firstBlock = blocks[0];
-            var dfsTree = Build(firstBlock);
+            var dfsTree = Build(controlFlowGraph);
 
             dfsTree.RemoveBlocksOutsideOfDfsTree(blocks);
 
@@ -55,8 +54,9 @@
             }
         }
 
-        public static FlowgraphDfsTree Build(BasicBlock firstBlock)
+        public static FlowgraphDfsTree Build(ControlFlowGraph controlFlowGraph)
         {
+            var firstBlock = controlFlowGraph.Blocks[0];
             var postOrder = new List<BasicBlock>();
             bool hasCycle = false;
 
@@ -66,7 +66,7 @@
             uint preOrderIndex = 0;
 
             var blocks = new Stack<AllSuccessorEnumerator>();
-            blocks.Push(new AllSuccessorEnumerator(firstBlock));
+            blocks.Push(new AllSuccessorEnumerator(firstBlock, controlFlowGraph));
             VisitPreOrder(firstBlock, preOrderIndex++);
 
             while (blocks.Count != 0)
@@ -78,7 +78,7 @@
                 {
                     if (!visitedBlocks.Contains(successor))
                     {
-                        blocks.Push(new AllSuccessorEnumerator(successor));
+                        blocks.Push(new AllSuccessorEnumerator(successor, controlFlowGraph));
                         visitedBlocks.Add(successor);
 
                         VisitPreOrder(successor, preOrderIndex++);

--- a/ILCompiler/Compiler/FlowgraphHelpers/FlowgraphDfsTree.cs
+++ b/ILCompiler/Compiler/FlowgraphHelpers/FlowgraphDfsTree.cs
@@ -5,7 +5,7 @@
         public IList<BasicBlock> PostOrder { get; init; } = postOrder;
         public bool HasCycle { get; init; } = hasCycle;
 
-        public class AllSuccessorEnumerator(BasicBlock block, ControlFlowGraph controlFlowGraph)
+        public class AllSuccessorEnumerator(BasicBlock block, FlowGraph controlFlowGraph)
         {
             public BasicBlock Block { get; init; } = block;
 
@@ -19,7 +19,7 @@
                 descendant.PostOrderNum <= ancestor.PostOrderNum;
         }
 
-        public static FlowgraphDfsTree BuildAndRemove(ControlFlowGraph controlFlowGraph)
+        public static FlowgraphDfsTree BuildAndRemove(FlowGraph controlFlowGraph)
         {
             var blocks = SetupBasicBlockRoot(controlFlowGraph.Blocks);
 
@@ -54,7 +54,7 @@
             }
         }
 
-        public static FlowgraphDfsTree Build(ControlFlowGraph controlFlowGraph)
+        public static FlowgraphDfsTree Build(FlowGraph controlFlowGraph)
         {
             var firstBlock = controlFlowGraph.Blocks[0];
             var postOrder = new List<BasicBlock>();

--- a/ILCompiler/Compiler/Importer.cs
+++ b/ILCompiler/Compiler/Importer.cs
@@ -289,7 +289,7 @@ namespace ILCompiler.Compiler
 
             var basicBlockAnalyser = new BasicBlockAnalyser(Method, NameMangler, _methodIL, this);
             var offsetToIndexMap = new Dictionary<int, int>();
-            BasicBlocks = basicBlockAnalyser.FindBasicBlocks(offsetToIndexMap, ehClauses);
+            BasicBlocks = basicBlockAnalyser.FindBasicBlocks(offsetToIndexMap, ehClauses);            
 
             // Trigger static constructor if required
             if (Method.IsDefaultConstructor)
@@ -306,29 +306,12 @@ namespace ILCompiler.Compiler
 
             ImportBasicBlocks(offsetToIndexMap);
 
-            compiler.Blocks.Clear();
+            compiler.ControlFlowGraph.Blocks.Clear();
             for (int i = 0; i < BasicBlocks.Length; i++)
             {
                 if (BasicBlocks[i] != null)
                 {
-                    compiler.Blocks.Add(BasicBlocks[i]);
-                }
-            }
-
-            // Add EH begin block as successor to all blocks in trys
-            SetTryBlockSuccessors(compiler.Blocks);
-        }
-
-        private static void SetTryBlockSuccessors(IList<BasicBlock> basicBlocks)
-        {
-            foreach (var block in basicBlocks)
-            {
-                if (block.HandlerStart)
-                {
-                    foreach (var tryBlock in block.TryBlocks)
-                    {
-                        tryBlock.Successors.Add(block);
-                    }
+                    compiler.ControlFlowGraph.Blocks.Add(BasicBlocks[i]);
                 }
             }
         }

--- a/ILCompiler/Compiler/InductionVariableOptimizer.cs
+++ b/ILCompiler/Compiler/InductionVariableOptimizer.cs
@@ -12,15 +12,13 @@ namespace ILCompiler.Compiler
     internal class InductionVariableOptimizer : IInductionVariableOptimizer
     {
         private readonly ILogger<InductionVariableOptimizer> _logger;
-        private readonly IFlowgraph _flowgraph;
 
-        public InductionVariableOptimizer(ILogger<InductionVariableOptimizer> logger, IFlowgraph flowgraph)
+        public InductionVariableOptimizer(ILogger<InductionVariableOptimizer> logger)
         {
             _logger = logger;
-            _flowgraph = flowgraph;
         }
 
-        public void Run(MethodCompiler compiler)
+        public void Run(MethodCompiler compiler, FlowGraph controlFlowGraph)
         {
             FlowGraphNaturalLoops loops = compiler.Loops!;
 
@@ -38,11 +36,11 @@ namespace ILCompiler.Compiler
                     // Consider doing something useful here
                     _logger.LogInformation("Processing loop with header {LoopLabel}", loop.Header.Label);
 
-                    var strengthReductionContext = new StrengthReductionContext(scalarEvolutionContext, loop, loopInfo, compiler.Locals, _flowgraph, _logger);
+                    var strengthReductionContext = new StrengthReductionContext(scalarEvolutionContext, loop, loopInfo, compiler.Locals, controlFlowGraph, _logger);
                     strengthReductionContext.TryStrengthReduce();
 
                     // TODO: Remove unused IVs
-                    RemoveUnusedIVs(loop, loopInfo, compiler.Flowgraph!, compiler.Locals);
+                    RemoveUnusedIVs(loop, loopInfo, controlFlowGraph, compiler.Locals);
                 }
             }
         }

--- a/ILCompiler/Compiler/Inliner.cs
+++ b/ILCompiler/Compiler/Inliner.cs
@@ -32,7 +32,7 @@ namespace ILCompiler.Compiler
 
             do
             {
-                var block = compiler.Blocks[blockIndex];
+                var block = compiler.ControlFlowGraph.Blocks[blockIndex];
                 if (block.Statements.Count > 0)
                 {
                     int statementIndex = 0;
@@ -68,7 +68,7 @@ namespace ILCompiler.Compiler
                 }
 
                 blockIndex++;
-            } while (blockIndex < compiler.Blocks.Count);
+            } while (blockIndex < compiler.ControlFlowGraph.Blocks.Count);
         }
 
         private static int CheckInlineDepthAndRecursion(InlineInfo inlineInfo)
@@ -336,13 +336,13 @@ namespace ILCompiler.Compiler
                 // Split block after statement being inlined
                 var bottomBlock = SplitBlockAfterStatement(methodInfo.Block, afterStatementIndex);
 
-                var blockIndex = compiler.Blocks!.IndexOf(methodInfo.Block) + 1;
-                compiler.Blocks.Insert(blockIndex, bottomBlock);
+                var blockIndex = compiler.ControlFlowGraph.Blocks!.IndexOf(methodInfo.Block) + 1;
+                compiler.ControlFlowGraph.Blocks.Insert(blockIndex, bottomBlock);
 
                 // Insert the blocks between the current block and the bottom block
                 foreach (var block in blocks)
                 {
-                    compiler.Blocks.Insert(blockIndex++, block);
+                    compiler.ControlFlowGraph.Blocks.Insert(blockIndex++, block);
 
                     // For the first/entry block in the blocks being inserted
                     // link it up to the original method block

--- a/ILCompiler/Compiler/LoopFinder.cs
+++ b/ILCompiler/Compiler/LoopFinder.cs
@@ -16,7 +16,7 @@ namespace ILCompiler.Compiler
 
         public FlowGraphNaturalLoops FindLoops(MethodCompiler compiler)
         {
-            var loops = FlowGraphNaturalLoops.Find(compiler.DfsTree!, _logger);
+            var loops = FlowGraphNaturalLoops.Find(compiler.DfsTree!, _logger, compiler.ControlFlowGraph);
 
             // Consider moving out of here
             ComputeReachabilitySets(compiler.DfsTree!);
@@ -45,7 +45,7 @@ namespace ILCompiler.Compiler
         }
     }
 
-    public class FlowGraphNaturalLoop(FlowgraphDfsTree dfsTree, BasicBlock header)
+    public class FlowGraphNaturalLoop(FlowgraphDfsTree dfsTree, BasicBlock header, FlowGraph controlFlowGraph)
     {
         public FlowgraphDfsTree DfsTree { get; init; } = dfsTree;
         public BasicBlock Header { get; } = header;
@@ -117,7 +117,7 @@ namespace ILCompiler.Compiler
                     continue;
                 }
 
-                foreach (BasicBlock succ in topBlock.Successors)
+                foreach (BasicBlock succ in controlFlowGraph.VisitAllSuccs(topBlock))
                 {
                     if (succ == Header)
                     {
@@ -170,7 +170,7 @@ namespace ILCompiler.Compiler
             _loops.Add(loop);
         }
 
-        public static FlowGraphNaturalLoops Find(FlowgraphDfsTree dfsTree, ILogger logger)
+        public static FlowGraphNaturalLoops Find(FlowgraphDfsTree dfsTree, ILogger logger, FlowGraph controlFlowGraph)
         {
             logger.LogDebug("Finding loops in DFS tree");
             logger.LogDebug("Reverse Post Order -> Block [pre, post]");
@@ -197,7 +197,7 @@ namespace ILCompiler.Compiler
                 FlowGraphNaturalLoop? loop = null;
 
                 // If a block is a ancestor of one of its predecessors then the block is a loop header
-                loop = FindBackEdges(dfsTree, logger, header, loop);
+                loop = FindBackEdges(dfsTree, logger, header, loop, controlFlowGraph);
 
                 if (loop == null)
                     continue;
@@ -253,13 +253,13 @@ namespace ILCompiler.Compiler
             return loops;
         }
 
-        private static FlowGraphNaturalLoop? FindBackEdges(FlowgraphDfsTree dfsTree, ILogger logger, BasicBlock header, FlowGraphNaturalLoop? loop)
+        private static FlowGraphNaturalLoop? FindBackEdges(FlowgraphDfsTree dfsTree, ILogger logger, BasicBlock header, FlowGraphNaturalLoop? loop, FlowGraph controlFlowGraph)
         {
             foreach (BasicBlock predecessorBlock in header.Predecessors)
             {
                 if (dfsTree.PostOrder.Contains(predecessorBlock) && FlowgraphDfsTree.IsAncestor(header, predecessorBlock))
                 {
-                    loop = loop ?? new FlowGraphNaturalLoop(dfsTree, header);
+                    loop = loop ?? new FlowGraphNaturalLoop(dfsTree, header, controlFlowGraph);
                     loop.BackEdges.Add(new FlowEdge(predecessorBlock, header));
 
                     logger.LogDebug("{PredecssorLabel} -> {HeaderLabel} is a backedge", predecessorBlock.Label, header.Label);

--- a/ILCompiler/Compiler/Lowering.cs
+++ b/ILCompiler/Compiler/Lowering.cs
@@ -19,7 +19,7 @@ namespace ILCompiler.Compiler
         public void Run(MethodCompiler compiler)
         {
             _locals = compiler.Locals;
-            foreach (var block in compiler.Blocks)
+            foreach (var block in compiler.ControlFlowGraph.Blocks)
             {
                 _currentBlock = block;
                 LowerBlock(block);

--- a/ILCompiler/Compiler/MethodCompiler.cs
+++ b/ILCompiler/Compiler/MethodCompiler.cs
@@ -15,14 +15,12 @@ namespace ILCompiler.Compiler
         private readonly ILogger<MethodCompiler> _logger;
         private readonly IPhaseFactory _phaseFactory;
 
-
         public MethodDesc? Method { get; private set; }
         public LocalVariableTable Locals { get; } = [];
         public FlowgraphDfsTree? DfsTree { get; private set; }
         public FlowgraphDominatorTree? DominatorTree { get; private set; }
         public FlowGraphNaturalLoops? Loops { get; private set; }
-        public IFlowgraph? Flowgraph { get; private set; }
-        public IList<BasicBlock> Blocks { get; } = [];
+        public FlowGraph ControlFlowGraph { get; } = new();
 
         public MethodCompiler(ILogger<MethodCompiler> logger, IConfiguration configuration, IPhaseFactory phaseFactory)
         {
@@ -62,10 +60,10 @@ namespace ILCompiler.Compiler
 
             if (_configuration.DumpFlowGraphs)
             {
-                Diagnostics.DumpFlowGraph(inputFilePath, method, Blocks);
+                Diagnostics.DumpFlowGraph(inputFilePath, method, ControlFlowGraph);
             }
 
-            return Blocks;
+            return ControlFlowGraph.Blocks;
         }
 
         public void CompileMethod(Z80MethodCodeNode methodCodeNodeNeedingCode, string inputFilePath)
@@ -96,11 +94,12 @@ namespace ILCompiler.Compiler
             var ilImporter = _phaseFactory.Create<IImporter>();
 
             // Main phases of the compiler live here
-            ilImporter.Import(this, methodCodeNodeNeedingCode.EhClauses);
+            ilImporter.Import(this, ControlFlowGraph.EhClauses);
+            methodCodeNodeNeedingCode.EhClauses = ControlFlowGraph.EhClauses;
 
             if (_configuration.DumpFlowGraphs)
             {
-                Diagnostics.DumpFlowGraph(inputFilePath, method, Blocks);
+                Diagnostics.DumpFlowGraph(inputFilePath, method, ControlFlowGraph);
             }
             DumpIRTrees("After Import");
 
@@ -118,11 +117,10 @@ namespace ILCompiler.Compiler
             if (_configuration.Optimize)
             {
                 // Build the dfs tree and remove unreachable blocks
-                DfsTree = FlowgraphDfsTree.BuildAndRemove(Blocks);
+                DfsTree = FlowgraphDfsTree.BuildAndRemove(ControlFlowGraph);
             }
 
-            Flowgraph = _phaseFactory.Create<IFlowgraph>();
-            Flowgraph.SetBlockOrder(Blocks);
+            ControlFlowGraph.SetBlockOrder();
 
             if (_configuration.Optimize)
             {
@@ -138,7 +136,7 @@ namespace ILCompiler.Compiler
 
                 // Optimize induction variables
                 var inductionVarOptimizer = _phaseFactory.Create<IInductionVariableOptimizer>();
-                inductionVarOptimizer.Run(this);
+                inductionVarOptimizer.Run(this, ControlFlowGraph);
 
                 DumpIRTrees("After Strength Reduction");
 
@@ -169,7 +167,7 @@ namespace ILCompiler.Compiler
             {
                 // Dump LIR here
                 var lirDumper = new LIRDumper();
-                var lirDump = lirDumper.Dump(Blocks);
+                var lirDump = lirDumper.Dump(ControlFlowGraph.Blocks);
                 _logger.LogInformation("{LirDump}", lirDump);
             }
         }
@@ -199,7 +197,7 @@ namespace ILCompiler.Compiler
                 _logger.LogInformation("{LocalVars}", sb.ToString());
 
                 var treeDumper = new TreeDumper();
-                var treedump = treeDumper.Dump(Blocks, Locals);
+                var treedump = treeDumper.Dump(ControlFlowGraph, Locals);
                 _logger.LogInformation("{Treedump}", treedump);
             }
         }

--- a/ILCompiler/Compiler/Morpher.cs
+++ b/ILCompiler/Compiler/Morpher.cs
@@ -28,7 +28,7 @@ namespace ILCompiler.Compiler
         public void Morph()
         {
             _locals = _compiler.Locals;
-            foreach (var block in _compiler.Blocks)
+            foreach (var block in _compiler.ControlFlowGraph.Blocks)
             {
                 // fgMorphBlocks -> fgMorphStmts -> fgMorphTree -> fgMorphSmpOp -> fgMorphArrayIndex
                 MorphStatements(block);
@@ -50,9 +50,9 @@ namespace ILCompiler.Compiler
 
                 var newStatement = new Statement(staticInitCall);
 
-                if (_compiler.Blocks.Count > 0)
+                if (_compiler.ControlFlowGraph.Blocks.Count > 0)
                 {
-                    var firstBlock = _compiler.Blocks[0];
+                    var firstBlock = _compiler.ControlFlowGraph.Blocks[0];
 
                     if (firstBlock.Statements.Count > 0)
                     {

--- a/ILCompiler/Compiler/PostOrderTraversalVisitor.cs
+++ b/ILCompiler/Compiler/PostOrderTraversalVisitor.cs
@@ -1,0 +1,37 @@
+﻿using ILCompiler.Compiler.EvaluationStack;
+
+namespace ILCompiler.Compiler
+{
+    public class PostOrderTraversalVisitor : StackEntryVisitor
+    {
+        public StackEntry? Current { get; private set; }
+        public StackEntry? First { get; set; }
+
+        public List<StackEntry> PostOrderNodes { get; set; } = new List<StackEntry>();
+
+        public PostOrderTraversalVisitor(StackEntry? current)
+        {
+            Current = current;
+        }
+
+        public override WalkResult PostOrderVisit(Edge<StackEntry> use, StackEntry? user)
+        {
+            SetNext(use.Get());
+            return WalkResult.Continue;
+        }
+        private void SetNext(StackEntry entry)
+        {
+            PostOrderNodes.Add(entry);
+            if (Current != null)
+            {
+                Current.Next = entry;
+                entry.Prev = Current;
+            }
+            Current = entry;
+            if (First == null)
+            {
+                First = Current;
+            }
+        }
+    }
+}

--- a/ILCompiler/Compiler/Rationalizer.cs
+++ b/ILCompiler/Compiler/Rationalizer.cs
@@ -8,7 +8,7 @@ namespace ILCompiler.Compiler
     {
         public void Rationalize(MethodCompiler compiler)
         {
-            foreach (var block in compiler.Blocks)
+            foreach (var block in compiler.ControlFlowGraph.Blocks)
             {
                 // Link IR in statements together
                 foreach (var statement in block.Statements)

--- a/ILCompiler/Compiler/Ssa/LiveVarAnalyser.cs
+++ b/ILCompiler/Compiler/Ssa/LiveVarAnalyser.cs
@@ -6,17 +6,19 @@ namespace ILCompiler.Compiler.Ssa
     {
         readonly VariableSet _liveIn;
         readonly VariableSet _liveOut;
+        readonly FlowGraph _controlFlowGraph;
 
-        public static void AnalyzeLiveVars(IList<BasicBlock> blocks, FlowgraphDfsTree dfsTree)
+        public static void AnalyzeLiveVars(FlowGraph controlFlowGraph, FlowgraphDfsTree dfsTree)
         {
-            var analyzer = new LiveVarAnalyzer();
-            analyzer.Run(blocks, dfsTree);
+            var analyzer = new LiveVarAnalyzer(controlFlowGraph);
+            analyzer.Run(dfsTree);
         }
 
-        public LiveVarAnalyzer()
+        public LiveVarAnalyzer(FlowGraph controlFlowGraph)
         {
             _liveIn = new VariableSet();
             _liveOut = new VariableSet();
+            _controlFlowGraph = controlFlowGraph;
         }
 
         private bool PerBlockAnalysis(BasicBlock block)
@@ -32,7 +34,7 @@ namespace ILCompiler.Compiler.Ssa
             // TODO: Revisit when importer handles jmp cil
 
             // Union in all the live in vars of blocks successors
-            foreach (var succ in block.Successors)
+            foreach (var succ in _controlFlowGraph.VisitAllSuccs(block))
             {
                 _liveOut.Union(succ.LiveIn);
             }
@@ -72,7 +74,7 @@ namespace ILCompiler.Compiler.Ssa
             }
         }
 
-        public void Run(IList<BasicBlock> blocks, FlowgraphDfsTree dfsTree)
+        public void Run(FlowgraphDfsTree dfsTree)
         {
             bool changed;
             do

--- a/ILCompiler/Compiler/Ssa/Liveness.cs
+++ b/ILCompiler/Compiler/Ssa/Liveness.cs
@@ -11,7 +11,7 @@ namespace ILCompiler.Compiler
             LocalVarLivenessInit(compiler.Locals);
 
             // Figure out use/def info for all basic blocks
-            PerBlockLocalVarLiveness(compiler.Blocks, logger);
+            PerBlockLocalVarLiveness(compiler.ControlFlowGraph.Blocks, logger);
             InterBlockLocalVarLiveness(compiler);
         }
 
@@ -48,14 +48,14 @@ namespace ILCompiler.Compiler
         private static void InterBlockLocalVarLiveness(MethodCompiler compiler)
         {
             // Compute the IN and OUT sets using classic liveness algorithm
-            LiveVarAnalyzer.AnalyzeLiveVars(compiler.Blocks, compiler.DfsTree!);
+            LiveVarAnalyzer.AnalyzeLiveVars(compiler.ControlFlowGraph, compiler.DfsTree!);
 
             LocalVariableTable locals = compiler.Locals;
 
             // Set which local variable must be initialized
             for (var lclNum = 0; lclNum < locals.Count; lclNum++)
             {
-                if (!locals[lclNum].IsParameter && compiler.Blocks[0].LiveIn.IsMember(lclNum))
+                if (!locals[lclNum].IsParameter && compiler.ControlFlowGraph.Blocks[0].LiveIn.IsMember(lclNum))
                 {
                     locals[lclNum].MustInit = true;
                 }

--- a/ILCompiler/Compiler/Ssa/SsaRenameDominatorTreeVisitor.cs
+++ b/ILCompiler/Compiler/Ssa/SsaRenameDominatorTreeVisitor.cs
@@ -7,10 +7,12 @@ namespace ILCompiler.Compiler.Ssa
     {
         private readonly SsaRenameState _renameStack;
         private readonly LocalVariableTable _locals;
-        public SsaRenameDominatorTreeVisitor(DominatorTreeNode root, SsaRenameState renameStack, LocalVariableTable locals) : base(root)
+        private readonly FlowGraph _controlFlowGraph;
+        public SsaRenameDominatorTreeVisitor(DominatorTreeNode root, SsaRenameState renameStack, LocalVariableTable locals, FlowGraph controlFlowGraph) : base(root)
         {
             _renameStack = renameStack;
             _locals = locals;
+            _controlFlowGraph = controlFlowGraph;
         }
 
         public override void PostOrderVisit(BasicBlock block)
@@ -26,7 +28,7 @@ namespace ILCompiler.Compiler.Ssa
 
         private void AddPhiArgsToSuccessors(BasicBlock block)
         {
-            foreach (var successor in block.Successors)
+            foreach (var successor in _controlFlowGraph.VisitAllSuccs(block))
             {
                 foreach (var statement in successor.Statements)
                 {

--- a/ILCompiler/Compiler/SsaBuilder.cs
+++ b/ILCompiler/Compiler/SsaBuilder.cs
@@ -43,7 +43,7 @@ namespace ILCompiler.Compiler
             InsertPhiFunctions(postOrder, compiler.Locals);
 
             // Rename local variables
-            RenameVariables(compiler.DominatorTree!.Root, compiler.Locals);
+            RenameVariables(compiler.DominatorTree!.Root, compiler.Locals, compiler.ControlFlowGraph);
 
             // Log SSA form
             if (_dumpSsa)
@@ -87,7 +87,7 @@ namespace ILCompiler.Compiler
             }
         }
 
-        private void RenameVariables(DominatorTreeNode tree, LocalVariableTable locals)
+        private void RenameVariables(DominatorTreeNode tree, LocalVariableTable locals, FlowGraph controlFlowGraph)
         {
             var ssaRenameStack = new SsaRenameState(_logger, locals.Count);
 
@@ -128,7 +128,7 @@ namespace ILCompiler.Compiler
              * rename(entry)
              */
 
-            var visitor = new SsaRenameDominatorTreeVisitor(tree, ssaRenameStack, locals);
+            var visitor = new SsaRenameDominatorTreeVisitor(tree, ssaRenameStack, locals, controlFlowGraph);
             visitor.WalkTree();
         }
 

--- a/ILCompiler/Compiler/TreeDumper.cs
+++ b/ILCompiler/Compiler/TreeDumper.cs
@@ -19,17 +19,17 @@ namespace ILCompiler.Compiler
             return _sb.ToString();
         }
 
-        public string Dump(IList<BasicBlock> blocks, LocalVariableTable locals)
+        public string Dump(FlowGraph controlFlowGraph, LocalVariableTable locals)
         {
             _locals = locals;
             int statementId = 0;
 
             _sb.Clear();
-            foreach (BasicBlock block in blocks)
+            foreach (BasicBlock block in controlFlowGraph.Blocks)
             {
                 string blockKind = GetBlockKind(block);
                 string blockPreds = GetBlocks(block.Predecessors);
-                string blockSuccs = GetBlocks(block.Successors);
+                string blockSuccs = GetBlocks(controlFlowGraph.VisitAllSuccs(block));
                 _sb.AppendLine($"{block.Label} [{block.StartOffset:0000}] ({blockKind}) preds={{{blockPreds}}} succs={{{blockSuccs}}}");
 
                 foreach (Statement statement in block.Statements)
@@ -47,7 +47,7 @@ namespace ILCompiler.Compiler
             return _sb.ToString();
         }
 
-        private static string GetBlocks(IList<BasicBlock> blocks)
+        private static string GetBlocks(IEnumerable<BasicBlock> blocks)
         {
             bool first = true;
             StringBuilder sb = new();

--- a/ILCompiler/Compiler/Z80AssemblyWriter.cs
+++ b/ILCompiler/Compiler/Z80AssemblyWriter.cs
@@ -398,7 +398,7 @@ namespace ILCompiler.Compiler
                                     ehClausesBuilder.Dw(ehClause.TryBegin.Label, "Protected Region Start");
                                     if (ehClause.TryEnd != null)
                                     {
-                                        ehClausesBuilder.Dw($"{ehClause.TryEnd.Label}_END", "Protected Region End");
+                                        ehClausesBuilder.Dw(ehClause.TryEnd.Label, "Protected Region End");
                                     }
                                     else
                                     {

--- a/ILCompiler/Interfaces/IFlowgraph.cs
+++ b/ILCompiler/Interfaces/IFlowgraph.cs
@@ -5,7 +5,7 @@ namespace ILCompiler.Interfaces
 {
     public interface IFlowgraph : IPhase
     {
-        void SetBlockOrder(IList<BasicBlock> blocks);
+        void SetBlockOrder();
         void SetStatementSequence(Statement statement);
 
         void InsertStatementAfter(BasicBlock block, Statement insertionPoint, Statement statement);

--- a/ILCompiler/Interfaces/IInductionVariableOptimizer.cs
+++ b/ILCompiler/Interfaces/IInductionVariableOptimizer.cs
@@ -4,6 +4,6 @@ namespace ILCompiler.Interfaces
 {
     public interface IInductionVariableOptimizer : IPhase
     {
-        void Run(MethodCompiler compiler);
+        void Run(MethodCompiler compiler, FlowGraph controlFlowGraph);
     }
 }

--- a/ILCompiler/IoC/ServiceProviderFactory.cs
+++ b/ILCompiler/IoC/ServiceProviderFactory.cs
@@ -59,8 +59,6 @@ namespace ILCompiler.IoC
 
             services.AddTransient<IEarlyValuePropagation, EarlyValuePropagation>();
 
-            services.AddTransient<IFlowgraph, Flowgraph>();
-
             services.AddTransient<ISsaBuilder, SsaBuilder>();
 
             services.AddTransient<IComputeDominators, FlowgraphDominatorTreeBuilder>();


### PR DESCRIPTION
Move the basic block list representing the control flow graph into the FlowGraph class.
Only add non exceptional blocks as successors in the flow graph.
Synthesize all successors including exception handling blocks via a new VisitAllSuccs method in the flow graph
Revert changes to determining the try/handler end blocks to be the block after the try/handler

This is all preparatory work to enable moving to a funclet style model for handlers as per #768 