### PR TITLE
Change from windows-latest images in github workflows to windows-2025-vs2026

### DIFF
--- a/.github/workflows/MainBuild.yml
+++ b/.github/workflows/MainBuild.yml
@@ -21,7 +21,7 @@ jobs:
         platform: [Trs80,ZXSpectrum,CPM]
       fail-fast: false
     name: Build, Test and Analyze for ${{ matrix.platform }} 
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
 
     steps:
       - name: Set up JDK 17

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:  
   build:
     name: Build, test and analyze 
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
 
     steps:
       - name: Set up JDK 17


### PR DESCRIPTION
To test prior to windows-latest being migrated to this in early June.