### PR TITLE
Add intrinsic to optimize out EH second pass

### DIFF
--- a/ILCompiler/Compiler/Compilation.cs
+++ b/ILCompiler/Compiler/Compilation.cs
@@ -17,6 +17,7 @@ namespace ILCompiler.Compiler
         private readonly DnlibModule _module;
 
         public static bool AnyExceptionHandlers { get; set; } = false;
+        public static bool AnyFinallyHandlers { get; set; } = false;
 
         public Compilation(IConfiguration configuration, Z80AssemblyWriter z80Writer, CorLibModuleProvider corLibModuleProvider, DependencyAnalyzer dependencyAnalyzer, /*TypeSystemContext typeSystemContext, */ DnlibModule module)
         {
@@ -64,6 +65,7 @@ namespace ILCompiler.Compiler
             // Core Dependency Analysis and code output routine
             var nodes = _dependencyAnalyzer.ComputeMarkedNodes();
             AnyExceptionHandlers = nodes.OfType<Z80MethodCodeNode>().Any(n => n.HasExceptionHandlers);
+            AnyFinallyHandlers = nodes.OfType<Z80MethodCodeNode>().Any(n => n.HasFinallyHandlers);
 
             _z80AssemblyWriter.WriteCode(rootNode, nodes, inputFilePath, outputFilePath);
 

--- a/ILCompiler/Compiler/DependencyAnalysis/Z80MethodCodeNode.cs
+++ b/ILCompiler/Compiler/DependencyAnalysis/Z80MethodCodeNode.cs
@@ -24,6 +24,7 @@ namespace ILCompiler.Compiler.DependencyAnalysis
         }
 
         public bool HasExceptionHandlers => Method?.MethodIL?.GetExceptionRegions().Length > 0;
+        public bool HasFinallyHandlers => Method?.MethodIL?.GetExceptionRegions().Any(x => x.Kind == TypeSystem.IL.ILExceptionRegionKind.Fault) ?? false;
         public IList<Instruction> MethodCode { get; set; } = new List<Instruction>();
 
         public IList<EHClause> EhClauses { get; set; } = new List<EHClause>();

--- a/ILCompiler/Compiler/OpcodeImporters/CallImporter.cs
+++ b/ILCompiler/Compiler/OpcodeImporters/CallImporter.cs
@@ -268,6 +268,15 @@ namespace ILCompiler.Compiler.OpcodeImporters
                     }
                     break;
 
+                case "get_HasFinallyHandlers":
+                    if (IsTypeName(methodToCall, "System.Runtime.CompilerServices", "RuntimeHelpers"))
+                    {
+                        var result = new Int32ConstantEntry(Compilation.AnyFinallyHandlers ? 1 : 0);
+                        importer.Push(result);
+                        return true;
+                    }
+                    break;
+
                 case "Of":
                     if (IsTypeName(methodToCall, "Internal.Runtime", "EEType"))
                     {

--- a/System.Private.CoreLib/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/System.Private.CoreLib/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -20,6 +20,11 @@ namespace System.Runtime.CompilerServices
         {
             throw new PlatformNotSupportedException();
         }
+
+        public static bool HasFinallyHandlers
+        {
+            [Intrinsic] get => false;
+        }
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/System.Private.CoreLib/System/Runtime/ExceptionHandling.cs
+++ b/System.Private.CoreLib/System/Runtime/ExceptionHandling.cs
@@ -90,16 +90,19 @@ namespace System.Runtime
 
             // Second pass
             //
-            isValid = true;
-            for (; isValid; isValid = InternalCalls.SFINext(ref stackFrameIterator))
+            if (CompilerServices.RuntimeHelpers.HasFinallyHandlers)
             {
-                if (stackFrameIterator.StackPointer == handlingFrameSp)
+                isValid = true;
+                for (; isValid; isValid = InternalCalls.SFINext(ref stackFrameIterator))
                 {
-                    // Invoke a partial second pass here
-                    InvokeSecondPass(ref stackFrameIterator, catchingTryRegionIdx);
-                    break;
+                    if (stackFrameIterator.StackPointer == handlingFrameSp)
+                    {
+                        // Invoke a partial second pass here
+                        InvokeSecondPass(ref stackFrameIterator, catchingTryRegionIdx);
+                        break;
+                    }
+                    InvokeSecondPass(ref stackFrameIterator);
                 }
-                InvokeSecondPass(ref stackFrameIterator);
             }
 
             s_originalThrowSP = 0;


### PR DESCRIPTION
If there are no finally handlers then no need for the second pass.
Use the Dependency Analyzer to determine if methods have finally handlers and combine these at the compilation level
The intrinsic exposes the compilation level information and is used in the DispatchEx method.
Conditional folding will eliminate the wrapped code if there are no finally handlers reducing the code size.

Contributes to #768 